### PR TITLE
fix(core): catch errors in non-nullable futures using async IIFE

### DIFF
--- a/bloc_signals/CHANGELOG.md
+++ b/bloc_signals/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+- Fix runtime TypeError when async `onEvent` returns a non-nullable Future type.
+
 ## 0.1.3
 
 - Support asynchronous `onEvent` handlers (`FutureOr<void>`).

--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -123,10 +123,16 @@ abstract class BlocSignal<Event, StateType> {
         try {
           final result = onEvent(event);
           if (result is Future) {
-            unawaited(result.catchError((Object e, StackTrace stackTrace) {
-              onError(e, stackTrace);
-              if (e is Error) Error.throwWithStackTrace(e, stackTrace);
-            }));
+            unawaited(() async {
+              try {
+                await result;
+              } catch (e, stackTrace) {
+                onError(e, stackTrace);
+                if (e is Error) {
+                  Error.throwWithStackTrace(e, stackTrace);
+                }
+              }
+            }());
           }
         } catch (e, stackTrace) {
           onError(e, stackTrace);

--- a/bloc_signals/pubspec.yaml
+++ b/bloc_signals/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals
 resolution: workspace
 description: A synchronous state management container integrating BLoC patterns with Rody Davis's signals package.
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 

--- a/bloc_signals/test/bloc_signals_test.dart
+++ b/bloc_signals/test/bloc_signals_test.dart
@@ -92,6 +92,16 @@ class AsyncEmitBloc extends BlocSignal<String, int> {
   }
 }
 
+class NonNullableFutureBloc extends BlocSignal<String, int> {
+  NonNullableFutureBloc() : super(initialState: 0);
+
+  @override
+  Future<int> onEvent(String event) async {
+    await Future<void>.delayed(Duration.zero);
+    throw Exception('Non-nullable future async error');
+  }
+}
+
 class DummyObserver extends BlocSignalObserver {}
 
 class TestObserver extends BlocSignalObserver {
@@ -270,6 +280,16 @@ void main() {
         bloc.close();
       },
     );
+    test('handles async exceptions when Future is non-nullable', () async {
+      final bloc = NonNullableFutureBloc();
+      bloc.add('trigger');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(
+        observer.logs,
+        contains('error: Exception: Non-nullable future async error'),
+      );
+      bloc.close();
+    });
 
     test('covers default empty observer methods', () {
       final dummy = DummyObserver();


### PR DESCRIPTION
### Description
This PR addresses a high-priority bot review comment left on PR #10.

### Fix
Using `Future.catchError` on a `Future<T>` with a non-nullable type `T` results in a runtime `TypeError` when an error is thrown, since `catchError` returns `void` (resolving as `null`), violating type covariance expectations. 
We resolve this by replacing `catchError` with an async IIFE wrapper (`unawaited(() async { try { await result; } catch ... }())`) as suggested by the bot.

### Verification
- Added a `NonNullableFutureBloc` returning a non-nullable `Future<int>` that throws.
- Added a unit test validating that exceptions are caught and reported via `onError` without raising a `TypeError`.
- Confirmed that static analysis is clean and line coverage remains at 100%.
