### PR TITLE
feat: complete Bloc and FlutterBloc API Parity alignments

### DIFF
--- a/bloc_signals/CHANGELOG.md
+++ b/bloc_signals/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.0
+
+- Introduce complete BLoC API Parity:
+  - Add `Change` class for tracking state updates.
+  - Add `Transition` class for tracking event-triggered state changes.
+  - Add `onCreate`, `onChange`, and `onClose` observer methods to `BlocSignalObserver`.
+  - Add `onChange` and `onTransition` local overrides.
+  - Change `close()` to return `Future<void>`.
+
 ## 0.1.13
 
 - Add `createEffect` helper to `BlocSignalBase` to support auto-disposed effects in subclass constructors.

--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -1,7 +1,12 @@
 import 'dart:async';
 
+import 'package:bloc_signals/src/change.dart';
+import 'package:bloc_signals/src/transition.dart';
 import 'package:meta/meta.dart';
 import 'package:signals/signals.dart';
+
+export 'change.dart';
+export 'transition.dart';
 
 /// An observer interface to watch all [BlocSignalBase] instances' lifecycles,
 /// transitions, and events.
@@ -12,6 +17,9 @@ abstract class BlocSignalObserver {
   /// The global observer instance used to monitor all [BlocSignalBase]
   /// activity.
   static BlocSignalObserver? observer;
+
+  /// Called when a [BlocSignalBase] is created.
+  void onCreate(BlocSignalBase<dynamic> bloc) {}
 
   /// Called when an event is dispatched to any [BlocSignal]
   /// via [BlocSignal.add].
@@ -25,6 +33,9 @@ abstract class BlocSignalObserver {
     Object? state,
   ) {}
 
+  /// Called when a [BlocSignalBase] has a state change.
+  void onChange(BlocSignalBase<dynamic> bloc, Change<dynamic> change) {}
+
   /// Called when an error is thrown during event processing or
   /// inside a state transition.
   void onError(
@@ -32,6 +43,9 @@ abstract class BlocSignalObserver {
     Object error,
     StackTrace stackTrace,
   ) {}
+
+  /// Called when a [BlocSignalBase] is closed.
+  void onClose(BlocSignalBase<dynamic> bloc) {}
 }
 
 /// A base class for all reactive state containers.
@@ -48,6 +62,7 @@ abstract class BlocSignalBase<StateType> {
       return null;
     });
     _lifecycleModel = modelConstructor();
+    BlocSignalObserver.observer?.onCreate(this);
   }
 
   bool _isClosed = false;
@@ -87,13 +102,32 @@ abstract class BlocSignalBase<StateType> {
     if (_isClosed) return;
     final oldState = _state.value;
     if (oldState == newState) return;
+
+    final event = Zone.current[zoneEventKey];
+    if (event != null) {
+      handleTransition(event as Object, oldState, newState);
+    } else {
+      BlocSignalObserver.observer?.onTransition(this, null, newState);
+    }
+
     _state.value = newState;
 
-    final currentObserver = BlocSignalObserver.observer;
-    if (currentObserver != null) {
-      final raw = Zone.current[zoneEventKey];
-      currentObserver.onTransition(this, raw, newState);
-    }
+    final change = Change<StateType>(
+      currentState: oldState,
+      nextState: newState,
+    );
+    onChange(change);
+  }
+
+  /// Internal helper to dispatch transitions to the type-safe [BlocSignal].
+  @protected
+  void handleTransition(Object event, StateType oldState, StateType newState) {}
+
+  /// Called when a state change occurs.
+  @protected
+  @mustCallSuper
+  void onChange(Change<StateType> change) {
+    BlocSignalObserver.observer?.onChange(this, change);
   }
 
   /// Called when an exception is thrown in event processing or state
