### PR TITLE
feat(bloc_signals): add stream interop extensions and migration bridge (#41)

### DIFF
--- a/bloc_signals/CHANGELOG.md
+++ b/bloc_signals/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.2
+
+- Add bidirectional stream interop extensions and progressive migration bridge:
+  - Add `BlocSignalStreamExtension` on `BlocSignalBase` (`.toStream()`, `.stream`).
+  - Add `StreamBlocSignal` container adapting standard Dart `Stream<T>` / BLoCs to `BlocSignalBase<T>`.
+  - Add `StreamBlocSignalExtension` on `Stream<T>` (`.toBlocSignal()`).
+  - Auto-close `StreamBlocSignal` when underlying stream completes.
+
 ## 0.2.1
 
 - Fix package classification on pub.dev to include "Dart" SDK support by migrating from `signals` dependency to pure Dart `signals_core`.
@@ -32,7 +40,6 @@
 ## 0.1.9
 
 - Widen Dart SDK constraint to include pre-release versions of Dart `3.10.0`.
-
 
 ## 0.1.8
 

--- a/bloc_signals/lib/bloc_signals.dart
+++ b/bloc_signals/lib/bloc_signals.dart
@@ -8,3 +8,4 @@ library;
 import 'package:bloc_signals/src/bloc_signals_base.dart';
 
 export 'src/bloc_signals_base.dart';
+export 'src/stream_adapter.dart';

--- a/bloc_signals/lib/src/stream_adapter.dart
+++ b/bloc_signals/lib/src/stream_adapter.dart
@@ -28,6 +28,11 @@ class StreamBlocSignal<StateType> extends CubitSignal<StateType> {
       onError: (Object error, StackTrace stackTrace) {
         onError(error, stackTrace);
       },
+      onDone: () {
+        if (!isClosed) {
+          unawaited(close());
+        }
+      },
     );
   }
 

--- a/bloc_signals/lib/src/stream_adapter.dart
+++ b/bloc_signals/lib/src/stream_adapter.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:bloc_signals/src/bloc_signals_base.dart';
+import 'package:signals_core/signals_core.dart';
+
+/// Extension methods on [BlocSignalBase] to convert reactive state emissions
+/// into a standard Dart multi-subscription [Stream].
+extension BlocSignalStreamExtension<StateType> on BlocSignalBase<StateType> {
+  /// Converts the reactive state signal into a multi-subscription Dart
+  /// [Stream].
+  Stream<StateType> toStream() => state.toStream();
+
+  /// Exposes the reactive state signal as a multi-subscription Dart [Stream].
+  Stream<StateType> get stream => state.toStream();
+}
+
+/// A reactive state container wrapper that adapts an underlying Dart [Stream]
+/// (e.g. legacy BLoC, Cubit, or RxDart stream) into a [BlocSignalBase].
+class StreamBlocSignal<StateType> extends CubitSignal<StateType> {
+  /// Creates a [StreamBlocSignal] wrapping an underlying [stream] with
+  /// [initialState].
+  StreamBlocSignal(
+    Stream<StateType> stream, {
+    required super.initialState,
+  }) {
+    _subscription = stream.listen(
+      emit,
+      onError: (Object error, StackTrace stackTrace) {
+        onError(error, stackTrace);
+      },
+    );
+  }
+
+  late final StreamSubscription<StateType> _subscription;
+
+  @override
+  Future<void> close() async {
+    await _subscription.cancel();
+    await super.close();
+  }
+}
+
+/// Extension methods on [Stream] to create [BlocSignalBase] containers.
+extension StreamBlocSignalExtension<StateType> on Stream<StateType> {
+  /// Adapts this Dart [Stream] into a [BlocSignalBase] state container
+  /// with [initialState].
+  BlocSignalBase<StateType> toBlocSignal({required StateType initialState}) {
+    return StreamBlocSignal<StateType>(this, initialState: initialState);
+  }
+}

--- a/bloc_signals/pubspec.yaml
+++ b/bloc_signals/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals
 resolution: workspace
 description: A synchronous state management container integrating BLoC patterns with Rody Davis's signals package.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 

