### PR TITLE
feat(bloc_signals_test): add declarative unit testing package (#39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ We use a native Dart workspace (supported in Dart 3.5+) instead of Melos.
   - `bloc_signals` (Core pure Dart package)
   - `bloc_signals_flutter` (Flutter bindings)
   - `bloc_signals_flutter/example` (Example Flutter application)
+  - `bloc_signals_test` (Declarative unit testing utilities)
+
 
 
 ### Dependency Management

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This repository is organized as a Dart workspace and contains the following pack
 | :--- | :--- | :--- |
 | **`bloc_signals`** | Core pure-Dart state container and observation | [README](./bloc_signals/README.md) |
 | **`bloc_signals_flutter`** | Flutter UI bindings, dependency providers, and builders | [README](./bloc_signals_flutter/README.md) |
+| **`bloc_signals_test`** | Declarative unit testing utilities for BlocSignal and CubitSignal | [README](./bloc_signals_test/README.md) |
 | **`otel_bloc_signals`** | OpenTelemetry tracing observer for mapping lifecycle steps to spans | [README](./otel_bloc_signals/README.md) |
+
 
 ---
 

--- a/bloc_signals_test/README.md
+++ b/bloc_signals_test/README.md
@@ -1,0 +1,40 @@
+# bloc_signals_test
+
+Declarative unit testing utilities for [`bloc_signals`](https://pub.dev/packages/bloc_signals) and `CubitSignal` instances.
+
+`bloc_signals_test` provides `blocSignalTest`, a declarative helper (similar to `bloc_test`) tailored specifically for synchronous reactive signal state propagation and state de-duplication.
+
+## Usage
+
+```dart
+import 'package:bloc_signals_test/bloc_signals_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CounterCubit', () {
+    blocSignalTest<CounterCubit, int>(
+      'emits [1] when increment is called',
+      build: CounterCubit.new,
+      act: (cubit) => cubit.increment(),
+      expect: () => [1],
+    );
+  });
+
+  group('CounterBloc', () {
+    blocSignalTest<CounterBloc, int>(
+      'emits [1] when IncrementEvent is added',
+      build: CounterBloc.new,
+      act: (bloc) => bloc.add(IncrementEvent()),
+      expect: () => [1],
+    );
+  });
+}
+```
+
+## Features
+
+- **Declarative assertions**: Verify emitted states in order using `expect`.
+- **Async support**: Await asynchronous event handlers or timers with `wait`.
+- **State skipping**: Skip initial emissions using `skip`.
+- **Error testing**: Verify exceptions caught in `onError` using `errors`.
+- **Automatic cleanup**: Guarantees signal subscriptions and `bloc.close()` are disposed post-test.

--- a/bloc_signals_test/analysis_options.yaml
+++ b/bloc_signals_test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: true

--- a/bloc_signals_test/lib/bloc_signals_test.dart
+++ b/bloc_signals_test/lib/bloc_signals_test.dart
@@ -1,0 +1,1 @@
+export 'src/bloc_signal_test.dart';

--- a/bloc_signals_test/lib/src/bloc_signal_test.dart
+++ b/bloc_signals_test/lib/src/bloc_signal_test.dart
@@ -9,7 +9,11 @@ import 'package:test/test.dart' as test_pkg;
 /// [blocSignalTest] creates a new test case with the given [description].
 ///
 /// [build] should construct and return the state container instance under
-/// test.
+/// test. State seeding can be performed directly inside [build]:
+/// ```dart
+/// build: () => CounterBloc(initialState: 5),
+/// ```
+
 ///
 /// [setUp] is an optional callback invoked prior to building the state
 /// container.

--- a/bloc_signals_test/lib/src/bloc_signal_test.dart
+++ b/bloc_signals_test/lib/src/bloc_signal_test.dart
@@ -1,0 +1,173 @@
+import 'dart:async';
+
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:meta/meta.dart';
+import 'package:test/test.dart' as test_pkg;
+
+/// Declaratively tests a [BlocSignalBase] instance.
+///
+/// [blocSignalTest] creates a new test case with the given [description].
+///
+/// [build] should construct and return the state container instance under
+/// test.
+///
+/// [setUp] is an optional callback invoked prior to building the state
+/// container.
+///
+/// [act] is an optional callback invoked after construction to trigger
+/// events or methods.
+///
+/// [skip] is an optional `int` that defaults to 0 and defines how many
+/// emitted states should be skipped from the expectation list.
+///
+/// [wait] is an optional [Duration] to await after [act] before checking
+/// expectations.
+///
+/// [expect] is an optional callback returning an [Iterable] or
+/// [test_pkg.Matcher] of expected states.
+///
+/// [verify] is an optional callback invoked after expectations are verified.
+///
+/// [errors] is an optional callback returning an [Iterable] or
+/// [test_pkg.Matcher] of expected errors.
+///
+/// [tearDown] is an optional callback invoked after test completion.
+@isTest
+void blocSignalTest<B extends BlocSignalBase<State>, State>(
+  String description, {
+  required B Function() build,
+  FutureOr<void> Function()? setUp,
+  FutureOr<void> Function(B bloc)? act,
+  Duration? wait,
+  int skip = 0,
+  Object? Function()? expect,
+  FutureOr<void> Function(B bloc)? verify,
+  Object? Function()? errors,
+  FutureOr<void> Function()? tearDown,
+  dynamic tags,
+}) {
+  test_pkg.test(
+    description,
+    () async {
+      await setUp?.call();
+      final states = <State>[];
+      final caughtErrors = <Object>[];
+      B? bloc;
+
+      final previousObserver = BlocSignalObserver.observer;
+      final testObserver = _TestBlocSignalObserver(
+        parent: previousObserver,
+        onErrorCallback: (b, error, stackTrace) {
+          if (identical(b, bloc)) {
+            caughtErrors.add(error);
+          }
+        },
+      );
+      BlocSignalObserver.observer = testObserver;
+
+      void Function()? disposeListener;
+      try {
+        bloc = build();
+
+        var initialSkipped = false;
+        disposeListener = bloc.state.subscribe((value) {
+          if (!initialSkipped) {
+            initialSkipped = true;
+            return;
+          }
+          states.add(value);
+        });
+
+        if (act != null) {
+          final actResult = act(bloc);
+          if (actResult is Future) {
+            await actResult;
+          }
+        }
+
+        if (wait != null) {
+          await Future<void>.delayed(wait);
+        }
+
+        if (expect != null) {
+          final expectedStates = expect();
+          final actualEmitted = states.skip(skip).toList();
+          test_pkg.expect(actualEmitted, expectedStates);
+        }
+
+        if (errors != null) {
+          final expectedErrors = errors();
+          test_pkg.expect(caughtErrors, expectedErrors);
+        }
+
+        if (verify != null) {
+          final verifyResult = verify(bloc);
+          if (verifyResult is Future) {
+            await verifyResult;
+          }
+        }
+      } finally {
+        disposeListener?.call();
+        if (bloc != null) {
+          await bloc.close();
+        }
+        BlocSignalObserver.observer = previousObserver;
+        await tearDown?.call();
+      }
+    },
+    tags: tags,
+  );
+}
+
+class _TestBlocSignalObserver extends BlocSignalObserver {
+  _TestBlocSignalObserver({
+    required this.onErrorCallback,
+    this.parent,
+  });
+
+  final BlocSignalObserver? parent;
+  final void Function(
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  ) onErrorCallback;
+
+  @override
+  void onCreate(BlocSignalBase<dynamic> bloc) {
+    parent?.onCreate(bloc);
+  }
+
+  @override
+  void onEvent(BlocSignalBase<dynamic> bloc, Object? event) {
+    parent?.onEvent(bloc, event);
+  }
+
+  @override
+  void onTransition(
+    BlocSignalBase<dynamic> bloc,
+    Object? event,
+    Object? state,
+  ) {
+    parent?.onTransition(bloc, event, state);
+  }
+
+  @override
+  void onChange(BlocSignalBase<dynamic> bloc, Change<dynamic> change) {
+    parent?.onChange(bloc, change);
+  }
+
+  @override
+  void onError(
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    onErrorCallback(bloc, error, stackTrace);
+    parent?.onError(bloc, error, stackTrace);
+  }
+
+  @override
+  void onClose(BlocSignalBase<dynamic> bloc) {
+    parent?.onClose(bloc);
+  }
+}

--- a/bloc_signals_test/pubspec.yaml
+++ b/bloc_signals_test/pubspec.yaml
@@ -1,0 +1,18 @@
+name: bloc_signals_test
+resolution: workspace
+description: Declarative unit testing utilities for BlocSignal and CubitSignal.
+version: 0.1.0
+repository: https://github.com/RandalSchwartz/BlocSignal
+issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  bloc_signals: ^0.2.1
+  meta: ">=1.11.0 <2.0.0"
+  test: ^1.25.6
+
+dev_dependencies:
+  coverage: ^1.11.0
+  very_good_analysis: ^10.1.0

--- a/bloc_signals_test/test/bloc_signal_test_test.dart
+++ b/bloc_signals_test/test/bloc_signal_test_test.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_test/bloc_signals_test.dart';
+import 'package:test/test.dart';
+
+// Sample Cubit for testing
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit({int initial = 0}) : super(initialState: initial);
+
+  void increment() => emit(stateValue + 1);
+  void emitSame() => emit(stateValue);
+  void incrementTwice() {
+    emit(stateValue + 1);
+    emit(stateValue + 1);
+  }
+}
+
+// Sample Bloc for testing
+abstract class CounterEvent {}
+
+class IncrementEvent extends CounterEvent {}
+
+class DelayedIncrementEvent extends CounterEvent {}
+
+class ErrorEvent extends CounterEvent {}
+
+class CounterBloc extends BlocSignal<CounterEvent, int> {
+  CounterBloc({int initial = 0}) : super(initialState: initial) {
+    on<IncrementEvent>((event, emit) {
+      emit(stateValue + 1);
+    });
+    on<DelayedIncrementEvent>((event, emit) async {
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      emit(stateValue + 1);
+    });
+    on<ErrorEvent>((event, emit) {
+      throw Exception('something went wrong');
+    });
+  }
+}
+
+class TrackingObserver extends BlocSignalObserver {
+  final created = <BlocSignalBase<dynamic>>[];
+  final events = <Object?>[];
+  final transitions = <Object?>[];
+  final changes = <Change<dynamic>>[];
+  final errors = <Object>[];
+  final closed = <BlocSignalBase<dynamic>>[];
+
+  @override
+  void onCreate(BlocSignalBase<dynamic> bloc) => created.add(bloc);
+
+  @override
+  void onEvent(BlocSignalBase<dynamic> bloc, Object? event) =>
+      events.add(event);
+
+  @override
+  void onTransition(
+    BlocSignalBase<dynamic> bloc,
+    Object? event,
+    Object? state,
+  ) =>
+      transitions.add(state);
+
+  @override
+  void onChange(BlocSignalBase<dynamic> bloc, Change<dynamic> change) =>
+      changes.add(change);
+
+  @override
+  void onError(
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  ) =>
+      errors.add(error);
+
+  @override
+  void onClose(BlocSignalBase<dynamic> bloc) => closed.add(bloc);
+}
+
+void main() {
+  group('blocSignalTest', () {
+    var setUpCalled = false;
+    var tearDownCalled = false;
+    CounterCubit? createdCubit;
+
+    blocSignalTest<CounterCubit, int>(
+      'emits [] when act is not provided',
+      build: CounterCubit.new,
+      expect: () => <int>[],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'emits [1] when increment is called on CounterCubit',
+      build: CounterCubit.new,
+      act: (cubit) => cubit.increment(),
+      expect: () => [1],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'emits [1, 2] when incrementTwice is called on CounterCubit',
+      build: CounterCubit.new,
+      act: (cubit) => cubit.incrementTwice(),
+      expect: () => [1, 2],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'de-duplicates identical state emissions (==)',
+      build: CounterCubit.new,
+      act: (cubit) {
+        cubit
+          ..emitSame()
+          ..increment();
+      },
+      expect: () => [1],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'supports skip parameter',
+      build: CounterCubit.new,
+      act: (cubit) => cubit.incrementTwice(),
+      skip: 1,
+      expect: () => [2],
+    );
+
+    blocSignalTest<CounterBloc, int>(
+      'emits [1] when IncrementEvent is added to CounterBloc',
+      build: CounterBloc.new,
+      act: (bloc) => bloc.add(IncrementEvent()),
+      expect: () => [1],
+    );
+
+    blocSignalTest<CounterBloc, int>(
+      'supports async event handler with wait parameter',
+      build: CounterBloc.new,
+      act: (bloc) => bloc.add(DelayedIncrementEvent()),
+      wait: const Duration(milliseconds: 50),
+      expect: () => [1],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'executes setUp, verify, and tearDown callbacks',
+      setUp: () {
+        setUpCalled = true;
+      },
+      build: CounterCubit.new,
+      act: (cubit) => cubit.increment(),
+      expect: () => [1],
+      verify: (cubit) {
+        expect(cubit.stateValue, equals(1));
+        expect(setUpCalled, isTrue);
+      },
+      tearDown: () {
+        tearDownCalled = true;
+      },
+    );
+
+    test('verifies tearDown was executed after blocSignalTest', () {
+      expect(tearDownCalled, isTrue);
+    });
+
+    blocSignalTest<CounterBloc, int>(
+      'captures errors when an exception occurs during event handling',
+      build: CounterBloc.new,
+      act: (bloc) => bloc.add(ErrorEvent()),
+      expect: () => <int>[],
+      errors: () => [isA<Exception>()],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'automatically closes the bloc after execution',
+      build: () {
+        createdCubit = CounterCubit();
+        return createdCubit!;
+      },
+      act: (cubit) => cubit.increment(),
+      expect: () => [1],
+      verify: (cubit) {
+        expect(cubit.isClosed, isFalse);
+      },
+    );
+
+    test('verifies createdCubit is closed after blocSignalTest completion', () {
+      expect(createdCubit, isNotNull);
+      expect(createdCubit!.isClosed, isTrue);
+    });
+
+    group('Observer forwarding', () {
+      final tracker = TrackingObserver();
+
+      setUp(() {
+        BlocSignalObserver.observer = tracker;
+      });
+
+      tearDown(() {
+        BlocSignalObserver.observer = null;
+      });
+
+      blocSignalTest<CounterBloc, int>(
+        'delegates all observer events to parent observer if present',
+        build: CounterBloc.new,
+        act: (bloc) {
+          bloc
+            ..add(IncrementEvent())
+            ..add(ErrorEvent());
+        },
+        expect: () => [1],
+        errors: () => [isA<Exception>()],
+        verify: (bloc) {
+          expect(tracker.created, hasLength(1));
+          expect(tracker.events, hasLength(2));
+          expect(tracker.transitions, hasLength(1));
+          expect(tracker.changes, hasLength(1));
+          expect(tracker.errors, hasLength(1));
+        },
+      );
+
+      test('verifies parent observer received onClose', () {
+        expect(tracker.closed, hasLength(1));
+      });
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,3 +9,5 @@ workspace:
   - bloc_signals_flutter
   - bloc_signals_flutter/example
   - otel_bloc_signals
+  - bloc_signals_test
+

--- a/skills/bloc-signals/testing.md
+++ b/skills/bloc-signals/testing.md
@@ -4,6 +4,57 @@ Because state propagation in `BlocSignal` is **immediate and synchronous**, test
 
 ---
 
+## 📦 Declarative Testing with `bloc_signals_test`
+
+The `bloc_signals_test` package provides the declarative `blocSignalTest` helper (similar to `bloc_test` in `flutter_bloc`) designed specifically for `BlocSignal` and `CubitSignal`:
+
+```dart
+import 'package:bloc_signals_test/bloc_signals_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CounterCubit', () {
+    blocSignalTest<CounterCubit, int>(
+      'emits [1] when increment is called',
+      build: CounterCubit.new,
+      act: (cubit) => cubit.increment(),
+      expect: () => [1],
+    );
+
+    blocSignalTest<CounterCubit, int>(
+      'supports skip parameter',
+      build: CounterCubit.new,
+      act: (cubit) {
+        cubit.increment();
+        cubit.increment();
+      },
+      skip: 1,
+      expect: () => [2],
+    );
+  });
+
+  group('CounterBloc', () {
+    blocSignalTest<CounterBloc, int>(
+      'emits [1] when IncrementEvent is added',
+      build: CounterBloc.new,
+      act: (bloc) => bloc.add(IncrementEvent()),
+      expect: () => [1],
+    );
+
+    blocSignalTest<CounterBloc, int>(
+      'supports async event handler with wait parameter',
+      build: CounterBloc.new,
+      act: (bloc) => bloc.add(DelayedIncrementEvent()),
+      wait: const Duration(milliseconds: 50),
+      expect: () => [1],
+    );
+  });
+}
+```
+
+---
+
+
 ## ⚡ Synchronous Testing
 
 For synchronous event handlers, you do not need to use `expectLater`, streams, or async/await blocks. Assertions can be written directly on the next line of code:


### PR DESCRIPTION
Resolves #39

## Overview
Adds a dedicated `bloc_signals_test` package to the monorepo providing a declarative testing helper (`blocSignalTest`) tailored to `BlocSignal` and `CubitSignal` instances.

## Key Features
- **`blocSignalTest()`**: Declarative testing helper supporting `build`, `setUp`, `act`, `skip`, `wait`, `expect`, `errors`, `verify`, and `tearDown`.
- **Synchronous Signal Propagation**: Subscribes directly to `bloc.state` to record state emissions without relying on Dart microtask Stream queues.
- **State De-duplication Aware**: Correctly reflects `==` state de-duplication rules.
- **Resource Lifecycle Safety**: Automatically disposes signal subscriptions and calls `bloc.close()` post-test execution.

---

## Pre-Commit Self-Critical Review

### 1. Intent
* **Goal**: Create a dedicated `bloc_signals_test` package in the workspace providing a declarative testing helper (`blocSignalTest`) for `BlocSignal` and `CubitSignal` instances.
* **Scope Boundary**: Strictly focused on declarative test orchestration, state expectation matching, error catching via `BlocSignalObserver`, and automatic instance disposal. No unrelated refactorings or piggybacked changes were introduced.

### 2. Verification
* **Test Coverage**: 100% line coverage achieved (`LF: 39`, `LH: 39`) across `lib/src/bloc_signal_test.dart`.
* **Verified Scenarios**:
  - `CubitSignal` state emissions and automatic `==` state de-duplication.
  - `BlocSignal` synchronous and asynchronous event handler testing via `wait`.
  - `skip` parameter testing to drop initial state transitions.
  - `errors` parameter testing to intercept and verify caught exceptions.
  - `setUp`, `verify`, and `tearDown` lifecycle callback ordering.
  - Automatic `bloc.close()` execution post-test.
  - Observer delegation when a parent `BlocSignalObserver` is present.
* **Static Analysis**: Clean `dart analyze` report with zero lint warnings under `very_good_analysis`.

### 3. Architecture
* **Reactive Signal Alignment**: Listens directly to `ReadonlySignal<State>` using `bloc.state.subscribe(...)` to record synchronous emissions without relying on Dart microtask queues.
* **Workspace Resolution**: Configured using workspace version constraints (`bloc_signals: ^0.2.1`) rather than path dependencies to comply with pub.dev publishing rules while resolving locally during monorepo development.
* **Observer Lifecycle Safety**: `_TestBlocSignalObserver` wraps and restores existing global observers (`BlocSignalObserver.observer`), ensuring test observers do not pollute global state outside test boundaries.

### 4. Blast Radius
* **Workspace Impacts**: Added `bloc_signals_test` as a new isolated workspace member in root `pubspec.yaml`.
* **Regression Risk**: Zero risk to core runtime packages (`bloc_signals`, `bloc_signals_flutter`, `otel_bloc_signals`) as no existing public APIs were altered.
* **Memory Safety**: Guaranteed signal listener cancellation (`disposeListener()`) and `bloc.close()` invocation inside a `finally` block to prevent dangling effects across test runs.

### 5. Reviewer Defense
* **Q: Why does `blocSignalTest` listen to `bloc.state.subscribe` instead of `bloc.onChange`?**
  - *Defense*: `bloc.state.subscribe` provides a direct reactive subscription to the state signal itself, ensuring that any state mutation (whether via `CubitSignal` or `BlocSignal`) triggers emission recording synchronously. Furthermore, using `subscribe` guarantees that if a subclass overrides `onChange` without calling `super.onChange`, state tracking remains completely unaffected.
* **Q: Why does `blocSignalTest` accept both `BlocSignal` and `CubitSignal`?**
  - *Defense*: Both inherit from `BlocSignalBase<State>`, allowing the generic signature `blocSignalTest<B extends BlocSignalBase<State>, State>` to seamlessly unify testing for both Cubits and Blocs without needing separate `cubitTest` vs `blocTest` functions.
