### PR TITLE
refactor(example): use on<E> event handler syntax (#28)

### DIFF
--- a/bloc_signals_flutter/CHANGELOG.md
+++ b/bloc_signals_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.1
+
+- Refactor example app BLoCs (`LoginBloc` and `TimerBloc`) to use constructor-scoped `on<E>` event handler syntax.
+- Add unit tests for example BLoCs and update example documentation.
+
 ## 0.2.0
 
 - Complete Flutter Bloc API Parity alignments:

--- a/bloc_signals_flutter/example/README.md
+++ b/bloc_signals_flutter/example/README.md
@@ -1,17 +1,47 @@
-# example
+# BlocSignal Flutter Example App
 
-A new Flutter project.
+An example Flutter application demonstrating modern state management using **`bloc_signals`**, **`bloc_signals_flutter`**, and **`kaisel`** routing.
 
-## Getting Started
+## 🚀 Overview
 
-This project is a starting point for a Flutter application.
+This example demonstrates best practices for building reactive Flutter applications with `BlocSignal`:
 
-A few resources to get you started if this is your first Flutter project:
+1. **Constructor-Scoped `on<E>` Event Handlers**:
+   - Registering type-safe event handlers using `on<Event>((event, emit) => ...)` inside constructor scopes.
+   - Orchestrating synchronous and asynchronous handler executions cleanly without manual `onEvent` switch statements.
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+2. **Synchronous Reactive Propagation**:
+   - State emissions via `emit()` propagate synchronously to widget subtrees in the exact same frame.
+   - Built-in state de-duplication using `==` equality prevents unnecessary UI rebuilds.
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+3. **Type-Safe Routing with Kaisel**:
+   - Sealed class route hierarchies (`AppRoute`) paired with `MaterialApp.router`.
+
+4. **Dependency Injection & UI Scoping**:
+   - `BlocSignalProvider` for managing BLoC lifecycles and automatic disposal.
+   - `BlocSignalBuilder` for reactive UI rebuilds.
+   - `context.read<T>()` for context-scoped BLoC lookups without rebuild dependencies.
+
+## 📱 Features
+
+- **Authentication Flow (`LoginBloc`)**:
+  - Validates credentials and handles async authentication latency.
+  - Implements `UsernameChanged`, `PasswordChanged`, `SubmitLogin`, and `Logout` event handlers.
+- **Countdown Timer (`TimerBloc`)**:
+  - Demonstrates stream subscription coordination inside BLoC event handlers.
+  - Implements `TimerStarted`, `TimerPaused`, `TimerResumed`, `TimerReset`, and `_TimerTicked` event handlers.
+
+## 🧪 Running Tests & App
+
+- **Run Tests**:
+  ```bash
+  flutter test
+  ```
+- **Analyze Code**:
+  ```bash
+  flutter analyze
+  ```
+- **Run App**:
+  ```bash
+  flutter run
+  ```

--- a/bloc_signals_flutter/example/lib/main.dart
+++ b/bloc_signals_flutter/example/lib/main.dart
@@ -92,18 +92,21 @@ class LoginState {
 }
 
 /// [LoginBloc] coordinates the user authentication flow.
-/// It receives [LoginEvent] inputs and processes updates synchronously.
+/// It registers constructor-scoped [on] event handlers to process updates synchronously.
 class LoginBloc extends BlocSignal<LoginEvent, LoginState> {
-  LoginBloc() : super(initialState: const LoginState());
-
-  @override
-  Future<void> onEvent(LoginEvent event) async {
-    await super.onEvent(event);
-    if (event is UsernameChanged) {
+  LoginBloc() : super(initialState: const LoginState()) {
+    /// Update username credential on [UsernameChanged].
+    on<UsernameChanged>((event, emit) {
       emit(stateValue.copyWith(username: event.username));
-    } else if (event is PasswordChanged) {
+    });
+
+    /// Update password credential on [PasswordChanged].
+    on<PasswordChanged>((event, emit) {
       emit(stateValue.copyWith(password: event.password));
-    } else if (event is SubmitLogin) {
+    });
+
+    /// Process authentication validation and simulate network latency on [SubmitLogin].
+    on<SubmitLogin>((event, emit) async {
       // Validate inputs
       if (stateValue.username.trim().isEmpty) {
         emit(stateValue.copyWith(error: 'Username cannot be empty'));
@@ -120,7 +123,7 @@ class LoginBloc extends BlocSignal<LoginEvent, LoginState> {
       emit(stateValue.copyWith(isLoading: true, error: null));
 
       // Simulate a network latency/async process
-      await Future.delayed(const Duration(milliseconds: 800));
+      await Future<void>.delayed(const Duration(milliseconds: 800));
 
       if (stateValue.password == 'password') {
         // Authenticated successfully
@@ -134,10 +137,12 @@ class LoginBloc extends BlocSignal<LoginEvent, LoginState> {
           ),
         );
       }
-    } else if (event is Logout) {
-      // Reset state on logout
+    });
+
+    /// Reset authentication credentials on [Logout].
+    on<Logout>((event, emit) {
       emit(const LoginState());
-    }
+    });
   }
 }
 
@@ -193,6 +198,8 @@ class TimerRunComplete extends TimerState {
   const TimerRunComplete() : super(0);
 }
 
+/// [TimerBloc] manages countdown timer state using `on<E>` event handlers
+/// and ticker stream subscriptions.
 class TimerBloc extends BlocSignal<TimerEvent, TimerState> {
   final Ticker ticker;
   static const int _duration = 60;
@@ -200,38 +207,46 @@ class TimerBloc extends BlocSignal<TimerEvent, TimerState> {
   StreamSubscription<int>? _tickerSubscription;
 
   TimerBloc({required this.ticker})
-      : super(initialState: const TimerInitial(_duration));
+      : super(initialState: const TimerInitial(_duration)) {
+    /// Start countdown timer on [TimerStarted].
+    on<TimerStarted>((event, emit) {
+      emit(TimerRunInProgress(event.duration));
+      _tickerSubscription?.cancel();
+      _tickerSubscription = ticker
+          .tick(ticks: event.duration)
+          .listen((duration) => add(_TimerTicked(duration: duration)));
+    });
 
-  @override
-  void onEvent(TimerEvent event) {
-    super.onEvent(event);
-    switch (event) {
-      case TimerStarted(:final duration):
-        emit(TimerRunInProgress(duration));
-        _tickerSubscription?.cancel();
-        _tickerSubscription = ticker
-            .tick(ticks: duration)
-            .listen((duration) => add(_TimerTicked(duration: duration)));
-      case TimerPaused():
-        if (stateValue is TimerRunInProgress) {
-          _tickerSubscription?.pause();
-          emit(TimerRunPause(stateValue.duration));
-        }
-      case TimerResumed():
-        if (stateValue is TimerRunPause) {
-          _tickerSubscription?.resume();
-          emit(TimerRunInProgress(stateValue.duration));
-        }
-      case TimerReset():
-        _tickerSubscription?.cancel();
-        emit(const TimerInitial(_duration));
-      case _TimerTicked(:final duration):
-        emit(
-          duration > 0
-              ? TimerRunInProgress(duration)
-              : const TimerRunComplete(),
-        );
-    }
+    /// Pause active timer subscription on [TimerPaused].
+    on<TimerPaused>((event, emit) {
+      if (stateValue is TimerRunInProgress) {
+        _tickerSubscription?.pause();
+        emit(TimerRunPause(stateValue.duration));
+      }
+    });
+
+    /// Resume paused timer subscription on [TimerResumed].
+    on<TimerResumed>((event, emit) {
+      if (stateValue is TimerRunPause) {
+        _tickerSubscription?.resume();
+        emit(TimerRunInProgress(stateValue.duration));
+      }
+    });
+
+    /// Cancel timer subscription and reset state on [TimerReset].
+    on<TimerReset>((event, emit) {
+      _tickerSubscription?.cancel();
+      emit(const TimerInitial(_duration));
+    });
+
+    /// Process timer tick progression on [_TimerTicked].
+    on<_TimerTicked>((event, emit) {
+      emit(
+        event.duration > 0
+            ? TimerRunInProgress(event.duration)
+            : const TimerRunComplete(),
+      );
+    });
   }
 
   @override

--- a/bloc_signals_flutter/example/pubspec.yaml
+++ b/bloc_signals_flutter/example/pubspec.yaml
@@ -36,8 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   kaisel: ^1.0.0
-  bloc_signals_flutter:
-    path: ../
+  bloc_signals_flutter: ^0.2.1
 
 dev_dependencies:
   flutter_test:

--- a/bloc_signals_flutter/example/test/bloc_test.dart
+++ b/bloc_signals_flutter/example/test/bloc_test.dart
@@ -1,0 +1,138 @@
+import 'package:example/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LoginBloc Unit Tests', () {
+    late LoginBloc loginBloc;
+
+    setUp(() {
+      loginBloc = LoginBloc();
+    });
+
+    tearDown(() {
+      loginBloc.close();
+    });
+
+    test('initial state has empty credentials and is not logged in', () {
+      expect(loginBloc.stateValue.username, isEmpty);
+      expect(loginBloc.stateValue.password, isEmpty);
+      expect(loginBloc.stateValue.isLoading, isFalse);
+      expect(loginBloc.stateValue.isLoggedIn, isFalse);
+      expect(loginBloc.stateValue.error, null);
+    });
+
+    test('UsernameChanged updates username in state', () {
+      loginBloc.add(UsernameChanged('alice'));
+      expect(loginBloc.stateValue.username, 'alice');
+    });
+
+    test('PasswordChanged updates password in state', () {
+      loginBloc.add(PasswordChanged('secret'));
+      expect(loginBloc.stateValue.password, 'secret');
+    });
+
+    test('SubmitLogin with empty username sets error', () async {
+      loginBloc.add(SubmitLogin());
+      expect(loginBloc.stateValue.error, 'Username cannot be empty');
+    });
+
+    test('SubmitLogin with short password sets error', () async {
+      loginBloc.add(UsernameChanged('alice'));
+      loginBloc.add(PasswordChanged('123'));
+      loginBloc.add(SubmitLogin());
+      expect(
+        loginBloc.stateValue.error,
+        'Password must be at least 4 characters',
+      );
+    });
+
+    test('SubmitLogin with incorrect password sets error', () async {
+      loginBloc.add(UsernameChanged('alice'));
+      loginBloc.add(PasswordChanged('wrongpass'));
+      loginBloc.add(SubmitLogin());
+      expect(loginBloc.stateValue.isLoading, isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+
+      expect(loginBloc.stateValue.isLoading, isFalse);
+      expect(loginBloc.stateValue.isLoggedIn, isFalse);
+      expect(
+        loginBloc.stateValue.error,
+        'Incorrect password! (Hint: use "password")',
+      );
+    });
+
+    test('SubmitLogin with correct password logs in successfully', () async {
+      loginBloc.add(UsernameChanged('alice'));
+      loginBloc.add(PasswordChanged('password'));
+      loginBloc.add(SubmitLogin());
+      expect(loginBloc.stateValue.isLoading, isTrue);
+
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+
+      expect(loginBloc.stateValue.isLoading, isFalse);
+      expect(loginBloc.stateValue.isLoggedIn, isTrue);
+      expect(loginBloc.stateValue.error, null);
+    });
+
+    test('Logout resets state to initial', () async {
+      loginBloc.add(UsernameChanged('alice'));
+      loginBloc.add(PasswordChanged('password'));
+      loginBloc.add(SubmitLogin());
+      await Future<void>.delayed(const Duration(milliseconds: 900));
+      expect(loginBloc.stateValue.isLoggedIn, isTrue);
+
+      loginBloc.add(Logout());
+      expect(loginBloc.stateValue.username, isEmpty);
+      expect(loginBloc.stateValue.password, isEmpty);
+      expect(loginBloc.stateValue.isLoggedIn, isFalse);
+    });
+  });
+
+  group('TimerBloc Unit Tests', () {
+    late TimerBloc timerBloc;
+
+    setUp(() {
+      timerBloc = TimerBloc(ticker: const Ticker());
+    });
+
+    tearDown(() {
+      timerBloc.close();
+    });
+
+    test('initial state is TimerInitial with duration 60', () {
+      expect(timerBloc.stateValue, isA<TimerInitial>());
+      expect(timerBloc.stateValue.duration, 60);
+    });
+
+    test('TimerStarted transitions to TimerRunInProgress', () {
+      timerBloc.add(TimerStarted(duration: 10));
+      expect(timerBloc.stateValue, isA<TimerRunInProgress>());
+      expect(timerBloc.stateValue.duration, 10);
+    });
+
+    test('TimerPaused transitions from TimerRunInProgress to TimerRunPause',
+        () {
+      timerBloc.add(TimerStarted(duration: 10));
+      timerBloc.add(TimerPaused());
+      expect(timerBloc.stateValue, isA<TimerRunPause>());
+      expect(timerBloc.stateValue.duration, 10);
+    });
+
+    test('TimerResumed transitions from TimerRunPause to TimerRunInProgress',
+        () {
+      timerBloc.add(TimerStarted(duration: 10));
+      timerBloc.add(TimerPaused());
+      timerBloc.add(TimerResumed());
+      expect(timerBloc.stateValue, isA<TimerRunInProgress>());
+      expect(timerBloc.stateValue.duration, 10);
+    });
+
+    test('TimerReset resets to TimerInitial', () {
+      timerBloc.add(TimerStarted(duration: 10));
+      timerBloc.add(TimerReset());
+      expect(timerBloc.stateValue, isA<TimerInitial>());
+      expect(timerBloc.stateValue.duration, 60);
+    });
+  });
+}

--- a/bloc_signals_flutter/pubspec.yaml
+++ b/bloc_signals_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals_flutter
 resolution: workspace
 description: Flutter extensions and bindings for BlocSignal state management library.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 


### PR DESCRIPTION
Resolves #28

## Description
- Refactored `LoginBloc` and `TimerBloc` in `bloc_signals_flutter/example/lib/main.dart` from manual `onEvent` overrides to constructor-scoped `on<E>((event, emit) => ...)` event handler registrations.
- Added comprehensive unit tests in `bloc_signals_flutter/example/test/bloc_test.dart`.
- Enhanced doc comments (`///`) and updated `bloc_signals_flutter/example/README.md`.
- Bumped `bloc_signals_flutter` version to `0.2.1` and updated `CHANGELOG.md`.

## Verification
- `flutter analyze` passed with 0 issues.
- `flutter test` passed all tests cleanly.