### PR TITLE
Resolves #2

### DIFF
--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -84,8 +84,7 @@ abstract class BlocSignal<Event, StateType> {
   /// Otherwise, it triggers reactive effects and notifies the
   /// global [BlocSignalObserver].
   void emit(StateType newState) {
-    final oldState = _state.value;
-    if (oldState == newState) return;
+    if (_state.disposed) return;
     _state.value = newState;
 
     final currentObserver = BlocSignalObserver.observer;
@@ -131,5 +130,6 @@ abstract class BlocSignal<Event, StateType> {
   /// underlying [SignalModel].
   void close() {
     _lifecycleModel.dispose();
+    _state.dispose();
   }
 }

--- a/bloc_signals/test/bloc_signals_test.dart
+++ b/bloc_signals/test/bloc_signals_test.dart
@@ -107,20 +107,15 @@ void main() {
 
     test('disposal frees resources and cleans up effects', () {
       final bloc = CounterBloc();
-      var effectCallCount = 0;
 
-      // Create an effect that listens to the bloc's state
-      bloc.state.subscribe((_) {
-        effectCallCount++;
-      });
-
-      // Initially subscribed, call count increases
-      expect(effectCallCount, equals(1));
-
-      bloc.add(Increment());
-      expect(effectCallCount, equals(2));
+      expect(bloc.state.disposed, isFalse);
 
       bloc.close();
+
+      bloc.add(Increment());
+
+      expect(bloc.state.value, equals(0));
+      expect(bloc.state.disposed, isTrue);
     });
 
     test('handles errors during event processing', () {


### PR DESCRIPTION
made the fixes I outlined in issue #2, also i added a small check in the `emit` method to stay consistent with bloc:
```
  void emit(StateType newState) {
    if (_state.disposed) return;
    _state.value = newState;
    ...
}
```
in bloc, an event will simply be ignored after it is disposed. `Signal` will throw if the value is changed while it is diposed.