--- a/bloc_signals/test/stream_adapter_test.dart
+++ b/bloc_signals/test/stream_adapter_test.dart
@@ -1,0 +1,125 @@
+import 'dart:async';
+
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:test/test.dart';
+
+class _TestCubit extends CubitSignal<int> {
+  _TestCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+}
+
+class _TestObserver extends BlocSignalObserver {
+  Object? lastError;
+  StackTrace? lastStackTrace;
+
+  @override
+  void onError(
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    lastError = error;
+    lastStackTrace = stackTrace;
+  }
+}
+
+void main() {
+  group('BlocSignalStreamExtension (.toStream() & .stream)', () {
+    test('toStream() emits initial state followed by state updates', () async {
+      final cubit = _TestCubit();
+      final states = <int>[];
+
+      final subscription = cubit.toStream().listen(states.add);
+
+      cubit
+        ..increment()
+        ..increment();
+
+      await Future<void>.delayed(Duration.zero);
+      expect(states, equals([0, 1, 2]));
+
+      await subscription.cancel();
+      await cubit.close();
+    });
+
+    test('stream getter exposes state updates as a Stream', () async {
+      final cubit = _TestCubit();
+      final states = <int>[];
+
+      final subscription = cubit.stream.listen(states.add);
+
+      cubit.increment();
+
+      await Future<void>.delayed(Duration.zero);
+      expect(states, equals([0, 1]));
+
+      await subscription.cancel();
+      await cubit.close();
+    });
+  });
+
+  group('StreamBlocSignal & StreamBlocSignalExtension (.toBlocSignal())', () {
+    test('StreamBlocSignal listens to stream and updates stateValue', () async {
+      final controller = StreamController<int>.broadcast();
+      final blocSignal = controller.stream.toBlocSignal(initialState: 0);
+
+      expect(blocSignal.stateValue, equals(0));
+
+      controller.add(10);
+      await Future<void>.delayed(Duration.zero);
+      expect(blocSignal.stateValue, equals(10));
+
+      controller.add(20);
+      await Future<void>.delayed(Duration.zero);
+      expect(blocSignal.stateValue, equals(20));
+
+      await blocSignal.close();
+      await controller.close();
+    });
+
+    test('StreamBlocSignal forwards stream errors to onError observer',
+        () async {
+      final previousObserver = BlocSignalObserver.observer;
+      final observer = _TestObserver();
+      BlocSignalObserver.observer = observer;
+
+      try {
+        final controller = StreamController<String>.broadcast();
+        final blocSignal =
+            controller.stream.toBlocSignal(initialState: 'initial');
+
+        final exception = Exception('Stream error');
+        controller.addError(exception, StackTrace.current);
+
+        await Future<void>.delayed(Duration.zero);
+        expect(observer.lastError, equals(exception));
+
+        await blocSignal.close();
+        await controller.close();
+      } finally {
+        BlocSignalObserver.observer = previousObserver;
+      }
+    });
+
+    test('StreamBlocSignal cancels stream subscription on close()', () async {
+      var isCancelled = false;
+      final controller = StreamController<int>(
+        onCancel: () {
+          isCancelled = true;
+        },
+      );
+
+      final blocSignal = StreamBlocSignal(
+        controller.stream,
+        initialState: 0,
+      );
+
+      expect(isCancelled, isFalse);
+      await blocSignal.close();
+      expect(isCancelled, isTrue);
+
+      await controller.close();
+    });
+  });
+}

--- a/bloc_signals/test/stream_adapter_test.dart
+++ b/bloc_signals/test/stream_adapter_test.dart
@@ -102,6 +102,22 @@ void main() {
       }
     });
 
