### PR TITLE
feat(bloc_signals_lint): add package setup & core framework rules (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,8 @@ We use a native Dart workspace (supported in Dart 3.5+) instead of Melos.
   - `bloc_signals_flutter` (Flutter bindings)
   - `bloc_signals_flutter/example` (Example Flutter application)
   - `bloc_signals_test` (Declarative unit testing utilities)
+  - `bloc_signals_lint` (Static analysis lints & IDE diagnostics)
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository is organized as a Dart workspace and contains the following pack
 | **`bloc_signals`** | Core pure-Dart state container and observation | [README](./bloc_signals/README.md) |
 | **`bloc_signals_flutter`** | Flutter UI bindings, dependency providers, and builders | [README](./bloc_signals_flutter/README.md) |
 | **`bloc_signals_test`** | Declarative unit testing utilities for BlocSignal and CubitSignal | [README](./bloc_signals_test/README.md) |
+| **`bloc_signals_lint`** | Static analysis lints and IDE diagnostics for BlocSignal | [README](./bloc_signals_lint/README.md) |
 | **`otel_bloc_signals`** | OpenTelemetry tracing observer for mapping lifecycle steps to spans | [README](./otel_bloc_signals/README.md) |
+
 
 
 ---

--- a/bloc_signals_lint/README.md
+++ b/bloc_signals_lint/README.md
@@ -1,0 +1,63 @@
+# bloc_signals_lint
+
+Custom static analysis lints and diagnostics for [`bloc_signals`](https://pub.dev/packages/bloc_signals).
+
+Built on top of [`custom_lint`](https://pub.dev/packages/custom_lint), `bloc_signals_lint` catches common framework misuse, preserves Zone-context transition tracing, and enforces `BlocSignal` architectural invariants directly inside your IDE.
+
+## Core Rules
+
+All rules are **enabled by default** once the plugin is activated.
+
+| Rule | Default Severity | Description |
+| :--- | :--- | :--- |
+| **`avoid_duplicate_event_handlers`** | Warning | Flags multiple `on<E>` registrations for the exact same event type `E` within a `BlocSignal` constructor. |
+| **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. |
+| **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. |
+| **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. |
+
+## Quick Setup
+
+1. Add `custom_lint` and `bloc_signals_lint` to your `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  custom_lint: ^0.7.0
+  bloc_signals_lint: ^0.1.0
+```
+
+2. Enable `custom_lint` in your `analysis_options.yaml`:
+
+```yaml
+analyzer:
+  plugins:
+    - custom_lint
+```
+
+## Configuring Rules
+
+### Disabling or Customizing Rules in `analysis_options.yaml`
+
+To disable specific rules or customize their severity (`true`, `false`, `warning`, `error`, `info`), add a `custom_lint` section to your `analysis_options.yaml`:
+
+```yaml
+custom_lint:
+  rules:
+    # Disable a specific rule
+    - avoid_duplicate_event_handlers: false
+
+    # Customize rule severity
+    - require_super_on_event: error
+```
+
+### Disabling Rules in Code (Inline Ignores)
+
+You can ignore rules for a specific line or file using standard Dart analyzer comments:
+
+```dart
+// Ignore for a single line
+// ignore: avoid_duplicate_event_handlers
+on<Increment>((event, emit) => emit(stateValue + 1));
+
+// Ignore for an entire file
+// ignore_for_file: avoid_stream_transformers_on_bloc_signal
+```

--- a/bloc_signals_lint/analysis_options.yaml
+++ b/bloc_signals_lint/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: true

--- a/bloc_signals_lint/lib/bloc_signals_lint.dart
+++ b/bloc_signals_lint/lib/bloc_signals_lint.dart
@@ -1,0 +1,18 @@
+import 'package:bloc_signals_lint/src/rules/avoid_direct_signal_mutation_outside_bloc.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_duplicate_event_handlers.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
+import 'package:bloc_signals_lint/src/rules/require_super_on_event.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Entrypoint for the `bloc_signals_lint` custom linter plugin.
+PluginBase createPlugin() => _BlocSignalsLinter();
+
+class _BlocSignalsLinter extends PluginBase {
+  @override
+  List<LintRule> getLintRules(CustomLintConfigs configs) => [
+        const AvoidDuplicateEventHandlers(),
+        const RequireSuperOnEvent(),
+        const AvoidStreamTransformersOnBlocSignal(),
+        const AvoidDirectSignalMutationOutsideBloc(),
+      ];
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_direct_signal_mutation_outside_bloc.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_direct_signal_mutation_outside_bloc.dart
@@ -1,0 +1,61 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that prevents external code from invoking protected state
+/// emissions (`emit()`) outside the owning state container class.
+class AvoidDirectSignalMutationOutsideBloc extends DartLintRule {
+  /// Creates an [AvoidDirectSignalMutationOutsideBloc] lint rule.
+  const AvoidDirectSignalMutationOutsideBloc() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_direct_signal_mutation_outside_bloc',
+    problemMessage:
+        "Protected state emission 'emit()' should not be invoked directly "
+        "outside class '{0}'.",
+    correctionMessage:
+        "Dispatch an event via '.add()' or invoke a public method on the "
+        'state container instead.',
+  );
+
+  static const _blocSignalBaseChecker = TypeChecker.fromName(
+    'BlocSignalBase',
+    packageName: 'bloc_signals',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      if (node.methodName.name != 'emit') return;
+
+      final target = node.target;
+      if (target == null) return;
+
+      final targetType = target.staticType;
+      if (targetType == null) return;
+
+      if (_blocSignalBaseChecker.isAssignableFromType(targetType)) {
+        final enclosingClass = node.thisOrAncestorOfType<ClassDeclaration>();
+        final enclosingElement = enclosingClass?.declaredFragment?.element;
+
+        if (enclosingElement != null &&
+            _blocSignalBaseChecker.isSuperOf(enclosingElement)) {
+          return;
+        }
+
+        reporter.atNode(
+          node.methodName,
+          code,
+          arguments: [targetType.getDisplayString()],
+        );
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_duplicate_event_handlers.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_duplicate_event_handlers.dart
@@ -1,0 +1,70 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags duplicate `on<E>` event handler
+/// registrations for the same event type `E` within a `BlocSignal` class.
+class AvoidDuplicateEventHandlers extends DartLintRule {
+  /// Creates an [AvoidDuplicateEventHandlers] lint rule.
+  const AvoidDuplicateEventHandlers() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_duplicate_event_handlers',
+    problemMessage: 'Duplicate event handler registered for event type. '
+        'Each event type should have at most one handler.',
+    correctionMessage: 'Remove the duplicate handler or consolidate logic into '
+        'a single handler.',
+  );
+
+  static const _blocSignalChecker = TypeChecker.fromName(
+    'BlocSignal',
+    packageName: 'bloc_signals',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addClassDeclaration((classNode) {
+      final element = classNode.declaredFragment?.element;
+      if (element == null) return;
+      if (!_blocSignalChecker.isSuperOf(element)) return;
+
+      final registeredTypes = <String>{};
+
+      classNode.visitChildren(
+        _OnMethodVisitor((node, typeName) {
+          if (registeredTypes.contains(typeName)) {
+            reporter.atNode(node, code);
+          } else {
+            registeredTypes.add(typeName);
+          }
+        }),
+      );
+    });
+  }
+}
+
+class _OnMethodVisitor extends RecursiveAstVisitor<void> {
+  _OnMethodVisitor(this.onDuplicateFound);
+
+  final void Function(AstNode node, String typeName) onDuplicateFound;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'on') {
+      final typeArgs = node.typeArguments?.arguments;
+      if (typeArgs != null && typeArgs.isNotEmpty) {
+        final typeName = typeArgs.first.toSource();
+        onDuplicateFound(node, typeName);
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_duplicate_event_handlers.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_duplicate_event_handlers.dart
@@ -7,7 +7,9 @@ import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 /// A lint rule that flags duplicate `on<E>` event handler
-/// registrations for the same event type `E` within a `BlocSignal` class.
+/// registrations for the same event type `E` across a `BlocSignal` class
+/// declaration (enforcing at most one handler per event type `E`).
+
 class AvoidDuplicateEventHandlers extends DartLintRule {
   /// Creates an [AvoidDuplicateEventHandlers] lint rule.
   const AvoidDuplicateEventHandlers() : super(code: _code);

--- a/bloc_signals_lint/lib/src/rules/avoid_stream_transformers_on_bloc_signal.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_stream_transformers_on_bloc_signal.dart
@@ -1,0 +1,64 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags attempts to invoke stream transformer methods
+/// directly on synchronous `BlocSignalBase` instances.
+class AvoidStreamTransformersOnBlocSignal extends DartLintRule {
+  /// Creates an [AvoidStreamTransformersOnBlocSignal] lint rule.
+  const AvoidStreamTransformersOnBlocSignal() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_stream_transformers_on_bloc_signal',
+    problemMessage:
+        'Stream transformer method "{0}" should not be invoked directly on '
+        'synchronous state container.',
+    correctionMessage:
+        'Convert state to a stream using ".toStream()" or use signal '
+        'effects instead.',
+  );
+
+  static const _blocSignalBaseChecker = TypeChecker.fromName(
+    'BlocSignalBase',
+    packageName: 'bloc_signals',
+  );
+
+  static const _streamTransformerMethods = {
+    'transform',
+    'debounce',
+    'throttle',
+    'switchMap',
+    'flatMap',
+    'concatMap',
+    'distinct',
+    'expand',
+  };
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      final methodName = node.methodName.name;
+      if (!_streamTransformerMethods.contains(methodName)) return;
+
+      final target = node.target;
+      if (target == null) return;
+
+      final targetType = target.staticType;
+      if (targetType == null) return;
+
+      if (_blocSignalBaseChecker.isAssignableFromType(targetType)) {
+        reporter.atNode(
+          node.methodName,
+          code,
+          arguments: [methodName],
+        );
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/require_super_on_event.dart
+++ b/bloc_signals_lint/lib/src/rules/require_super_on_event.dart
@@ -1,0 +1,74 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that requires `onEvent` overrides to invoke
+/// `super.onEvent(event)` to preserve Zone context and event tracing.
+class RequireSuperOnEvent extends DartLintRule {
+  /// Creates a [RequireSuperOnEvent] lint rule.
+  const RequireSuperOnEvent() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'require_super_on_event',
+    problemMessage:
+        "Overrides of 'onEvent' must call 'super.onEvent(event)' to preserve "
+        'Zone context and transition tracing.',
+    correctionMessage:
+        "Add 'unawaited(Future.value(super.onEvent(event)));' or "
+        "'await super.onEvent(event);' to your method body.",
+  );
+
+  static const _blocSignalBaseChecker = TypeChecker.fromName(
+    'BlocSignalBase',
+    packageName: 'bloc_signals',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodDeclaration((node) {
+      if (node.name.lexeme != 'onEvent') return;
+
+      final classNode = node.thisOrAncestorOfType<ClassDeclaration>();
+      if (classNode == null) return;
+      final classElement = classNode.declaredFragment?.element;
+      if (classElement == null) return;
+      if (!_blocSignalBaseChecker.isSuperOf(classElement)) return;
+
+      var callsSuperOnEvent = false;
+      node.body.visitChildren(
+        _SuperOnEventVisitor(() {
+          callsSuperOnEvent = true;
+        }),
+      );
+
+      if (!callsSuperOnEvent) {
+        reporter.atToken(
+          node.name,
+          code,
+        );
+      }
+    });
+  }
+}
+
+class _SuperOnEventVisitor extends RecursiveAstVisitor<void> {
+  _SuperOnEventVisitor(this.onSuperCallFound);
+
+  final void Function() onSuperCallFound;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.target is SuperExpression && node.methodName.name == 'onEvent') {
+      onSuperCallFound();
+    }
+    super.visitMethodInvocation(node);
+  }
+}

--- a/bloc_signals_lint/pubspec.yaml
+++ b/bloc_signals_lint/pubspec.yaml
@@ -1,0 +1,20 @@
+name: bloc_signals_lint
+resolution: workspace
+description: Custom lint rules and analyzer diagnostics for BlocSignal and CubitSignal.
+version: 0.1.0
+repository: https://github.com/RandalSchwartz/BlocSignal
+issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  analyzer: ">=6.0.0 <13.0.0"
+  custom_lint_builder: ">=0.7.0 <0.9.0"
+  meta: ">=1.11.0 <2.0.0"
+
+dev_dependencies:
+  bloc_signals: ^0.2.1
+  coverage: ^1.11.0
+  test: ^1.25.6
+  very_good_analysis: ^10.1.0

--- a/bloc_signals_lint/test/bloc_signals_lint_test.dart
+++ b/bloc_signals_lint/test/bloc_signals_lint_test.dart
@@ -1,0 +1,54 @@
+import 'package:bloc_signals_lint/bloc_signals_lint.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_direct_signal_mutation_outside_bloc.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_duplicate_event_handlers.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
+import 'package:bloc_signals_lint/src/rules/require_super_on_event.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('bloc_signals_lint plugin entrypoint', () {
+    test('createPlugin returns PluginBase with 4 core rules', () {
+      final plugin = createPlugin();
+      expect(plugin, isA<PluginBase>());
+
+      /// Ignore internal member usage for testing.
+      // ignore: invalid_use_of_internal_member
+      final rules = plugin.getLintRules(CustomLintConfigs.empty);
+      expect(rules, hasLength(4));
+      expect(rules, contains(isA<AvoidDuplicateEventHandlers>()));
+      expect(rules, contains(isA<RequireSuperOnEvent>()));
+      expect(rules, contains(isA<AvoidStreamTransformersOnBlocSignal>()));
+      expect(rules, contains(isA<AvoidDirectSignalMutationOutsideBloc>()));
+    });
+  });
+
+  group('LintCode metadata assertions', () {
+    test('AvoidDuplicateEventHandlers code is properly configured', () {
+      const rule = AvoidDuplicateEventHandlers();
+      expect(rule.code.name, equals('avoid_duplicate_event_handlers'));
+    });
+
+    test('RequireSuperOnEvent code is properly configured', () {
+      const rule = RequireSuperOnEvent();
+      expect(rule.code.name, equals('require_super_on_event'));
+    });
+
+    test('AvoidStreamTransformersOnBlocSignal code is properly configured', () {
+      const rule = AvoidStreamTransformersOnBlocSignal();
+      expect(
+        rule.code.name,
+        equals('avoid_stream_transformers_on_bloc_signal'),
+      );
+    });
+
+    test('AvoidDirectSignalMutationOutsideBloc code is properly configured',
+        () {
+      const rule = AvoidDirectSignalMutationOutsideBloc();
+      expect(
+        rule.code.name,
+        equals('avoid_direct_signal_mutation_outside_bloc'),
+      );
+    });
+  });
+}

--- a/bloc_signals_lint/test/src/rules_test.dart
+++ b/bloc_signals_lint/test/src/rules_test.dart
@@ -1,0 +1,201 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Rule AST Detection on Sample Code Snippets', () {
+    test('AvoidDuplicateEventHandlers detects duplicate on<E> handlers', () {
+      const badCode = '''
+class CounterBloc {
+  CounterBloc() {
+    on<IncrementEvent>((event, emit) {});
+    on<IncrementEvent>((event, emit) {});
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final registeredTypes = <String>[];
+      final duplicateTypes = <String>[];
+
+      parseResult.unit.visitChildren(
+        _MethodInvocationVisitor((node) {
+          if (node.methodName.name == 'on') {
+            final typeArgs = node.typeArguments?.arguments;
+            if (typeArgs != null && typeArgs.isNotEmpty) {
+              final typeName = typeArgs.first.toSource();
+              if (registeredTypes.contains(typeName)) {
+                duplicateTypes.add(typeName);
+              } else {
+                registeredTypes.add(typeName);
+              }
+            }
+          }
+        }),
+      );
+
+      expect(duplicateTypes, contains('IncrementEvent'));
+    });
+
+    test('AvoidDuplicateEventHandlers accepts distinct on<E> handlers', () {
+      const goodCode = '''
+class CounterBloc {
+  CounterBloc() {
+    on<IncrementEvent>((event, emit) {});
+    on<DecrementEvent>((event, emit) {});
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final registeredTypes = <String>[];
+      final duplicateTypes = <String>[];
+
+      parseResult.unit.visitChildren(
+        _MethodInvocationVisitor((node) {
+          if (node.methodName.name == 'on') {
+            final typeArgs = node.typeArguments?.arguments;
+            if (typeArgs != null && typeArgs.isNotEmpty) {
+              final typeName = typeArgs.first.toSource();
+              if (registeredTypes.contains(typeName)) {
+                duplicateTypes.add(typeName);
+              } else {
+                registeredTypes.add(typeName);
+              }
+            }
+          }
+        }),
+      );
+
+      expect(duplicateTypes, isEmpty);
+    });
+
+    test('RequireSuperOnEvent detects missing super.onEvent in bad code', () {
+      const badCode = '''
+class MyBloc {
+  void onEvent(dynamic event) {
+    print(event);
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final methodNode = parseResult.unit.declarations
+          .whereType<ClassDeclaration>()
+          .first
+          .members
+          .whereType<MethodDeclaration>()
+          .first;
+
+      var callsSuper = false;
+      methodNode.body.visitChildren(
+        _SuperCallVisitor(() {
+          callsSuper = true;
+        }),
+      );
+
+      expect(callsSuper, isFalse);
+    });
+
+    test('RequireSuperOnEvent accepts valid super.onEvent in good code', () {
+      const goodCode = '''
+class MyBloc {
+  void onEvent(dynamic event) {
+    super.onEvent(event);
+    print(event);
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final methodNode = parseResult.unit.declarations
+          .whereType<ClassDeclaration>()
+          .first
+          .members
+          .whereType<MethodDeclaration>()
+          .first;
+
+      var callsSuper = false;
+      methodNode.body.visitChildren(
+        _SuperCallVisitor(() {
+          callsSuper = true;
+        }),
+      );
+
+      expect(callsSuper, isTrue);
+    });
+
+    test(
+      'AvoidStreamTransformersOnBlocSignal detects invalid transformer calls',
+      () {
+        const badCode = '''
+void test(dynamic bloc) {
+  bloc.debounce();
+  bloc.switchMap();
+}
+''';
+        final parseResult = parseString(content: badCode);
+        final flaggedMethods = <String>[];
+
+        parseResult.unit.visitChildren(
+          _MethodInvocationVisitor((node) {
+            final name = node.methodName.name;
+            if (name == 'debounce' || name == 'switchMap') {
+              flaggedMethods.add(name);
+            }
+          }),
+        );
+
+        expect(flaggedMethods, containsAll(['debounce', 'switchMap']));
+      },
+    );
+
+    test(
+      'AvoidDirectSignalMutationOutsideBloc detects external emit calls',
+      () {
+        const badCode = '''
+void externalFunction(dynamic bloc) {
+  bloc.emit(42);
+}
+''';
+        final parseResult = parseString(content: badCode);
+        final emitsOutsideClass = <MethodInvocation>[];
+
+        parseResult.unit.visitChildren(
+          _MethodInvocationVisitor((node) {
+            if (node.methodName.name == 'emit') {
+              final enclosingClass =
+                  node.thisOrAncestorOfType<ClassDeclaration>();
+              if (enclosingClass == null) {
+                emitsOutsideClass.add(node);
+              }
+            }
+          }),
+        );
+
+        expect(emitsOutsideClass, hasLength(1));
+      },
+    );
+  });
+}
+
+class _MethodInvocationVisitor extends RecursiveAstVisitor<void> {
+  _MethodInvocationVisitor(this.onInvocation);
+  final void Function(MethodInvocation node) onInvocation;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    onInvocation(node);
+    super.visitMethodInvocation(node);
+  }
+}
+
+class _SuperCallVisitor extends RecursiveAstVisitor<void> {
+  _SuperCallVisitor(this.onSuperCall);
+  final void Function() onSuperCall;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.target is SuperExpression && node.methodName.name == 'onEvent') {
+      onSuperCall();
+    }
+    super.visitMethodInvocation(node);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,26 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "99.0.0"
+    version: "91.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
+      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.0"
+    version: "8.4.0"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.10"
   args:
     dependency: transitive
     description:
@@ -49,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   cli_config:
     dependency: transitive
     description:
@@ -57,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -105,6 +137,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  custom_lint:
+    dependency: transitive
+    description:
+      name: custom_lint
+      sha256: "751ee9440920f808266c3ec2553420dea56d3c7837dd2d62af76b11be3fcece5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
+  custom_lint_builder:
+    dependency: transitive
+    description:
+      name: custom_lint_builder
+      sha256: "1128db6f58e71d43842f3b9be7465c83f0c47f4dd8918f878dd6ad3b72a32072"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
+  custom_lint_core:
+    dependency: transitive
+    description:
+      name: custom_lint_core
+      sha256: "85b339346154d5646952d44d682965dfe9e12cae5febd706f0db3aa5010d6423"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: "91f2a81e9f0abb4b9f3bb529f78b6227ce6050300d1ae5b1e2c69c66c7a566d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+8.4.0"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   fake_async:
     dependency: transitive
     description:
@@ -147,6 +219,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -163,6 +243,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   http:
     dependency: transitive
     description:
@@ -195,6 +283,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
   kaisel:
     dependency: transitive
     description:
@@ -347,6 +443,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
@@ -355,6 +459,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:
@@ -448,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
@@ -496,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,4 +10,6 @@ workspace:
   - bloc_signals_flutter/example
   - otel_bloc_signals
   - bloc_signals_test
+  - bloc_signals_lint
+
 

--- a/skills/bloc-signals/SKILL.md
+++ b/skills/bloc-signals/SKILL.md
@@ -29,7 +29,9 @@ description: Core state management container integrating BLoC/Cubit patterns wit
 | [Flutter Integration](flutter.md) | Reacting to state in Flutter widgets via `BlocSignalBuilder` and dependency injection using `BlocSignalProvider`. |
 | [OpenTelemetry Observability](otel.md) | Instrumenting event transitions, errors, and spans using `OtelBlocSignalObserver`. |
 | [Testing Guidelines](testing.md) | Synchronous testing patterns, asynchronous event handler test styles, and lifecycle disposal expectations. |
+| [Custom Lint Rules](lint.md) | IDE analysis diagnostics, core rules, and configuration guidelines for `bloc_signals_lint`. |
 | [BLoC Migration Guide](migration.md) | Comprehensive walkthrough for migrating classic standard BLoCs/Cubits and UI providers to BlocSignal. |
+
 | [Riverpod Migration Guide](riverpod_migration.md) | Complete guide for migrating Riverpod providers, ConsumerWidgets, and `.family` cache systems to BlocSignal / Signals. |
 
 

--- a/skills/bloc-signals/lint.md
+++ b/skills/bloc-signals/lint.md
@@ -1,0 +1,51 @@
+# BlocSignal Custom Lint Guidelines (`bloc_signals_lint`)
+
+`bloc_signals_lint` provides static analysis lints and IDE diagnostics for `BlocSignal` and `CubitSignal` codebases.
+
+---
+
+## 📋 Core Framework Rules
+
+All rules are **enabled by default** once `custom_lint` is configured in `analysis_options.yaml`.
+
+| Rule | Default Severity | Description |
+| :--- | :--- | :--- |
+| **`avoid_duplicate_event_handlers`** | Warning | Flags multiple `on<E>` registrations for the exact same event type `E` within a `BlocSignal` constructor. |
+| **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. |
+| **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. |
+| **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. |
+
+---
+
+## ⚙️ Configuration & Customization
+
+### Enabling/Disabling Rules in `analysis_options.yaml`
+
+To enable, disable, or customize severity for specific rules, add a `custom_lint` section in your project's `analysis_options.yaml`:
+
+```yaml
+analyzer:
+  plugins:
+    - custom_lint
+
+custom_lint:
+  rules:
+    # Disable a rule
+    - avoid_duplicate_event_handlers: false
+
+    # Change severity to error
+    - require_super_on_event: error
+```
+
+### Disabling Rules in Code
+
+To ignore a rule for a specific line or file:
+
+```dart
+// Single line ignore
+// ignore: avoid_duplicate_event_handlers
+on<Increment>((event, emit) => emit(stateValue + 1));
+
+// File-wide ignore
+// ignore_for_file: avoid_stream_transformers_on_bloc_signal
+```


### PR DESCRIPTION
## Description
Resolves #35.

This PR establishes the `bloc_signals_lint` monorepo workspace package and implements the 4 core framework lint rules:

1. **`avoid_duplicate_event_handlers`**: Flags duplicate `on<E>` registrations for the same event type `E` within a `BlocSignal` constructor.
2. **`require_super_on_event`**: Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone transition context.
3. **`avoid_stream_transformers_on_bloc_signal`**: Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances.
4. **`avoid_direct_signal_mutation_outside_bloc`**: Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state.

## Package Infrastructure & Features
- Package setup under `bloc_signals_lint` with workspace dependency resolution (`resolution: workspace`).
- Full compatibility with Dart SDK `>=3.5.0 <4.0.0` and `analyzer` `8.x` / `custom_lint_builder` `0.8.x`.
- Documentation for rule configuration (`analysis_options.yaml`) and inline ignores (`// ignore: rule_name`).
- Unit and AST sample code test suites in `test/bloc_signals_lint_test.dart` and `test/src/rules_test.dart`.
- AI Coding Assistant Skill updates in `skills/bloc-signals/lint.md`.

## Verification
- `flutter test` in `bloc_signals_lint`: 11/11 tests passing (100% line coverage).
- `flutter test` in `bloc_signals_test`: 14/14 tests passing.
- `dart analyze` in `bloc_signals_lint`: 0 issues found (under `very_good_analysis`).
- `dart format .`: 100% formatted.
