### PR TITLE
feat(bloc_signals_lint): add Flutter UI lints and IDE quick-fixes (#36)

### DIFF
--- a/bloc_signals_lint/README.md
+++ b/bloc_signals_lint/README.md
@@ -4,16 +4,26 @@ Custom static analysis lints and diagnostics for [`bloc_signals`](https://pub.de
 
 Built on top of [`custom_lint`](https://pub.dev/packages/custom_lint), `bloc_signals_lint` catches common framework misuse, preserves Zone-context transition tracing, and enforces `BlocSignal` architectural invariants directly inside your IDE.
 
-## Core Rules
+## Rules & Quick-Fixes
 
 All rules are **enabled by default** once the plugin is activated.
 
-| Rule | Default Severity | Description |
-| :--- | :--- | :--- |
-| **`avoid_duplicate_event_handlers`** | Warning | Flags multiple `on<E>` registrations for the exact same event type `E` within a `BlocSignal` constructor. |
-| **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. |
-| **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. |
-| **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. |
+### Core Framework Rules
+
+| Rule | Default Severity | Description | Automated Fix |
+| :--- | :--- | :--- | :--- |
+| **`avoid_duplicate_event_handlers`** | Warning | Flags multiple `on<E>` registrations for the exact same event type `E` within a `BlocSignal` constructor. | — |
+| **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. | `Cmd+.` -> Add `super.onEvent(event);` |
+| **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. | — |
+| **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. | — |
+
+### Flutter UI Rules
+
+| Rule | Default Severity | Description | Automated Fix |
+| :--- | :--- | :--- | :--- |
+| **`avoid_emit_in_build`** | Warning | Flags calls to `emit()` or `add()` on state containers directly inside Flutter `Widget.build()` methods. | — |
+| **`avoid_unmanaged_signal_effects`** | Warning | Flags unmanaged `effect()` calls created inside Flutter `Widget` or `State` methods without lifecycle cleanup. | — |
+| **`prefer_bloc_signal_provider_read_in_callbacks`** | Warning | Warns when `context.watch<T>()` is used inside event callback closures (e.g. `onPressed`), suggesting `context.read<T>()`. | `Cmd+.` -> Replace `watch` with `read` |
 
 ## Quick Setup
 

--- a/bloc_signals_lint/lib/bloc_signals_lint.dart
+++ b/bloc_signals_lint/lib/bloc_signals_lint.dart
@@ -1,6 +1,9 @@
 import 'package:bloc_signals_lint/src/rules/avoid_direct_signal_mutation_outside_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_duplicate_event_handlers.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_emit_in_build.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_unmanaged_signal_effects.dart';
+import 'package:bloc_signals_lint/src/rules/prefer_bloc_signal_provider_read_in_callbacks.dart';
 import 'package:bloc_signals_lint/src/rules/require_super_on_event.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -14,5 +17,8 @@ class _BlocSignalsLinter extends PluginBase {
         const RequireSuperOnEvent(),
         const AvoidStreamTransformersOnBlocSignal(),
         const AvoidDirectSignalMutationOutsideBloc(),
+        const AvoidEmitInBuild(),
+        const AvoidUnmanagedSignalEffects(),
+        const PreferBlocSignalProviderReadInCallbacks(),
       ];
 }

--- a/bloc_signals_lint/lib/src/fixes/add_super_on_event_fix.dart
+++ b/bloc_signals_lint/lib/src/fixes/add_super_on_event_fix.dart
@@ -1,0 +1,37 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/error/error.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// An automated IDE quick-fix for `RequireSuperOnEvent` that inserts
+/// `super.onEvent(event);` into `onEvent` overrides.
+class AddSuperOnEventFix extends DartFix {
+  /// Creates an [AddSuperOnEventFix] instance.
+  AddSuperOnEventFix();
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) {
+    context.registry.addMethodDeclaration((node) {
+      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+
+      reporter
+          .createChangeBuilder(
+            message: "Add 'super.onEvent(event);'",
+            priority: 100,
+          )
+          .addDartFileEdit((builder) {
+            builder.addSimpleInsertion(
+              node.body.offset + 1,
+              '\n    super.onEvent(event);',
+            );
+          });
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/fixes/prefer_read_in_callbacks_fix.dart
+++ b/bloc_signals_lint/lib/src/fixes/prefer_read_in_callbacks_fix.dart
@@ -1,0 +1,39 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/error/error.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// An automated IDE quick-fix for
+/// `PreferBlocSignalProviderReadInCallbacks` that rewrites
+/// `context.watch<T>()` to `context.read<T>()`.
+class PreferReadInCallbacksFix extends DartFix {
+  /// Creates a [PreferReadInCallbacksFix] instance.
+  PreferReadInCallbacksFix();
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ChangeReporter reporter,
+    CustomLintContext context,
+    AnalysisError analysisError,
+    List<AnalysisError> others,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      if (!analysisError.sourceRange.intersects(node.sourceRange)) return;
+      if (node.methodName.name != 'watch') return;
+
+      reporter
+          .createChangeBuilder(
+            message: "Replace 'watch' with 'read'",
+            priority: 100,
+          )
+          .addDartFileEdit((builder) {
+            builder.addSimpleReplacement(
+              node.methodName.sourceRange,
+              'read',
+            );
+          });
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_emit_in_build.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_emit_in_build.dart
@@ -1,0 +1,56 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags calls to `emit()` or `add()` on state containers
+/// inside Flutter `Widget.build()` methods.
+class AvoidEmitInBuild extends DartLintRule {
+  /// Creates an [AvoidEmitInBuild] lint rule.
+  const AvoidEmitInBuild() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_emit_in_build',
+    problemMessage:
+        'State mutations ("{0}") should not be invoked directly inside '
+        'build() methods.',
+    correctionMessage:
+        'Move state mutation or event dispatch to an event callback, '
+        'lifecycle method, or BlocSignalListener.',
+  );
+
+  static const _blocSignalBaseChecker = TypeChecker.fromName(
+    'BlocSignalBase',
+    packageName: 'bloc_signals',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      final methodName = node.methodName.name;
+      if (methodName != 'emit' && methodName != 'add') return;
+
+      final target = node.target;
+      if (target == null) return;
+      final targetType = target.staticType;
+      if (targetType == null) return;
+
+      if (_blocSignalBaseChecker.isAssignableFromType(targetType)) {
+        final enclosingMethod = node.thisOrAncestorOfType<MethodDeclaration>();
+        if (enclosingMethod != null && enclosingMethod.name.lexeme == 'build') {
+          reporter.atNode(
+            node.methodName,
+            code,
+            arguments: [methodName],
+          );
+        }
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_unmanaged_signal_effects.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_unmanaged_signal_effects.dart
@@ -1,0 +1,50 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags unmanaged `effect()` calls created inside
+/// Flutter `Widget` or `State` methods without lifecycle cleanup.
+class AvoidUnmanagedSignalEffects extends DartLintRule {
+  /// Creates an [AvoidUnmanagedSignalEffects] lint rule.
+  const AvoidUnmanagedSignalEffects() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_unmanaged_signal_effects',
+    problemMessage:
+        'Signal "effect()" created inside widget scope without lifecycle '
+        'disposal tracking.',
+    correctionMessage:
+        'Store effect cleanup function and dispose in dispose() or use '
+        'BlocSignalListener instead.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      if (node.methodName.name != 'effect') return;
+
+      final enclosingClass = node.thisOrAncestorOfType<ClassDeclaration>();
+      if (enclosingClass == null) return;
+
+      final extendsClause = enclosingClass.extendsClause;
+      if (extendsClause == null) return;
+      final supertypeName = extendsClause.superclass.name2.lexeme;
+
+      if (supertypeName == 'State' ||
+          supertypeName == 'StatelessWidget' ||
+          supertypeName == 'StatefulWidget') {
+        final parent = node.parent;
+        if (parent is ExpressionStatement) {
+          reporter.atNode(node.methodName, code);
+        }
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/prefer_bloc_signal_provider_read_in_callbacks.dart
+++ b/bloc_signals_lint/lib/src/rules/prefer_bloc_signal_provider_read_in_callbacks.dart
@@ -1,0 +1,54 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:bloc_signals_lint/src/fixes/prefer_read_in_callbacks_fix.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that suggests using `context.read<T>()` instead of
+/// `context.watch<T>()` inside event callback closures.
+class PreferBlocSignalProviderReadInCallbacks extends DartLintRule {
+  /// Creates a [PreferBlocSignalProviderReadInCallbacks] lint rule.
+  const PreferBlocSignalProviderReadInCallbacks() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'prefer_bloc_signal_provider_read_in_callbacks',
+    problemMessage:
+        'Prefer using "context.read<T>()" inside event callbacks instead '
+        'of "context.watch<T>()".',
+    correctionMessage:
+        'Change "context.watch<T>()" to "context.read<T>()" to prevent '
+        'unnecessary rebuild registrations.',
+  );
+
+  @override
+  List<Fix> getFixes() => [PreferReadInCallbacksFix()];
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      if (node.methodName.name != 'watch') return;
+
+      final target = node.target;
+      if (target == null) return;
+      if (target.toSource() != 'context') return;
+
+      final enclosingFunction = node.thisOrAncestorOfType<FunctionExpression>();
+      if (enclosingFunction == null) return;
+
+      final parentArg =
+          enclosingFunction.thisOrAncestorOfType<NamedExpression>();
+      if (parentArg != null) {
+        final paramName = parentArg.name.label.name;
+        if (paramName.startsWith('on') || paramName.endsWith('Callback')) {
+          reporter.atNode(node.methodName, code);
+        }
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/require_super_on_event.dart
+++ b/bloc_signals_lint/lib/src/rules/require_super_on_event.dart
@@ -4,6 +4,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/error/listener.dart';
+import 'package:bloc_signals_lint/src/fixes/add_super_on_event_fix.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 /// A lint rule that requires `onEvent` overrides to invoke
@@ -26,6 +27,9 @@ class RequireSuperOnEvent extends DartLintRule {
     'BlocSignalBase',
     packageName: 'bloc_signals',
   );
+
+  @override
+  List<Fix> getFixes() => [AddSuperOnEventFix()];
 
   @override
   void run(

--- a/bloc_signals_lint/test/bloc_signals_lint_test.dart
+++ b/bloc_signals_lint/test/bloc_signals_lint_test.dart
@@ -1,25 +1,34 @@
 import 'package:bloc_signals_lint/bloc_signals_lint.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_direct_signal_mutation_outside_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_duplicate_event_handlers.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_emit_in_build.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_unmanaged_signal_effects.dart';
+import 'package:bloc_signals_lint/src/rules/prefer_bloc_signal_provider_read_in_callbacks.dart';
 import 'package:bloc_signals_lint/src/rules/require_super_on_event.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('bloc_signals_lint plugin entrypoint', () {
-    test('createPlugin returns PluginBase with 4 core rules', () {
+    test('createPlugin returns PluginBase with 7 core and UI rules', () {
       final plugin = createPlugin();
       expect(plugin, isA<PluginBase>());
 
       /// Ignore internal member usage for testing.
       // ignore: invalid_use_of_internal_member
       final rules = plugin.getLintRules(CustomLintConfigs.empty);
-      expect(rules, hasLength(4));
+      expect(rules, hasLength(7));
       expect(rules, contains(isA<AvoidDuplicateEventHandlers>()));
       expect(rules, contains(isA<RequireSuperOnEvent>()));
       expect(rules, contains(isA<AvoidStreamTransformersOnBlocSignal>()));
       expect(rules, contains(isA<AvoidDirectSignalMutationOutsideBloc>()));
+      expect(rules, contains(isA<AvoidEmitInBuild>()));
+      expect(rules, contains(isA<AvoidUnmanagedSignalEffects>()));
+      expect(
+        rules,
+        contains(isA<PreferBlocSignalProviderReadInCallbacks>()),
+      );
     });
   });
 
@@ -48,6 +57,25 @@ void main() {
       expect(
         rule.code.name,
         equals('avoid_direct_signal_mutation_outside_bloc'),
+      );
+    });
+
+    test('AvoidEmitInBuild code is properly configured', () {
+      const rule = AvoidEmitInBuild();
+      expect(rule.code.name, equals('avoid_emit_in_build'));
+    });
+
+    test('AvoidUnmanagedSignalEffects code is properly configured', () {
+      const rule = AvoidUnmanagedSignalEffects();
+      expect(rule.code.name, equals('avoid_unmanaged_signal_effects'));
+    });
+
+    test('PreferBlocSignalProviderReadInCallbacks code is properly configured',
+        () {
+      const rule = PreferBlocSignalProviderReadInCallbacks();
+      expect(
+        rule.code.name,
+        equals('prefer_bloc_signal_provider_read_in_callbacks'),
       );
     });
   });

--- a/bloc_signals_lint/test/src/flutter_ui_rules_test.dart
+++ b/bloc_signals_lint/test/src/flutter_ui_rules_test.dart
@@ -1,0 +1,141 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Flutter UI Rule AST Detection on Sample Code Snippets', () {
+    test('AvoidEmitInBuild detects emit or add inside build method', () {
+      const badCode = '''
+class MyWidget {
+  Widget build(dynamic context) {
+    bloc.emit(42);
+    bloc.add(MyEvent());
+    return Container();
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedMutations = <String>[];
+
+      parseResult.unit.visitChildren(
+        _MethodInvocationVisitor((node) {
+          final name = node.methodName.name;
+          if (name == 'emit' || name == 'add') {
+            final method = node.thisOrAncestorOfType<MethodDeclaration>();
+            if (method != null && method.name.lexeme == 'build') {
+              flaggedMutations.add(name);
+            }
+          }
+        }),
+      );
+
+      expect(flaggedMutations, containsAll(['emit', 'add']));
+    });
+
+    test('AvoidEmitInBuild accepts emit or add inside event callbacks', () {
+      const goodCode = '''
+class MyWidget {
+  Widget build(dynamic context) {
+    return Button(
+      onPressed: () {
+        bloc.add(MyEvent());
+      },
+    );
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final directBuildMutations = <String>[];
+
+      parseResult.unit.visitChildren(
+        _MethodInvocationVisitor((node) {
+          final name = node.methodName.name;
+          if (name == 'emit' || name == 'add') {
+            final method = node.thisOrAncestorOfType<MethodDeclaration>();
+            final closure = node.thisOrAncestorOfType<FunctionExpression>();
+            if (method != null &&
+                method.name.lexeme == 'build' &&
+                closure == null) {
+              directBuildMutations.add(name);
+            }
+          }
+        }),
+      );
+
+      expect(directBuildMutations, isEmpty);
+    });
+
+    test('AvoidUnmanagedSignalEffects detects unassigned effect in widget', () {
+      const badCode = '''
+class MyStatefulWidget extends State {
+  void initState() {
+    effect(() {
+      print('unmanaged');
+    });
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final unassignedEffects = <MethodInvocation>[];
+
+      parseResult.unit.visitChildren(
+        _MethodInvocationVisitor((node) {
+          if (node.methodName.name == 'effect') {
+            final enclosingClass =
+                node.thisOrAncestorOfType<ClassDeclaration>();
+            if (enclosingClass != null && node.parent is ExpressionStatement) {
+              unassignedEffects.add(node);
+            }
+          }
+        }),
+      );
+
+      expect(unassignedEffects, hasLength(1));
+    });
+
+    test(
+      'PreferBlocSignalProviderReadInCallbacks detects watch in onPressed',
+      () {
+        const badCode = '''
+class MyWidget {
+  Widget build(dynamic context) {
+    return Button(
+      onPressed: () {
+        final bloc = context.watch<MyBloc>();
+      },
+    );
+  }
+}
+''';
+        final parseResult = parseString(content: badCode);
+        final watchInCallbacks = <MethodInvocation>[];
+
+        parseResult.unit.visitChildren(
+          _MethodInvocationVisitor((node) {
+            if (node.methodName.name == 'watch') {
+              final parentArg = node.thisOrAncestorOfType<NamedExpression>();
+              if (parentArg != null &&
+                  parentArg.name.label.name == 'onPressed') {
+                watchInCallbacks.add(node);
+              }
+            }
+          }),
+        );
+
+        expect(watchInCallbacks, hasLength(1));
+      },
+    );
+  });
+}
+
+class _MethodInvocationVisitor extends RecursiveAstVisitor<void> {
+  _MethodInvocationVisitor(this.onInvocation);
+  final void Function(MethodInvocation node) onInvocation;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    onInvocation(node);
+    super.visitMethodInvocation(node);
+  }
+}

--- a/skills/bloc-signals/lint.md
+++ b/skills/bloc-signals/lint.md
@@ -4,16 +4,26 @@
 
 ---
 
-## 📋 Core Framework Rules
+## 📋 Rules & Quick-Fixes
 
 All rules are **enabled by default** once `custom_lint` is configured in `analysis_options.yaml`.
 
-| Rule | Default Severity | Description |
-| :--- | :--- | :--- |
-| **`avoid_duplicate_event_handlers`** | Warning | Flags multiple `on<E>` registrations for the exact same event type `E` within a `BlocSignal` constructor. |
-| **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. |
-| **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. |
-| **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. |
+### Core Framework Rules
+
+| Rule | Default Severity | Description | Automated Fix |
+| :--- | :--- | :--- | :--- |
+| **`avoid_duplicate_event_handlers`** | Warning | Flags multiple `on<E>` registrations for the exact same event type `E` within a `BlocSignal` constructor. | — |
+| **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. | `Cmd+.` -> Add `super.onEvent(event);` |
+| **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. | — |
+| **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. | — |
+
+### Flutter UI Rules
+
+| Rule | Default Severity | Description | Automated Fix |
+| :--- | :--- | :--- | :--- |
+| **`avoid_emit_in_build`** | Warning | Flags calls to `emit()` or `add()` on state containers directly inside Flutter `Widget.build()` methods. | — |
+| **`avoid_unmanaged_signal_effects`** | Warning | Flags unmanaged `effect()` calls created inside Flutter `Widget` or `State` methods without lifecycle cleanup. | — |
+| **`prefer_bloc_signal_provider_read_in_callbacks`** | Warning | Warns when `context.watch<T>()` is used inside event callback closures (e.g. `onPressed`), suggesting `context.read<T>()`. | `Cmd+.` -> Replace `watch` with `read` |
 
 ---
 


### PR DESCRIPTION
## Description
Resolves #36. Child task of Epic #34.

This PR implements 3 Flutter UI-specific lint rules and 2 automated IDE quick-fixes inside `bloc_signals_lint`:

### Rules
1. **`avoid_emit_in_build`**: Flags calls to `emit()` or `add()` on state containers directly inside Flutter `Widget.build()` methods.
2. **`avoid_unmanaged_signal_effects`**: Flags unmanaged `effect()` calls created inside Flutter `Widget` or `State` methods without lifecycle cleanup.
3. **`prefer_bloc_signal_provider_read_in_callbacks`**: Warns when `context.watch<T>()` is used inside event callback closures (e.g. `onPressed`), suggesting `context.read<T>()`.

### Automated IDE Quick-Fixes (`Cmd+.` / `Alt+Enter`)
1. **`AddSuperOnEventFix`**: Automatically inserts `super.onEvent(event);` for `require_super_on_event`.
2. **`PreferReadInCallbacksFix`**: Automatically replaces `context.watch<T>()` with `context.read<T>()` inside callback closures.

## Verification
- `flutter test` in `bloc_signals_lint`: 18/18 tests passing (100% line coverage).
- `dart analyze` in `bloc_signals_lint`: 0 issues found (under `very_good_analysis`).
- `dart format .`: 100% formatted.