+    test('StreamBlocSignal auto-closes when underlying stream completes',
+        () async {
+      final controller = StreamController<int>();
+      final blocSignal = StreamBlocSignal(
+        controller.stream,
+        initialState: 0,
+      );
+
+      expect(blocSignal.isClosed, isFalse);
+
+      await controller.close();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(blocSignal.isClosed, isTrue);
+    });
+
     test('StreamBlocSignal cancels stream subscription on close()', () async {
       var isCancelled = false;
       final controller = StreamController<int>(

--- a/skills/bloc-signals/SKILL.md
+++ b/skills/bloc-signals/SKILL.md
@@ -31,8 +31,9 @@ description: Core state management container integrating BLoC/Cubit patterns wit
 | [Testing Guidelines](testing.md) | Synchronous testing patterns, asynchronous event handler test styles, and lifecycle disposal expectations. |
 | [Custom Lint Rules](lint.md) | IDE analysis diagnostics, core rules, and configuration guidelines for `bloc_signals_lint`. |
 | [BLoC Migration Guide](migration.md) | Comprehensive walkthrough for migrating classic standard BLoCs/Cubits and UI providers to BlocSignal. |
-
+| [Stream Migration Bridge](migration_bridge.md) | Bidirectional stream interop, `toStream()` extensions, and `toBlocSignal()` stream wrappers for progressive migration. |
 | [Riverpod Migration Guide](riverpod_migration.md) | Complete guide for migrating Riverpod providers, ConsumerWidgets, and `.family` cache systems to BlocSignal / Signals. |
+
 
 
 

--- a/skills/bloc-signals/migration.md
+++ b/skills/bloc-signals/migration.md
@@ -2,7 +2,45 @@
 
 This guide explains how to migrate your Flutter and Dart applications from classic BLoC (`package:bloc` and `package:flutter_bloc`) to `BlocSignal` (`package:bloc_signals` and `package:bloc_signals_flutter`).
 
+## 🚀 Progressive Migration Strategy (Zero All-at-Once Rewrite)
+
+You don't need to rewrite your entire application at once! `bloc_signals` provides built-in stream interop extensions so you can adopt `BlocSignal` incrementally:
+
+### 1. Wrapping Legacy BLoCs into `BlocSignal` Containers
+Wrap any existing classic BLoC or Cubit stream into a `BlocSignal` container to use `BlocSignalBuilder` or reactive signals immediately without changing your existing BLoC code:
+
+```dart
+final legacyBloc = LegacyCounterBloc();
+
+// Convert legacy BLoC stream into a BlocSignal container
+final blocSignal = legacyBloc.stream.toBlocSignal(
+  initialState: legacyBloc.state,
+);
+
+// Consume in reactive BlocSignalBuilder or signals UI!
+BlocSignalBuilder<StreamBlocSignal<int>, int>(
+  bloc: blocSignal as StreamBlocSignal<int>,
+  builder: (context, count) => Text('Count: $count'),
+);
+```
+
+### 2. Consuming `BlocSignal` in Legacy Stream / `BlocBuilder` Widgets
+If you convert a state container to `BlocSignal` but want to keep existing UI widgets unchanged during early migration, use `.toStream()` or `.stream`:
+
+```dart
+final myBlocSignal = CounterBloc();
+
+// Consume in legacy StreamBuilder or Stream widgets
+StreamBuilder<int>(
+  stream: myBlocSignal.toStream(), // or myBlocSignal.stream
+  builder: (context, snapshot) => Text('${snapshot.data}'),
+);
+```
+
+---
+
 ## Core Paradigm Shift: Streams vs. Signals
+
 
 `BlocSignal` offers a synchronous, glitch-free alternative to classic BLoC while maintaining its core architectural predictability (events in, states out).
 

--- a/skills/bloc-signals/migration_bridge.md
+++ b/skills/bloc-signals/migration_bridge.md
@@ -1,0 +1,72 @@
+# Progressive Migration Bridge Guide (`Stream` & `BlocSignal` Interop)
+
+`bloc_signals` provides seamless, bidirectional stream interop extensions so you can adopt `BlocSignal` incrementally in existing Flutter codebases without rewriting legacy BLoC business logic or UI widgets all at once.
+
+---
+
+## 🔄 Bidirectional Interop Summary
+
+| Conversion | Extension Method | Use Case |
+| :--- | :--- | :--- |
+| **`BlocSignal` -> `Stream`** | `blocSignal.toStream()` / `blocSignal.stream` | Consume state updates from a `BlocSignal` using standard `StreamBuilder`, RxDart, or legacy `BlocBuilder`. |
+| **`Stream` / BLoC -> `BlocSignal`** | `legacyStream.toBlocSignal(initialState: ...)` | Wrap any standard Dart `Stream` or legacy `Bloc`/`Cubit` stream in a `BlocSignal` container for consumption in `BlocSignalBuilder` or reactive signals. |
+
+---
+
+## 1. Consuming `BlocSignal` in Legacy Stream / `BlocBuilder` Widgets
+
+If you migrate a backend container to `BlocSignal` but want to keep existing UI widgets unchanged during early migration:
+
+```dart
+import 'package:bloc_signals/bloc_signals.dart';
+
+final myBlocSignal = CounterBloc();
+
+// 1. Standard Dart StreamBuilder
+StreamBuilder<int>(
+  stream: myBlocSignal.toStream(), // or myBlocSignal.stream
+  builder: (context, snapshot) => Text('${snapshot.data}'),
+);
+
+// 2. RxDart / Stream transformations
+myBlocSignal.toStream()
+    .debounceTime(const Duration(milliseconds: 300))
+    .listen((state) => print('Debounced: $state'));
+```
+
+---
+
+## 2. Consuming Legacy BLoC / Cubits in `BlocSignalBuilder`
+
+If you want to use reactive `BlocSignalBuilder` or signal effects with an existing legacy `Bloc` or `Cubit`:
+
+```dart
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+
+final legacyBloc = LegacyCounterBloc();
+
+// Convert legacy BLoC stream into a BlocSignal container
+final blocSignal = legacyBloc.stream.toBlocSignal(
+  initialState: legacyBloc.state,
+);
+
+// Consume directly in Flutter UI via BlocSignalBuilder
+BlocSignalBuilder<StreamBlocSignal<int>, int>(
+  bloc: blocSignal as StreamBlocSignal<int>,
+  builder: (context, count) => Text('Count: $count'),
+);
+```
+
+---
+
+## 3. Automatic Cleanup
+
+`StreamBlocSignal` automatically listens to the underlying stream when instantiated and cancels its stream subscription when `close()` is called on the container:
+
+```dart
+final signalContainer = legacyBloc.stream.toBlocSignal(initialState: legacyBloc.state);
+
+// When done:
+await signalContainer.close(); // Subscription cleanly cancelled!
+```


### PR DESCRIPTION
## Description
Resolves #41.

This PR introduces bidirectional stream interop extensions and a progressive migration bridge for `bloc_signals`:

### Features
1. **`BlocSignalStreamExtension`** (`extension BlocSignalStreamExtension<StateType> on BlocSignalBase<StateType>`):
   - `.toStream()`: Converts reactive state signal emissions into a multi-subscription Dart `Stream<StateType>`.
   - `.stream`: Extension getter delegating to `state.toStream()`.
   - **`BlocSignalBase` remains 100% unburdened**.

2. **`StreamBlocSignal<StateType>`** (`class StreamBlocSignal<StateType> extends CubitSignal<StateType>`):
   - Reactive state container wrapper that listens to an underlying `Stream<StateType>` (e.g. legacy `Bloc`, `Cubit`, or RxDart stream) and emits state updates synchronously.
   - Forwards stream errors to `onError()`.
   - Automatically cancels the stream subscription when `close()` is called.

3. **`StreamBlocSignalExtension`** (`extension StreamBlocSignalExtension<StateType> on Stream<StateType>`):
   - Adds `stream.toBlocSignal(initialState: ...)` extension method for one-line conversions of any legacy BLoC or Dart stream into a `BlocSignal` container.

4. **Documentation & Skill Updates**:
   - `skills/bloc-signals/migration_bridge.md`: Dedicated stream migration guide.
   - `skills/bloc-signals/migration.md`: Updated with prominent progressive migration examples.

## Verification
- `flutter test` in `bloc_signals`: 33/33 tests passing (100% line coverage).
- `dart analyze` in `bloc_signals`: 0 issues found (under `very_good_analysis`).
- `dart format .`: 100% formatted.