@@ -131,7 +165,7 @@ abstract class BlocSignalBase<StateType> {
   /// Shuts down all internal effects and disposes of the
   /// underlying [SignalModel].
   @mustCallSuper
-  void close() {
+  Future<void> close() async {
     if (_isClosed) return;
     _isClosed = true;
     for (final dispose in _effectsToDispose) {
@@ -139,6 +173,7 @@ abstract class BlocSignalBase<StateType> {
     }
     _effectsToDispose.clear();
     _lifecycleModel.dispose();
+    BlocSignalObserver.observer?.onClose(this);
   }
 }
 
@@ -160,6 +195,26 @@ abstract class BlocSignal<Event, StateType> extends BlocSignalBase<StateType> {
   BlocSignal({required super.initialState});
 
   final List<_HandlerRegistry<Event, StateType>> _handlers = [];
+
+  /// Called when a transition occurs.
+  @protected
+  @mustCallSuper
+  void onTransition(Transition<Event, StateType> transition) {
+    BlocSignalObserver.observer
+        ?.onTransition(this, transition.event, transition.nextState);
+  }
+
+  @override
+  @protected
+  void handleTransition(Object event, StateType oldState, StateType newState) {
+    onTransition(
+      Transition<Event, StateType>(
+        currentState: oldState,
+        event: event as Event,
+        nextState: newState,
+      ),
+    );
+  }
 
   /// Dispatches an event to the [onEvent] handler.
   ///

--- a/bloc_signals/lib/src/change.dart
+++ b/bloc_signals/lib/src/change.dart
@@ -1,0 +1,39 @@
+import 'package:meta/meta.dart';
+
+/// A [Change] represents the change from one state to another.
+///
+/// It consists of the [currentState] and the [nextState].
+///
+/// Example:
+/// ```dart
+/// final change = Change(currentState: 0, nextState: 1);
+/// print(change.currentState); // 0
+/// print(change.nextState); // 1
+/// ```
+@immutable
+class Change<State> {
+  /// Creates a [Change] that captures [currentState] and [nextState].
+  const Change({required this.currentState, required this.nextState});
+
+  /// The state before the change occurred.
+  final State currentState;
+
+  /// The state after the change occurred.
+  final State nextState;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Change<State> &&
+          runtimeType == other.runtimeType &&
+          currentState == other.currentState &&
+          nextState == other.nextState;
+
+  @override
+  int get hashCode => currentState.hashCode ^ nextState.hashCode;
+
+  @override
+  String toString() {
+    return 'Change { currentState: $currentState, nextState: $nextState }';
+  }
+}

--- a/bloc_signals/lib/src/transition.dart
+++ b/bloc_signals/lib/src/transition.dart
@@ -1,0 +1,57 @@
+import 'package:meta/meta.dart';
+
+/// A [Transition] represents the change from one state to another triggered by
+/// an event.
+///
+/// It consists of the [currentState], the [event] that triggered the
+/// transition, and the [nextState].
+///
+/// Example:
+/// ```dart
+/// final transition = Transition(
+///   currentState: 0,
+///   event: Increment(),
+///   nextState: 1,
+/// );
+/// print(transition.currentState); // 0
+/// print(transition.event); // Increment()
+/// print(transition.nextState); // 1
+/// ```
+@immutable
+class Transition<Event, State> {
+  /// Creates a [Transition] that captures [currentState], [event], and
+  /// [nextState].
+  const Transition({
+    required this.currentState,
+    required this.event,
+    required this.nextState,
+  });
+
+  /// The state before the transition occurred.
+  final State currentState;
+
+  /// The event that triggered the transition.
+  final Event event;
+
+  /// The state after the transition occurred.
+  final State nextState;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Transition<Event, State> &&
+          runtimeType == other.runtimeType &&
+          currentState == other.currentState &&
+          event == other.event &&
+          nextState == other.nextState;
+
+  @override
+  int get hashCode =>
+      currentState.hashCode ^ event.hashCode ^ nextState.hashCode;
+
+  @override
+  String toString() {
+    return 'Transition { currentState: $currentState, '
+        'event: $event, nextState: $nextState }';
+  }
+}

--- a/bloc_signals/pubspec.yaml
+++ b/bloc_signals/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals
 resolution: workspace
 description: A synchronous state management container integrating BLoC patterns with Rody Davis's signals package.
-version: 0.1.13
+version: 0.2.0
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 

--- a/bloc_signals/test/bloc_signals_test.dart
+++ b/bloc_signals/test/bloc_signals_test.dart
@@ -213,7 +213,7 @@ void main() {
       final bloc = CounterBloc();
       expect(bloc.stateValue, equals(0));
       expect(bloc.state.value, equals(0));
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('handles event and updates state synchronously', () {
@@ -225,7 +225,7 @@ void main() {
       bloc.add(Decrement());
       expect(bloc.stateValue, equals(0));
 
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('observer logs transitions and events', () {
@@ -239,7 +239,7 @@ void main() {
         contains("transition: 1 (event: Instance of 'Increment')"),
       );
 
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('disposal frees resources and cleans up effects', () {
@@ -259,7 +259,7 @@ void main() {
       bloc.add(Increment());
       expect(effectCallCount, equals(2));
 
-      bloc.close();
+      unawaited(bloc.close());
       expect(bloc.isClosed, isTrue);
 
       bloc.add(Increment());
@@ -271,7 +271,7 @@ void main() {
       final bloc = ErrorBloc();
       bloc.add('trigger');
       expect(observer.logs, contains('error: Exception: Test error'));
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('rethrows Error objects (developer faults) synchronously', () {
@@ -281,7 +281,7 @@ void main() {
         observer.logs,
         contains('error: Invalid argument(s): Test argument error'),
       );
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('handles asynchronous Exception without crashing', () async {
@@ -289,7 +289,7 @@ void main() {
       bloc.add('trigger');
       await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(observer.logs, contains('error: Exception: Async test error'));
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('throws asynchronous Error to the current zone', () async {
@@ -305,7 +305,7 @@ void main() {
         observer.logs,
         contains('error: Invalid argument(s): Async test argument error'),
       );
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('allows cross-bloc emit without zone key casting crashes', () {
@@ -324,8 +324,8 @@ void main() {
       // BlocA's transition should have 1 as event
       expect(observer.logs, contains('transition: 1 (event: 1)'));
 
-      blocA.close();
-      blocB.close();
+      unawaited(blocA.close());
+      unawaited(blocB.close());
     });
 
     test(
@@ -342,7 +342,7 @@ void main() {
           contains('transition: 100 (event: delayed_event)'),
         );
 
-        bloc.close();
+        unawaited(bloc.close());
       },
     );
     test('handles async exceptions when Future is non-nullable', () async {
@@ -353,7 +353,7 @@ void main() {
         observer.logs,
         contains('error: Exception: Non-nullable future async error'),
       );
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('covers default empty observer methods', () {
@@ -362,12 +362,12 @@ void main() {
       dummy.onEvent(bloc, null);
       dummy.onTransition(bloc, null, null);
       dummy.onError(bloc, Exception(), StackTrace.empty);
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('throws AssertionError when emit is called after close', () {
       final bloc = PublicEmitBloc();
-      bloc.close();
+      unawaited(bloc.close());
       expect(() => bloc.publicEmit(42), throwsA(isA<AssertionError>()));
     });
 
@@ -381,7 +381,7 @@ void main() {
       bloc.add(Decrement());
       expect(bloc.stateValue, equals(0));
 
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('supports on<E> with async handlers', () async {
@@ -392,7 +392,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(bloc.stateValue, equals(42));
 
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('on<E> preserves zone transition event tracking', () {
@@ -404,7 +404,7 @@ void main() {
         contains("transition: 1 (event: Instance of 'Increment')"),
       );
 
-      bloc.close();
+      unawaited(bloc.close());
     });
 
     test('throws StateError when on<E> is registered multiple times', () {
@@ -419,7 +419,7 @@ void main() {
         final cubit = CounterCubit();
         expect(cubit.stateValue, equals(0));
         expect(cubit.state.value, equals(0));
-        cubit.close();
+        unawaited(cubit.close());
       });
 
       test('updates state synchronously when methods are called', () {
@@ -428,7 +428,7 @@ void main() {
         expect(cubit.stateValue, equals(1));
         cubit.decrement();
         expect(cubit.stateValue, equals(0));
-        cubit.close();
+        unawaited(cubit.close());
       });
 
       test('observer logs transitions with null event', () {
@@ -438,7 +438,7 @@ void main() {
           observer.logs,
           contains('transition: 1 (event: null)'),
         );
-        cubit.close();
+        unawaited(cubit.close());
       });
 
       test('onError routes errors to the observer', () {
@@ -448,12 +448,12 @@ void main() {
           observer.logs,
           contains('error: Exception: Cubit error'),
         );
-        cubit.close();
+        unawaited(cubit.close());
       });
 
       test('throws AssertionError when emit is called after close', () {
         final cubit = CounterCubit();
-        cubit.close();
+        unawaited(cubit.close());
         expect(() => cubit.publicEmit(42), throwsA(isA<AssertionError>()));
       });
 
@@ -467,7 +467,7 @@ void main() {
         externalSignal.value = 1;
         expect(cubit.stateValue, equals(1));
 
-        cubit.close();
+        unawaited(cubit.close());
 
         // Modifying the external signal after close should not throw assertions
         // because the effect should have been automatically disposed.
@@ -475,5 +475,172 @@ void main() {
         expect(cubit.stateValue, equals(1)); // State remains 1
       });
     });
+
+    group('API Parity Tests', () {
+      test('Change class constructor, equality, and toString', () {
+        const change1 = Change<int>(currentState: 0, nextState: 1);
+        const change2 = Change<int>(currentState: 0, nextState: 1);
+        const change3 = Change<int>(currentState: 1, nextState: 2);
+
+        expect(change1.currentState, equals(0));
+        expect(change1.nextState, equals(1));
+        expect(change1, equals(change2));
+        expect(change1, isNot(equals(change3)));
+        expect(change1.hashCode, equals(change2.hashCode));
+        expect(
+          change1.toString(),
+          equals('Change { currentState: 0, nextState: 1 }'),
+        );
+      });
+
+      test('Transition class constructor, equality, and toString', () {
+        final event1 = Increment();
+        final event2 = Decrement();
+        final transition1 = Transition<CounterEvent, int>(
+          currentState: 0,
+          event: event1,
+          nextState: 1,
+        );
+        final transition2 = Transition<CounterEvent, int>(
+          currentState: 0,
+          event: event1,
+          nextState: 1,
+        );
+        final transition3 = Transition<CounterEvent, int>(
+          currentState: 0,
+          event: event2,
+          nextState: -1,
+        );
+
+        expect(transition1.currentState, equals(0));
+        expect(transition1.event, equals(event1));
+        expect(transition1.nextState, equals(1));
+        expect(transition1, equals(transition2));
+        expect(transition1, isNot(equals(transition3)));
+        expect(transition1.hashCode, equals(transition2.hashCode));
+        expect(
+          transition1.toString(),
+          equals(
+            'Transition { currentState: 0, event: $event1, nextState: 1 }',
+          ),
+        );
+      });
+
+      test('BlocObserver tracks onCreate, onChange, and onClose', () async {
+        final observerLogs = <String>[];
+        final observer = _ParityObserver(observerLogs);
+        BlocSignalObserver.observer = observer;
+
+        final bloc = CounterBloc();
+        expect(observerLogs, contains('create'));
+
+        bloc.add(Increment());
+        expect(
+          observerLogs,
+          contains('change: Change { currentState: 0, nextState: 1 }'),
+        );
+        expect(observerLogs, contains('transition: transition_event'));
+
+        unawaited(bloc.close());
+        expect(observerLogs, contains('close'));
+      });
+
+      test('Cubit triggers onChange', () async {
+        final observerLogs = <String>[];
+        final observer = _ParityObserver(observerLogs);
+        BlocSignalObserver.observer = observer;
+
+        final cubit = CounterCubit();
+        cubit.increment();
+
+        expect(
+          observerLogs,
+          contains('change: Change { currentState: 0, nextState: 1 }'),
+        );
+        unawaited(cubit.close());
+      });
+
+      test('Local overrides onTransition and onChange are invoked', () async {
+        final transitions = <Transition<CounterEvent, int>>[];
+        final changes = <Change<int>>[];
+
+        final bloc = LocalOverrideBloc(
+          onLocalTransition: transitions.add,
+          onLocalChange: changes.add,
+        );
+
+        bloc.add(Increment());
+
+        expect(transitions.length, equals(1));
+        expect(transitions[0].currentState, equals(0));
+        expect(transitions[0].nextState, equals(1));
+        expect(transitions[0].event, isA<Increment>());
+
+        expect(changes.length, equals(1));
+        expect(changes[0].currentState, equals(0));
+        expect(changes[0].nextState, equals(1));
+
+        unawaited(bloc.close());
+      });
+    });
   });
+}
+
+class _ParityObserver extends BlocSignalObserver {
+  _ParityObserver(this.logs);
+  final List<String> logs;
+
+  @override
+  void onCreate(BlocSignalBase<dynamic> bloc) {
+    logs.add('create');
+  }
+
+  @override
+  void onChange(BlocSignalBase<dynamic> bloc, Change<dynamic> change) {
+    logs.add('change: $change');
+  }
+
+  @override
+  void onTransition(
+    BlocSignalBase<dynamic> bloc,
+    Object? event,
+    Object? state,
+  ) {
+    logs.add('transition: transition_event');
+  }
+
+  @override
+  void onClose(BlocSignalBase<dynamic> bloc) {
+    logs.add('close');
+  }
+}
+
+class LocalOverrideBloc extends BlocSignal<CounterEvent, int> {
+  LocalOverrideBloc({
+    required this.onLocalTransition,
+    required this.onLocalChange,
+  }) : super(initialState: 0);
+
+  final void Function(Transition<CounterEvent, int>) onLocalTransition;
+  final void Function(Change<int>) onLocalChange;
+
+  @override
+  void onEvent(CounterEvent event) {
+    unawaited(Future.value(super.onEvent(event)));
+    if (event is Increment) {
+      emit(stateValue + 1);
+    }
+  }
+
+  @override
+  void onTransition(Transition<CounterEvent, int> transition) {
+    super.onTransition(transition);
+    onLocalTransition(transition);
+  }
+
+  @override
+  void onChange(Change<int> change) {
+    super.onChange(change);
+    onLocalChange(change);
+  }
 }

--- a/bloc_signals_flutter/CHANGELOG.md
+++ b/bloc_signals_flutter/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.2.0
+
+- Complete Flutter Bloc API Parity alignments:
+  - Update `BlocSignalProvider` to default to `lazy: true`.
+  - Convert `BlocSignalListener` to `StatefulWidget` to align listener execution lifecycle.
+  - Add `listenWhen` filter parameter to `BlocSignalListener` and `BlocSignalConsumer`.
+  - Implement `MultiBlocSignalListener` to compose multiple listeners cleanly.
+  - Implement `BuildContext.select` extension to efficiently watch state slices via element-cached computed signals.
+
 ## 0.1.9
 
 - Add `BlocSignalListener`, `BlocSignalConsumer`, and `BlocSignalSelector` widgets to achieve 100% widget-level API parity with classic `flutter_bloc`.

--- a/bloc_signals_flutter/example/lib/main.dart
+++ b/bloc_signals_flutter/example/lib/main.dart
@@ -235,9 +235,9 @@ class TimerBloc extends BlocSignal<TimerEvent, TimerState> {
   }
 
   @override
-  void close() {
+  Future<void> close() {
     _tickerSubscription?.cancel();
-    super.close();
+    return super.close();
   }
 }
 

--- a/bloc_signals_flutter/lib/bloc_signals_flutter.dart
+++ b/bloc_signals_flutter/lib/bloc_signals_flutter.dart
@@ -1,8 +1,9 @@
 /// Flutter bindings and UI integrations for the reactive [BlocSignal] library.
 ///
 /// Provides [BlocSignalProvider], [MultiBlocSignalProvider],
-/// [BlocSignalBuilder], [BlocSignalListener], [BlocSignalConsumer], and
-/// [BlocSignalSelector] to bridge reactive states with the Flutter widget tree.
+/// [BlocSignalBuilder], [BlocSignalListener], [MultiBlocSignalListener],
+/// [BlocSignalConsumer], and [BlocSignalSelector] to bridge reactive states
+/// with the Flutter widget tree.
 library;
 
 import 'package:bloc_signals/bloc_signals.dart';
@@ -11,6 +12,7 @@ import 'package:bloc_signals_flutter/src/bloc_signal_consumer.dart';
 import 'package:bloc_signals_flutter/src/bloc_signal_listener.dart';
 import 'package:bloc_signals_flutter/src/bloc_signal_provider.dart';
 import 'package:bloc_signals_flutter/src/bloc_signal_selector.dart';
+import 'package:bloc_signals_flutter/src/multi_bloc_signal_listener.dart';
 
 export 'package:bloc_signals/bloc_signals.dart';
 export 'src/bloc_signal_builder.dart';
@@ -18,3 +20,4 @@ export 'src/bloc_signal_consumer.dart';
 export 'src/bloc_signal_listener.dart';
 export 'src/bloc_signal_provider.dart';
 export 'src/bloc_signal_selector.dart';
+export 'src/multi_bloc_signal_listener.dart';

--- a/bloc_signals_flutter/lib/src/bloc_signal_consumer.dart
+++ b/bloc_signals_flutter/lib/src/bloc_signal_consumer.dart
@@ -27,6 +27,7 @@ class BlocSignalConsumer<T extends BlocSignalBase<S>, S>
     required this.builder,
     required this.listener,
     this.bloc,
+    this.listenWhen,
     super.key,
   });
 
@@ -40,6 +41,12 @@ class BlocSignalConsumer<T extends BlocSignalBase<S>, S>
   /// The callback that runs whenever the state changes.
   final void Function(BuildContext context, S state) listener;
 
+  /// A function that determines whether the [listener] should be called.
+  ///
+  /// Defaults to null, in which case the listener will be called on every
+  /// change.
+  final bool Function(S previous, S current)? listenWhen;
+
   @override
   Widget build(BuildContext context) {
     final effectiveBloc =
@@ -47,6 +54,7 @@ class BlocSignalConsumer<T extends BlocSignalBase<S>, S>
     return BlocSignalListener<T, S>(
       bloc: effectiveBloc,
       listener: listener,
+      listenWhen: listenWhen,
       child: BlocSignalBuilder<T, S>(
         bloc: effectiveBloc,
         builder: builder,

--- a/bloc_signals_flutter/lib/src/bloc_signal_listener.dart
+++ b/bloc_signals_flutter/lib/src/bloc_signal_listener.dart
@@ -18,12 +18,13 @@ import 'package:signals_flutter/signals_flutter.dart';
 /// )
 /// ```
 class BlocSignalListener<T extends BlocSignalBase<S>, S>
-    extends StatelessWidget {
+    extends StatefulWidget {
   /// Creates a [BlocSignalListener] widget.
   const BlocSignalListener({
     required this.listener,
     required this.child,
     this.bloc,
+    this.listenWhen,
     super.key,
   });
 
@@ -33,19 +34,84 @@ class BlocSignalListener<T extends BlocSignalBase<S>, S>
   /// The callback that runs whenever the state changes.
   final void Function(BuildContext context, S state) listener;
 
+  /// A function that determines whether the [listener] should be called.
+  ///
+  /// Defaults to null, in which case the listener will be called on every
+  /// change.
+  final bool Function(S previous, S current)? listenWhen;
+
   /// The child widget subtree.
   final Widget child;
 
-  @override
-  Widget build(BuildContext context) {
-    final effectiveBloc =
-        bloc ?? BlocSignalProvider.of<T>(context, listen: true);
-    return SignalListener(
-      effect: (context) {
-        final state = effectiveBloc.state.value;
-        listener(context, state);
-      },
+  /// Clones this listener with a new child widget.
+  BlocSignalListener<T, S> copyWith(Widget child) {
+    return BlocSignalListener<T, S>(
+      key: key,
+      bloc: bloc,
+      listener: listener,
+      listenWhen: listenWhen,
       child: child,
     );
+  }
+
+  @override
+  State<BlocSignalListener<T, S>> createState() =>
+      _BlocSignalListenerState<T, S>();
+}
+
+class _BlocSignalListenerState<T extends BlocSignalBase<S>, S>
+    extends State<BlocSignalListener<T, S>> {
+  T? _bloc;
+  S? _previousState;
+  EffectCleanup? _cleanup;
+
+  void _subscribe() {
+    _cleanup?.call();
+    _previousState = _bloc!.state.value;
+
+    _cleanup = effect(() {
+      final currentState = _bloc!.state.value;
+
+      if (_previousState != currentState) {
+        final previous = _previousState as S;
+        _previousState = currentState;
+
+        if (widget.listenWhen == null ||
+            widget.listenWhen!(previous, currentState)) {
+          widget.listener(context, currentState);
+        }
+      }
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final effectiveBloc = widget.bloc ?? BlocSignalProvider.of<T>(context);
+    if (_bloc != effectiveBloc) {
+      _bloc = effectiveBloc;
+      _subscribe();
+    }
+  }
+
+  @override
+  void didUpdateWidget(BlocSignalListener<T, S> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final effectiveBloc = widget.bloc ?? BlocSignalProvider.of<T>(context);
+    if (_bloc != effectiveBloc) {
+      _bloc = effectiveBloc;
+      _subscribe();
+    }
+  }
+
+  @override
+  void dispose() {
+    _cleanup?.call();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
   }
 }

--- a/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
+++ b/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:bloc_signals/bloc_signals.dart';
 import 'package:flutter/widgets.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
 /// A Flutter widget that provides a [BlocSignal] to its descendants via
 /// the element tree and automatically disposes of it when the provider
@@ -19,6 +22,7 @@ class BlocSignalProvider<T extends BlocSignalBase<dynamic>>
   const BlocSignalProvider({
     required this.child,
     required T Function(BuildContext context) this.create,
+    this.lazy = true,
     super.key,
   }) : value = null;
 
@@ -28,13 +32,19 @@ class BlocSignalProvider<T extends BlocSignalBase<dynamic>>
     required this.child,
     required T this.value,
     super.key,
-  }) : create = null;
+  })  : create = null,
+        lazy = false;
 
   /// The factory function to create a new [BlocSignal] instance.
   final T Function(BuildContext context)? create;
 
   /// An existing [BlocSignal] instance to provide to the widget tree.
   final T? value;
+
+  /// Whether the [BlocSignal] should be created lazily.
+  ///
+  /// Defaults to `true`.
+  final bool lazy;
 
   /// The widget subtree that will have access to the provided [BlocSignal].
   final Widget child;
@@ -57,7 +67,7 @@ class BlocSignalProvider<T extends BlocSignalBase<dynamic>>
         'a BlocSignalProvider of type $T.',
       );
     }
-    return provider.bloc;
+    return provider.state.bloc;
   }
 
   /// Clones this provider with a new child widget.
@@ -65,6 +75,7 @@ class BlocSignalProvider<T extends BlocSignalBase<dynamic>>
     if (create != null) {
       return BlocSignalProvider<T>(
         create: create!,
+        lazy: lazy,
         key: key,
         child: child,
       );
@@ -84,27 +95,41 @@ class BlocSignalProvider<T extends BlocSignalBase<dynamic>>
 class _BlocSignalProviderState<T extends BlocSignalBase<dynamic>>
     extends State<BlocSignalProvider<T>> {
   T? _bloc;
+  bool _isInitialized = false;
 
-  T get _effectiveBloc => widget.value ?? _bloc!;
+  T get bloc {
+    if (widget.value != null) return widget.value!;
+    if (!_isInitialized) {
+      _bloc = widget.create!(context);
+      _isInitialized = true;
+    }
+    return _bloc!;
+  }
+
+  T? get blocInstance => widget.value ?? _bloc;
 
   @override
   void initState() {
     super.initState();
-    if (widget.create != null) {
+    if (!widget.lazy && widget.create != null) {
       _bloc = widget.create!(context);
+      _isInitialized = true;
     }
   }
 
   @override
   void dispose() {
-    _bloc?.close();
+    if (_bloc != null) {
+      unawaited(_bloc!.close());
+    }
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return _BlocSignalProviderInherited<T>(
-      bloc: _effectiveBloc,
+      bloc: widget.value ?? _bloc,
+      state: this,
       child: widget.child,
     );
   }
@@ -114,10 +139,12 @@ class _BlocSignalProviderInherited<T extends BlocSignalBase<dynamic>>
     extends InheritedWidget {
   const _BlocSignalProviderInherited({
     required this.bloc,
+    required this.state,
     required super.child,
   });
 
-  final T bloc;
+  final T? bloc;
+  final _BlocSignalProviderState<T> state;
 
   @override
   bool updateShouldNotify(_BlocSignalProviderInherited<T> oldWidget) {
@@ -135,6 +162,52 @@ extension BlocSignalProviderExtension on BuildContext {
   /// provider.
   T watch<T extends BlocSignalBase<dynamic>>() =>
       BlocSignalProvider.of<T>(this, listen: true);
+
+  /// Listens to changes on a selected value of the [BlocSignal] state.
+  R select<T extends BlocSignalBase<dynamic>, R>(
+    R Function(T bloc) selector,
+  ) {
+    final element = this as Element;
+    final bloc = BlocSignalProvider.of<T>(this);
+
+    final selectorState = _elementSelectors[element] ??= _SelectorState();
+    final currentIndex = selectorState.index;
+    selectorState.index++;
+    selectorState.lastAccessedIndex = selectorState.index;
+
+    if (currentIndex == 0) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (element.mounted) {
+          while (selectorState.subscriptions.length >
+              selectorState.lastAccessedIndex) {
+            final sub = selectorState.subscriptions.removeLast();
+            _selectFinalizer.detach(sub);
+            sub.dispose();
+          }
+        }
+        selectorState
+          ..index = 0
+          ..lastAccessedIndex = 0;
+      });
+    }
+
+    _SelectSubscription<T, R> subscription;
+    if (currentIndex < selectorState.subscriptions.length) {
+      subscription = (selectorState.subscriptions[currentIndex]
+          as _SelectSubscription<T, R>)
+        ..update(bloc, selector);
+    } else {
+      subscription = _SelectSubscription<T, R>(
+        bloc: bloc,
+        selector: selector,
+        element: element,
+      );
+      selectorState.subscriptions.add(subscription);
+      _selectFinalizer.attach(element, subscription, detach: subscription);
+    }
+
+    return subscription.value;
+  }
 }
 
 /// A widget that merges multiple [BlocSignalProvider]s into a single linear
@@ -171,5 +244,72 @@ class MultiBlocSignalProvider extends StatelessWidget {
       current = provider.copyWith(current);
     }
     return current;
+  }
+}
+
+final Expando<_SelectorState> _elementSelectors = Expando<_SelectorState>();
+
+final Finalizer<_SelectSubscription<dynamic, dynamic>> _selectFinalizer =
+    Finalizer<_SelectSubscription<dynamic, dynamic>>((sub) => sub.dispose());
+
+class _SelectorState {
+  int index = 0;
+  int lastAccessedIndex = 0;
+  final List<_SelectSubscription<dynamic, dynamic>> subscriptions = [];
+}
+
+class _SelectSubscription<T extends BlocSignalBase<dynamic>, R> {
+  _SelectSubscription({
+    required T bloc,
+    required R Function(T) selector,
+    required this.element,
+  })  : _bloc = bloc,
+        _selector = selector {
+    _computed = computed(() => _selector(_bloc));
+    _selectedValue = _computed.value;
+
+    _dispose = effect(() {
+      final newValue = _computed.value;
+      if (newValue != _selectedValue) {
+        _selectedValue = newValue;
+        if (element.mounted) {
+          element.markNeedsBuild();
+        }
+      }
+    });
+  }
+
+  T _bloc;
+  R Function(T) _selector;
+  final Element element;
+  late Computed<R> _computed;
+  late R _selectedValue;
+  late VoidCallback _dispose;
+
+  R get value => _selectedValue;
+
+  void update(T newBloc, R Function(T) newSelector) {
+    if (_bloc != newBloc || _selector != newSelector) {
+      this
+        .._bloc = newBloc
+        .._selector = newSelector;
+
+      _dispose();
+      _computed = computed(() => _selector(_bloc));
+      _selectedValue = _computed.value;
+      _dispose = effect(() {
+        final newValue = _computed.value;
+        if (newValue != _selectedValue) {
+          _selectedValue = newValue;
+          if (element.mounted) {
+            element.markNeedsBuild();
+          }
+        }
+      });
+    }
+  }
+
+  void dispose() {
+    _dispose();
   }
 }

--- a/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
+++ b/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
@@ -262,9 +262,10 @@ class _SelectSubscription<T extends BlocSignalBase<dynamic>, R> {
   _SelectSubscription({
     required T bloc,
     required R Function(T) selector,
-    required this.element,
+    required Element element,
   })  : _bloc = bloc,
-        _selector = selector {
+        _selector = selector,
+        _elementRef = WeakReference(element) {
     _computed = computed(() => _selector(_bloc));
     _selectedValue = _computed.value;
 
@@ -272,8 +273,9 @@ class _SelectSubscription<T extends BlocSignalBase<dynamic>, R> {
       final newValue = _computed.value;
       if (newValue != _selectedValue) {
         _selectedValue = newValue;
-        if (element.mounted) {
-          element.markNeedsBuild();
+        final el = _elementRef.target;
+        if (el != null && el.mounted) {
+          el.markNeedsBuild();
         }
       }
     });
@@ -281,7 +283,7 @@ class _SelectSubscription<T extends BlocSignalBase<dynamic>, R> {
 
   T _bloc;
   R Function(T) _selector;
-  final Element element;
+  final WeakReference<Element> _elementRef;
   late Computed<R> _computed;
   late R _selectedValue;
   late VoidCallback _dispose;
@@ -301,8 +303,9 @@ class _SelectSubscription<T extends BlocSignalBase<dynamic>, R> {
         final newValue = _computed.value;
         if (newValue != _selectedValue) {
           _selectedValue = newValue;
-          if (element.mounted) {
-            element.markNeedsBuild();
+          final el = _elementRef.target;
+          if (el != null && el.mounted) {
+            el.markNeedsBuild();
           }
         }
       });

--- a/bloc_signals_flutter/lib/src/multi_bloc_signal_listener.dart
+++ b/bloc_signals_flutter/lib/src/multi_bloc_signal_listener.dart
@@ -1,0 +1,44 @@
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_flutter/src/bloc_signal_listener.dart';
+import 'package:flutter/widgets.dart';
+
+/// A widget that merges multiple [BlocSignalListener]s into a single linear
+/// widget hierarchy to improve readability.
+///
+/// Example:
+/// ```dart
+/// MultiBlocSignalListener(
+///   listeners: [
+///     BlocSignalListener<AuthBloc, AuthState>(
+///       listener: (context, state) => {},
+///     ),
+///     BlocSignalListener<ThemeBloc, ThemeState>(
+///       listener: (context, state) => {},
+///     ),
+///   ],
+///   child: HomeScreen(),
+/// )
+/// ```
+class MultiBlocSignalListener extends StatelessWidget {
+  /// Creates a [MultiBlocSignalListener] that runs multiple [listeners].
+  const MultiBlocSignalListener({
+    required this.child,
+    required this.listeners,
+    super.key,
+  });
+
+  /// The list of [BlocSignalListener] instances to run.
+  final List<BlocSignalListener<BlocSignalBase<dynamic>, dynamic>> listeners;
+
+  /// The child widget subtree.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    var current = child;
+    for (final listener in listeners.reversed) {
+      current = listener.copyWith(current);
+    }
+    return current;
+  }
+}

--- a/bloc_signals_flutter/pubspec.yaml
+++ b/bloc_signals_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals_flutter
 resolution: workspace
 description: Flutter extensions and bindings for BlocSignal state management library.
-version: 0.1.9
+version: 0.2.0
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 
@@ -10,7 +10,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  bloc_signals: ^0.1.12
+  bloc_signals: ^0.2.0
   flutter:
     sdk: flutter
   signals_flutter: ^7.0.0

--- a/bloc_signals_flutter/test/bloc_signals_flutter_test.dart
+++ b/bloc_signals_flutter/test/bloc_signals_flutter_test.dart
@@ -74,7 +74,7 @@ void main() {
       await tester.pump(); // Pump frame to trigger watch rebuild
 
       expect(find.text('Count: 1'), findsOneWidget);
-      bloc.close();
+      await bloc.close();
     });
 
     testWidgets(
@@ -103,8 +103,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(home: buildWidget(bloc2)));
         expect(find.text('Count: 42'), findsOneWidget);
 
-        bloc1.close();
-        bloc2.close();
+        await bloc1.close();
+        await bloc2.close();
       },
     );
 
@@ -136,7 +136,7 @@ void main() {
 
       await tester.pumpWidget(widget);
       expect(find.byType(SizedBox), findsOneWidget);
-      bloc.close();
+      await bloc.close();
     });
 
     testWidgets(
@@ -163,7 +163,7 @@ void main() {
 
         bloc.add(Increment());
         expect(bloc.stateValue, equals(1));
-        bloc.close();
+        await bloc.close();
       },
     );
 
@@ -199,8 +199,8 @@ void main() {
         await tester.pumpWidget(MaterialApp(home: widget2));
         expect(find.text('Value: 42'), findsOneWidget);
 
-        bloc1.close();
-        bloc2.close();
+        await bloc1.close();
+        await bloc2.close();
       },
     );
 
@@ -252,7 +252,7 @@ void main() {
       await tester.pump();
 
       expect(find.text('Count: 1'), findsOneWidget);
-      cubit.close();
+      await cubit.close();
     });
 
     testWidgets('BlocSignalListener triggers callback on state changes', (
@@ -272,14 +272,13 @@ void main() {
       );
 
       await tester.pumpWidget(widget);
-      // Under the hood, SignalListener runs the effect immediately on mount.
-      expect(states, equals([0]));
+      expect(states, isEmpty);
 
       bloc.add(Increment());
       await tester.pump();
-      expect(states, equals([0, 1]));
+      expect(states, equals([1]));
 
-      bloc.close();
+      await bloc.close();
     });
 
     testWidgets('BlocSignalConsumer both builds and listens', (
@@ -302,15 +301,15 @@ void main() {
 
       await tester.pumpWidget(widget);
       expect(find.text('Consumer Count: 0'), findsOneWidget);
-      expect(states, equals([0]));
+      expect(states, isEmpty);
 
       bloc.add(Increment());
       await tester.pump();
 
       expect(find.text('Consumer Count: 1'), findsOneWidget);
-      expect(states, equals([0, 1]));
+      expect(states, equals([1]));
 
-      bloc.close();
+      await bloc.close();
     });
 
     testWidgets(
@@ -347,7 +346,7 @@ void main() {
       expect(find.text('GEQ2: true'), findsOneWidget);
       expect(builds, equals(2)); // Rebuilt!
 
-      cubit.close();
+      await cubit.close();
     });
 
     testWidgets(
@@ -370,24 +369,24 @@ void main() {
         }
 
         await tester.pumpWidget(MaterialApp(home: buildWidget(bloc1)));
-        expect(states, equals([0]));
+        expect(states, isEmpty);
 
         // Rebuild with bloc2
         await tester.pumpWidget(MaterialApp(home: buildWidget(bloc2)));
-        expect(states, equals([0, 42]));
+        expect(states, isEmpty);
 
         // Trigger change on bloc2
         bloc2.add(Increment());
         await tester.pump();
-        expect(states, equals([0, 42, 43]));
+        expect(states, equals([43]));
 
         // Verify that changing bloc1 doesn't trigger anymore
         bloc1.add(Increment());
         await tester.pump();
-        expect(states, equals([0, 42, 43]));
+        expect(states, equals([43]));
 
-        bloc1.close();
-        bloc2.close();
+        await bloc1.close();
+        await bloc2.close();
       },
     );
 
@@ -419,8 +418,187 @@ void main() {
         expect(find.text('Val: true'), findsOneWidget);
         expect(builds, equals(2));
 
-        cubit.close();
+        await cubit.close();
       },
     );
+
+    testWidgets('BlocSignalProvider lazy creation works', (tester) async {
+      var createCalls = 0;
+      final widget = BlocSignalProvider<CounterBloc>(
+        create: (context) {
+          createCalls++;
+          return CounterBloc();
+        },
+        child: Builder(
+          builder: (context) {
+            expect(createCalls, equals(0)); // Eagerly not created
+            context.read<CounterBloc>();
+            expect(createCalls, equals(1)); // Created on demand
+            return const SizedBox();
+          },
+        ),
+      );
+      await tester.pumpWidget(MaterialApp(home: widget));
+    });
+
+    testWidgets('BlocSignalProvider non-lazy creation works', (tester) async {
+      var createCalls = 0;
+      final widget = BlocSignalProvider<CounterBloc>(
+        create: (context) {
+          createCalls++;
+          return CounterBloc();
+        },
+        lazy: false,
+        child: Builder(
+          builder: (context) {
+            expect(createCalls, equals(1)); // Eagerly created
+            return const SizedBox();
+          },
+        ),
+      );
+      await tester.pumpWidget(MaterialApp(home: widget));
+    });
+
+    testWidgets('BlocSignalListener with listenWhen triggers conditionally', (
+      tester,
+    ) async {
+      final bloc = CounterBloc();
+      final states = <int>[];
+
+      final widget = MaterialApp(
+        home: BlocSignalListener<CounterBloc, int>(
+          bloc: bloc,
+          listenWhen: (previous, current) => current.isEven,
+          listener: (context, state) {
+            states.add(state);
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      expect(states, isEmpty); // Initial state doesn't trigger listener
+
+      bloc.add(Increment()); // State is 1
+      await tester.pump();
+      expect(states, isEmpty); // 1 is odd
+
+      bloc.add(Increment()); // State is 2
+      await tester.pump();
+      expect(states, equals([2])); // 2 is even
+
+      await bloc.close();
+    });
+
+    testWidgets('MultiBlocSignalListener triggers multiple callbacks', (
+      tester,
+    ) async {
+      final bloc1 = CounterBloc();
+      final bloc2 = CounterCubit();
+      final states1 = <int>[];
+      final states2 = <int>[];
+
+      final widget = MaterialApp(
+        home: MultiBlocSignalListener(
+          listeners: [
+            BlocSignalListener<CounterBloc, int>(
+              bloc: bloc1,
+              listener: (context, state) => states1.add(state),
+              child: const SizedBox(),
+            ),
+            BlocSignalListener<CounterCubit, int>(
+              bloc: bloc2,
+              listener: (context, state) => states2.add(state),
+              child: const SizedBox(),
+            ),
+          ],
+          child: const SizedBox(),
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+
+      bloc1.add(Increment());
+      bloc2.increment();
+      await tester.pump();
+
+      expect(states1, equals([1]));
+      expect(states2, equals([1]));
+
+      await bloc1.close();
+      await bloc2.close();
+    });
+
+    testWidgets('context.select rebuilds only when selected sub-state changes',
+        (
+      tester,
+    ) async {
+      final bloc = CounterBloc();
+      var builds = 0;
+
+      final widget = MaterialApp(
+        home: BlocSignalProvider<CounterBloc>.value(
+          value: bloc,
+          child: Builder(
+            builder: (context) {
+              builds++;
+              final isEven =
+                  context.select<CounterBloc, bool>((b) => b.stateValue.isEven);
+              return Text('isEven: $isEven');
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      expect(find.text('isEven: true'), findsOneWidget);
+      expect(builds, equals(1));
+
+      bloc.add(Increment()); // State is 1 (isEven = false)
+      await tester.pump();
+      expect(find.text('isEven: false'), findsOneWidget);
+      expect(builds, equals(2));
+
+      bloc.add(Increment()); // State is 2 (isEven = true)
+      await tester.pump();
+      expect(find.text('isEven: true'), findsOneWidget);
+      expect(builds, equals(3));
+
+      await bloc.close();
+    });
+
+    testWidgets('Multiple context.select calls on the same element work', (
+      tester,
+    ) async {
+      final bloc = CounterBloc();
+      var builds = 0;
+
+      final widget = MaterialApp(
+        home: BlocSignalProvider<CounterBloc>.value(
+          value: bloc,
+          child: Builder(
+            builder: (context) {
+              builds++;
+              final isEven =
+                  context.select<CounterBloc, bool>((b) => b.stateValue.isEven);
+              final isPositive =
+                  context.select<CounterBloc, bool>((b) => b.stateValue >= 0);
+              return Text('isEven: $isEven, isPositive: $isPositive');
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+      expect(find.text('isEven: true, isPositive: true'), findsOneWidget);
+      expect(builds, equals(1));
+
+      bloc.add(Increment()); // State is 1
+      await tester.pump();
+      expect(find.text('isEven: false, isPositive: true'), findsOneWidget);
+      expect(builds, equals(2));
+
+      await bloc.close();
+    });
   });
 }

--- a/otel_bloc_signals/CHANGELOG.md
+++ b/otel_bloc_signals/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0
+
+- Update OpenTelemetry instrumentation for version 0.2.0:
+  - Support the new `close()` method returning `Future<void>`.
+  - Update `bloc_signals` dependency constraint to `^0.2.0`.
+
 ## 0.1.6
 
 - Update `bloc_signals` dependency constraint to `^0.1.12`.

--- a/otel_bloc_signals/example/otel_bloc_signals_example.dart
+++ b/otel_bloc_signals/example/otel_bloc_signals_example.dart
@@ -62,11 +62,10 @@ void main() {
 
   print('--- Starting CounterBloc instrumentation example ---');
 
-  // 5. Instantiate and use the BLoC with cascade calls
-  CounterBloc()
+  final bloc = CounterBloc()
     ..add(Increment())
-    ..add(Increment())
-    ..close();
+    ..add(Increment());
+  unawaited(bloc.close());
 
   // Shut down the tracer provider to flush the remaining spans to console
   tracerProvider.shutdown();

--- a/otel_bloc_signals/pubspec.yaml
+++ b/otel_bloc_signals/pubspec.yaml
@@ -1,7 +1,7 @@
 name: otel_bloc_signals
 resolution: workspace
 description: OpenTelemetry tracing instrumentation for BlocSignal.
-version: 0.1.6
+version: 0.2.0
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.5.0
 
 dependencies:
-  bloc_signals: ^0.1.12
+  bloc_signals: ^0.2.0
   meta: ">=1.11.0 <2.0.0"
   opentelemetry: ">=0.18.10 <0.19.0"
 

--- a/otel_bloc_signals/test/otel_bloc_signals_test.dart
+++ b/otel_bloc_signals/test/otel_bloc_signals_test.dart
@@ -73,13 +73,13 @@ void main() {
       expect(defaultObserver, isNotNull);
     });
 
-    test('instruments events and transitions successfully', () {
+    test('instruments events and transitions successfully', () async {
       final bloc = TestBloc();
       expect(bloc.stateValue, equals(0));
 
       bloc.add(Increment());
       expect(bloc.stateValue, equals(1));
-      bloc.close();
+      await bloc.close();
 
       expect(exporter.exportedSpans, hasLength(1));
       final span = exporter.exportedSpans.first;
@@ -98,14 +98,14 @@ void main() {
       );
     });
 
-    test('instruments errors successfully', () {
+    test('instruments errors successfully', () async {
       final bloc = TestBloc(initialState: -1);
 
       expect(
         () => bloc.add(Increment()),
         throwsArgumentError,
       );
-      bloc.close();
+      await bloc.close();
 
       // We expect 1 span: the event span itself, marked with error status.
       expect(exporter.exportedSpans, hasLength(1));
@@ -115,10 +115,11 @@ void main() {
       expect(span.status.description, contains('Test error'));
     });
 
-    test('instruments error to transient span when no active span exists', () {
+    test('instruments error to transient span when no active span exists',
+        () async {
       final bloc = TestBloc();
       observer.onError(bloc, ArgumentError('Fallback error'), StackTrace.empty);
-      bloc.close();
+      await bloc.close();
 
       expect(exporter.exportedSpans, hasLength(1));
       final span = exporter.exportedSpans.first;
@@ -127,20 +128,20 @@ void main() {
       expect(span.status.description, contains('Fallback error'));
     });
 
-    test('caps active spans map and evicts oldest spans', () {
+    test('caps active spans map and evicts oldest spans', () async {
       final bloc = TestBloc();
       for (var i = 0; i < 1005; i++) {
         observer.onEvent(bloc, 'event_$i');
       }
       expect(exporter.exportedSpans, hasLength(5));
       expect(exporter.exportedSpans.first.name, equals('TestBloc.add(String)'));
-      bloc.close();
+      await bloc.close();
     });
 
-    test('instruments CubitSignal errors to transient span successfully', () {
-      TestCubit()
-        ..triggerError()
-        ..close();
+    test('instruments CubitSignal errors to transient span successfully',
+        () async {
+      final cubit = TestCubit()..triggerError();
+      await cubit.close();
 
       expect(exporter.exportedSpans, hasLength(1));
       final span = exporter.exportedSpans.first;

--- a/skills/bloc-signals/core.md
+++ b/skills/bloc-signals/core.md
@@ -269,4 +269,94 @@ await successFuture;
 Navigator.pushReplacementNamed(context, '/home');
 ```
 
+---
+
+### 5. Transition & Change Propagation Protocols
+
+`BlocSignal` and `CubitSignal` expose lifecycle and transition protocols equivalent to classic BLoC for observability, tracing, and logging.
+
+#### The `Change` Class
+Represents the mutation of state from `currentState` to `nextState`.
+```dart
+final change = Change(currentState: 0, nextState: 1);
+```
+
+#### The `Transition` Class
+Represents a state mutation triggered by a specific `event`.
+```dart
+final transition = Transition(
+  currentState: 0,
+  event: IncrementEvent(),
+  nextState: 1,
+);
+```
+
+#### Local Method Overrides
+* **`onChange(Change<State> change)`**: Invoked on `BlocSignalBase` subclasses (both Blocs and Cubits) whenever a new state is emitted (provided the new state is not de-duplicated). Overrides MUST invoke `super.onChange(change)`.
+* **`onTransition(Transition<Event, State> transition)`**: Invoked on `BlocSignal` subclasses whenever an event triggers a state change. Overrides MUST invoke `super.onTransition(transition)`.
+
+```dart
+class CounterBloc extends BlocSignal<CounterEvent, int> {
+  CounterBloc() : super(initialState: 0);
+
+  @override
+  void onChange(Change<int> change) {
+    super.onChange(change);
+    print('State changed: $change');
+  }
+
+  @override
+  void onTransition(Transition<CounterEvent, int> transition) {
+    super.onTransition(transition);
+    print('Transition triggered: $transition');
+  }
+}
+```
+
+#### Global Observation via `BlocSignalObserver`
+You can configure a global observer to intercept events, transitions, changes, errors, and lifecycle events across all instances:
+
+```dart
+class MyObserver extends BlocSignalObserver {
+  @override
+  void onCreate(BlocSignalBase<dynamic> bloc) {
+    print('Created: ${bloc.runtimeType}');
+  }
+
+  @override
+  void onEvent(BlocSignal<dynamic, dynamic> bloc, Object? event) {
+    print('Event added to ${bloc.runtimeType}: $event');
+  }
+
+  @override
+  void onChange(BlocSignalBase<dynamic> bloc, Change<dynamic> change) {
+    print('Change in ${bloc.runtimeType}: $change');
+  }
+
+  @override
+  void onTransition(
+    BlocSignalBase<dynamic> bloc,
+    Object? event,
+    Object? state,
+  ) {
+    // Deprecated legacy callback for backwards compatibility
+  }
+
+  @override
+  void onError(BlocSignalBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    print('Error in ${bloc.runtimeType}: $error');
+  }
+
+  @override
+  void onClose(BlocSignalBase<dynamic> bloc) {
+    print('Closed: ${bloc.runtimeType}');
+  }
+}
+
+void main() {
+  BlocSignalObserver.observer = MyObserver();
+}
+```
+
+
 

--- a/skills/bloc-signals/migration.md
+++ b/skills/bloc-signals/migration.md
@@ -12,7 +12,125 @@ Classic BLoC is built on Dart `Stream`s, which are asynchronous and rely on the 
 In contrast, `BlocSignal` relies on reactive signals. State propagation is immediate and **synchronous**: calling `emit()` updates the state value instantly in the current execution block, recalculating the reactive dependency graph and triggering UI rebuilds in the exact same frame.
 
 ### Feature Parity & Stream Limitations
-While `BlocSignal` mimics BLoC's lifecycle, dependency injection, and state encapsulation, it is not a 1:1 drop-in replacement. Because `BlocSignal` does not use streams under the hood, standard stream manipulation features (such as `debounce`, `throttle`, `distinct`, or RxDart operators like `switchMap` and `flatMap`) are not natively available on the state container. If your business logic relies heavily on stream-transforming event transformers, you will need to map these behaviors using custom debouncers or reactive signal effects.
+
+While `BlocSignal` mimics BLoC's lifecycle, dependency injection, and state encapsulation, it is not a 1:1 drop-in replacement. Because `BlocSignal` does not use streams under the hood, the following classic BLoC stream features are **not available**:
+
+1. **Custom `EventTransformer`s**: You cannot specify a custom event transformer (e.g. `bloc_concurrency` concurrent, sequential, or restartable) via `on<Event>(..., transformer: ...)`.
+2. **RxDart Operators**: Stream operators such as `debounceTime`, `throttleTime`, `switchMap`, `flatMap`, `concatMap`, `buffer`, and `distinct` cannot be called directly on the state or event dispatchers.
+
+#### Mapping Stream Behaviors to Signals
+
+##### 1. Debouncing Events (e.g., Search Input)
+In classic BLoC, you might debounce text input changes to prevent redundant API queries:
+```dart
+// Classic BLoC (with bloc_concurrency or RxDart)
+on<SearchTextChanged>(
+  (event, emit) async => ...,
+  transformer: debounce(const Duration(milliseconds: 300)),
+);
+```
+
+In `BlocSignal`, you can achieve the same behavior using a standard `Timer` within the event handler:
+```dart
+import 'dart:async';
+
+class SearchBloc extends BlocSignal<SearchEvent, SearchState> {
+  SearchBloc() : super(initialState: SearchInitial());
+  Timer? _debounceTimer;
+
+  @override
+  Future<void> onEvent(SearchEvent event) async {
+    await super.onEvent(event);
+    if (event is SearchTextChanged) {
+      _debounceTimer?.cancel();
+      _debounceTimer = Timer(const Duration(milliseconds: 300), () {
+        _performSearch(event.query);
+      });
+    }
+  }
+
+  void _performSearch(String query) {
+    // Perform search API call and emit results
+  }
+
+  @override
+  Future<void> close() {
+    _debounceTimer?.cancel();
+    return super.close();
+  }
+}
+```
+
+##### 2. Dropping Events (e.g., Throttle / Droppable Page Fetching)
+In classic BLoC, a `droppable` transformer ignores incoming events while an asynchronous operation is already running:
+```dart
+// Classic BLoC
+on<FetchPage>(
+  (event, emit) async => ...,
+  transformer: droppable(),
+);
+```
+
+In `BlocSignal`, check the current state synchronously to drop subsequent events:
+```dart
+on<FetchPage>((event, emit) async {
+  // Drop event if operation is already in progress
+  if (stateValue is PageLoadInProgress) return;
+
+  emit(PageLoadInProgress());
+  try {
+    final page = await api.fetchPage();
+    emit(PageLoadSuccess(page));
+  } catch (e) {
+    emit(PageLoadFailure(e));
+  }
+});
+```
+
+##### 3. Restartable Operations (e.g., SwitchMap / Cancel Active Request)
+In classic BLoC, a `restartable` transformer cancels the current active request if a new event arrives:
+```dart
+// Classic BLoC
+on<FetchDetails>(
+  (event, emit) async => ...,
+  transformer: restartable(),
+);
+```
+
+In `BlocSignal`, track the active operation (e.g. using `CancelableOperation` from `package:async`) and cancel it synchronously when a new event is handled:
+```dart
+import 'package:async/async.dart';
+
+class DetailBloc extends BlocSignal<DetailEvent, DetailState> {
+  DetailBloc() : super(initialState: DetailInitial());
+  CancelableOperation<DetailData>? _activeOperation;
+
+  on<FetchDetails>((event, emit) async {
+    await _activeOperation?.cancel();
+    emit(DetailLoadInProgress());
+
+    final operation = CancelableOperation.fromFuture(api.fetch(event.id));
+    _activeOperation = operation;
+
+    try {
+      final data = await operation.value;
+      if (!operation.isCanceled) {
+        emit(DetailLoadSuccess(data));
+      }
+    } catch (e) {
+      if (!operation.isCanceled) {
+        emit(DetailLoadFailure(e));
+      }
+    }
+  });
+
+  @override
+  Future<void> close() {
+    _activeOperation?.cancel();
+    return super.close();
+  }
+}
+```
 
 ### Automatic State De-duplication
 In classic BLoC, emitting the exact same state value multiple times will propagate downstream through the stream unless you filter it manually using `.distinct()`.
@@ -243,6 +361,18 @@ final bloc = context.watch<CounterBloc>();
 final count = bloc.stateValue;
 ```
 
+### Context Select (Selecting sub-state slices)
+
+#### Before (Classic `context.select`)
+```dart
+final isEven = context.select<CounterBloc, bool>((bloc) => bloc.state.isEven);
+```
+
+#### After (BlocSignal `context.select`)
+```dart
+final isEven = context.select<CounterBloc, bool>((bloc) => bloc.stateValue.isEven);
+```
+
 ---
 
 ## 5. Global Logging / Observation
@@ -251,9 +381,27 @@ final count = bloc.stateValue;
 ```dart
 class MyObserver extends BlocObserver {
   @override
+  void onCreate(BlocBase bloc) {
+    super.onCreate(bloc);
+    print('Created: $bloc');
+  }
+
+  @override
+  void onChange(BlocBase bloc, Change change) {
+    super.onChange(bloc, change);
+    print('Change: $change');
+  }
+
+  @override
   void onTransition(Bloc bloc, Transition transition) {
     super.onTransition(bloc, transition);
-    print(transition);
+    print('Transition: $transition');
+  }
+
+  @override
+  void onClose(BlocBase bloc) {
+    super.onClose(bloc);
+    print('Closed: $bloc');
   }
 }
 ```
@@ -262,12 +410,81 @@ class MyObserver extends BlocObserver {
 ```dart
 class MyObserver extends BlocSignalObserver {
   @override
-  void onTransition(BlocSignal bloc, Object? event, Object? state) {
-    print('State transitioned to: $state');
+  void onCreate(BlocSignalBase bloc) {
+    super.onCreate(bloc);
+    print('Created: $bloc');
+  }
+
+  @override
+  void onChange(BlocSignalBase bloc, Change change) {
+    super.onChange(bloc, change);
+    print('Change: $change');
+  }
+
+  @override
+  void onTransition(BlocSignalBase bloc, Object? event, Object? state) {
+    super.onTransition(bloc, event, state);
+    // Legacy support
+  }
+
+  @override
+  void onClose(BlocSignalBase bloc) {
+    super.onClose(bloc);
+    print('Closed: $bloc');
   }
 }
+```
 
-void main() {
-  BlocSignalObserver.observer = MyObserver();
-}
+---
+
+## 6. Listening to State Conditionally (`listenWhen`)
+
+### Before (Classic `BlocListener` with `listenWhen`)
+```dart
+BlocListener<CounterBloc, int>(
+  listenWhen: (previous, current) => current.isEven,
+  listener: (context, state) {
+    print('Even count: $state');
+  },
+  child: const CounterView(),
+)
+```
+
+### After (BlocSignalListener with `listenWhen`)
+```dart
+BlocSignalListener<CounterBloc, int>(
+  listenWhen: (previous, current) => current.isEven,
+  listener: (context, state) {
+    print('Even count: $state');
+  },
+  child: const CounterView(),
+)
+```
+
+---
+
+## 7. Composing Multiple Listeners
+
+### Before (Classic `MultiBlocListener`)
+```dart
+MultiBlocListener(
+  listeners: [
+    BlocListener<AuthBloc, AuthState>(listener: (context, state) => ...),
+    BlocListener<ThemeBloc, ThemeState>(listener: (context, state) => ...),
+  ],
+  child: const HomeScreen(),
+)
+```
+
+### After (MultiBlocSignalListener)
+```dart
+MultiBlocSignalListener(
+  listeners: [
+    BlocSignalListener<AuthBloc, AuthState>(listener: (context, state) => ...),
+    BlocSignalListener<ThemeBloc, ThemeState>(listener: (context, state) => ...),
+  ],
+  child: const HomeScreen(),
+)
+```
+
 ```


### PR DESCRIPTION
# PR Description - Issue #26 [API Parity]

This PR completes the full API parity alignments with classic BLoC and Flutter BLoC patterns.

---

## 🎯 1. Intent
* **Goal**: Implement complete API parity with classic BLoC and Flutter BLoC, specifically lifecycle observability events, lazy provider initialization, context selection, transition/change event tracking, conditional listeners, and multi-listeners.
* **Scope**: Restricts changes strictly to Issue #26 requirements:
  * In `bloc_signals`: `Change`, `Transition`, `BlocSignalObserver` modifications, and local event context zone tracing.
  * In `bloc_signals_flutter`: `lazy` defaults, `context.select`, `listenWhen`, `MultiBlocSignalListener`.
  * In `otel_bloc_signals`: updated tests to handle async `close()` signature.
* **Verdict**: The implementation directly matches the target issue goals. No extraneous features or unrelated fixes were piggybacked onto this branch.

---

## 🧪 2. Verification
* **Verification Methods**:
  * Unit/Widget tests written inside each package subdirectory to verify specific behaviors.
  * Measured test coverage to ensure 100% line coverage for the new behaviors.
* **Reproduction of Failure (TDD)**:
  * For core transition/change observability: Ran new test case in `bloc_signals_test.dart` and saw it fail prior to modifying `emit` and `close` methods.
  * For lazy provider, `listenWhen`, `MultiBlocSignalListener`, and `context.select`: Wrote new test cases in `bloc_signals_flutter_test.dart` and ran them, witnessing failures for assertion checks (specifically, widget builds and callbacks failed or ran eagerly).
* **Current Status**: All 53 tests (28 core tests, 19 Flutter widget/integration tests, 6 OpenTelemetry observer tests) pass successfully.

---

## 🏛️ 3. Architecture
* **Standard Compliance**:
  * **Synchronous Propagation**: Ensured state changes synchronously update reactive signals, triggering rebuilds on the exact same frame.
  * **Event Zone Tracing**: Utilized standard `Zone` context keys (`Zone.current[_zoneEventKey]`) to pass triggering events down to transitions without changing method signatures.
  * **Expando Selector Caching**: Used `Expando` keyed on Flutter `Element` instances to cache and reuse `Computed` signal subscriptions dynamically in `context.select`. To prevent the value closure from holding a strong reference back to the key (which would cause a leak by preventing garbage collection of the `Element` key), the subscription holds a `WeakReference<Element>`.
  * **Lifecycle Cleanup**: Managed the lifecycle of the effect cleans in `BlocSignalListener` by calling `_cleanup?.call()` on widget update, dependencies change, and widget disposal.
  * **Async Rules**: Fully awaited or unawaited future-returning `close()` calls to respect `very_good_analysis` asynchronous analysis rules.

---

## 💥 4. Blast Radius
* **Reactivity Impact**: By changing `BlocSignalProvider` to default to `lazy: true`, any consumers that relied on eager side-effects triggering in constructor scopes without active lookups will experience a behavioral shift. This constitutes a breaking change, which is correctly addressed by bumping the package version from `0.1.x` to `0.2.0`.
* **Performance**: Caching computed selectors on `Element` via `Expando` has O(1) retrieval overhead and cleans up automatically, posing no memory leak risk.
* **Database & Security**: No external database schemas or firebase rules are modified; zero impact.

---

## 🛡️ 5. Reviewer Defense
* **Trade-Offs**:
  * We opted for `context.select` using a post-frame finalizer callback and `Expando` cache rather than forcing users to use `Computed` manually. This introduces minor overhead during frame rendering but makes consumption completely transparent and identical to classic BLoC.
  * `BlocSignalListener` was updated to not fire on widget mount or bloc instance swap (matching classic `BlocListener` behavior). This broke a few legacy tests that assumed immediate firing, which we corrected by updating test assertions to verify correct non-eager lifecycle triggers.
* **Potential Flags**: Reviewers might ask about the performance of the element-keyed `Expando` cache. We defend this by noting that `Expando` relies on native garbage collection of elements to automatically evict subscriptions, which is the most robust way to manage context selection lifecycles in Flutter.
