### PR TITLE
feat(hydrate): create state persistence package

### DIFF
--- a/bloc_signals_hydrate/lib/bloc_signals_hydrate.dart
+++ b/bloc_signals_hydrate/lib/bloc_signals_hydrate.dart
@@ -1,0 +1,5 @@
+/// State persistence and hydration adapters for BlocSignal state containers.
+library bloc_signals_hydrate;
+
+export 'src/hydrated_bloc_signal.dart';
+export 'src/hydrated_storage.dart';

--- a/bloc_signals_hydrate/lib/src/hydrated_bloc_signal.dart
+++ b/bloc_signals_hydrate/lib/src/hydrated_bloc_signal.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_hydrate/src/hydrated_storage.dart';
+import 'package:meta/meta.dart';
+
+/// A mixin that provides state persistence and hydration capabilities for
+/// [BlocSignalBase] containers.
+mixin HydratedMixin<StateType> on BlocSignalBase<StateType> {
+  /// The initial default state for this container when no persisted state exists.
+  StateType get initialState;
+
+  /// An optional unique identifier for this instance when multiple instances
+  /// of the same class exist concurrently.
+  String? get id => null;
+
+  /// The prefix key used to scope this class in [HydratedStorage]. Defaults to
+  /// `runtimeType.toString()`.
+  String get storagePrefix => runtimeType.toString();
+
+  /// The unique storage token key derived from [storagePrefix] and optional [id].
+  String get storageToken => '$storagePrefix${id != null ? '_$id' : ''}';
+
+  /// An explicit [HydratedStorage] override instance for this container. If
+  /// `null`, falls back to [HydratedStorage.storage].
+  HydratedStorage? get storageOverride => null;
+
+  /// Resolves the active [HydratedStorage] instance.
+  @protected
+  HydratedStorage? get activeStorage =>
+      storageOverride ?? HydratedStorage.storage;
+
+  /// Converts stored JSON representation ([Object?]) back into [StateType].
+  ///
+  /// Accepts Maps, Lists, Strings, Numbers, Booleans, or null. Return `null` to
+  /// fall back to initial state.
+  StateType? fromJson(dynamic json);
+
+  /// Converts current [state] into a JSON-encodable representation ([Object?]).
+  ///
+  /// Can return a Map, List, String, number, boolean, or null. Returning `null`
+  /// will delete the key from storage.
+  dynamic toJson(StateType state);
+
+  /// Initializes hydration by loading stored state during constructor execution.
+  @protected
+  StateType initHydratedState(StateType initial) {
+    final storage = activeStorage;
+    if (storage == null) return initial;
+    try {
+      final json = storage.read(storageToken);
+      if (json != null) {
+        final restored = fromJson(json);
+        if (restored != null) return restored;
+      }
+    } on Object catch (error, stackTrace) {
+      onError(error, stackTrace);
+    }
+    return initial;
+  }
+
+  /// Persists [state] to [activeStorage].
+  @protected
+  void persist(StateType state) {
+    final storage = activeStorage;
+    if (storage == null) return;
+    try {
+      final json = toJson(state);
+      if (json != null) {
+        unawaited(Future.value(storage.write(storageToken, json)));
+      } else {
+        unawaited(Future.value(storage.delete(storageToken)));
+      }
+    } on Object catch (error, stackTrace) {
+      onError(error, stackTrace);
+    }
+  }
+
+  /// Deletes stored state from storage and resets container state to [initialState].
+  Future<void> clear() async {
+    final storage = activeStorage;
+    if (storage != null) {
+      await storage.delete(storageToken);
+    }
+    super.emit(initialState);
+  }
+}
+
+/// A reactive [CubitSignal] container that automatically persists and restores
+/// state across app restarts or container instantiation.
+abstract class HydratedCubitSignal<StateType> extends CubitSignal<StateType>
+    with HydratedMixin<StateType> {
+  /// Creates a [HydratedCubitSignal] with the specified [initialState].
+  HydratedCubitSignal({
+    required this.initialState,
+    super.equals,
+    this.id,
+    HydratedStorage? storage,
+  })  : _storageOverride = storage,
+        super(initialState: initialState) {
+    _hydrateState();
+  }
+
+  @override
+  final StateType initialState;
+
+  @override
+  final String? id;
+
+  final HydratedStorage? _storageOverride;
+
+  @override
+  HydratedStorage? get storageOverride => _storageOverride;
+
+  void _hydrateState() {
+    final restored = initHydratedState(initialState);
+    if (restored != initialState) {
+      emit(restored);
+    }
+  }
+
+  @override
+  void emit(StateType state) {
+    super.emit(state);
+    persist(state);
+  }
+}
+
+/// A reactive [BlocSignal] container that automatically persists and restores
+/// state across app restarts or container instantiation.
+abstract class HydratedBlocSignal<Event, StateType>
+    extends BlocSignal<Event, StateType> with HydratedMixin<StateType> {
+  /// Creates a [HydratedBlocSignal] with the specified [initialState].
+  HydratedBlocSignal({
+    required this.initialState,
+    super.equals,
+    this.id,
+    HydratedStorage? storage,
+  })  : _storageOverride = storage,
+        super(initialState: initialState) {
+    _hydrateState();
+  }
+
+  @override
+  final StateType initialState;
+
+  @override
+  final String? id;
+
+  final HydratedStorage? _storageOverride;
+
+  @override
+  HydratedStorage? get storageOverride => _storageOverride;
+
+  void _hydrateState() {
+    final restored = initHydratedState(initialState);
+    if (restored != initialState) {
+      emit(restored);
+    }
+  }
+
+  @override
+  void emit(StateType state) {
+    super.emit(state);
+    persist(state);
+  }
+}

--- a/bloc_signals_hydrate/lib/src/hydrated_storage.dart
+++ b/bloc_signals_hydrate/lib/src/hydrated_storage.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+/// An abstract interface for state persistence backends used by
+/// `HydratedBlocSignal` and `HydratedCubitSignal`.
+abstract class HydratedStorage {
+  /// The global default [HydratedStorage] instance used across hydrated blocs.
+  static HydratedStorage? storage;
+
+  /// Reads value associated with [key] from storage.
+  dynamic read(String key);
+
+  /// Writes [value] associated with [key] to storage.
+  FutureOr<void> write(String key, dynamic value);
+
+  /// Deletes value associated with [key] from storage.
+  FutureOr<void> delete(String key);
+
+  /// Clears all keys and values from storage.
+  FutureOr<void> clear();
+}
+
+/// An in-memory implementation of [HydratedStorage] useful for testing,
+/// temporary sessions, and default zero-dependency storage.
+class MemoryHydratedStorage implements HydratedStorage {
+  final Map<String, dynamic> _storage = {};
+
+  @override
+  dynamic read(String key) => _storage[key];
+
+  @override
+  void write(String key, dynamic value) {
+    _storage[key] = value;
+  }
+
+  @override
+  void delete(String key) {
+    _storage.remove(key);
+  }
+
+  @override
+  void clear() {
+    _storage.clear();
+  }
+}

--- a/bloc_signals_hydrate/pubspec.yaml
+++ b/bloc_signals_hydrate/pubspec.yaml
@@ -1,0 +1,24 @@
+name: bloc_signals_hydrate
+resolution: workspace
+description: State persistence and hydration adapters for BlocSignal state containers.
+version: 0.1.0
+repository: https://github.com/RandalSchwartz/BlocSignal
+issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
+
+topics:
+  - bloc
+  - signals
+  - hydrated
+  - persistence
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  bloc_signals: ^0.2.4
+  meta: ">=1.11.0 <2.0.0"
+  signals_core: ^7.0.0
+
+dev_dependencies:
+  test: ^1.25.6
+  very_good_analysis: ^10.1.0

--- a/bloc_signals_hydrate/test/hydrated_bloc_signal_test.dart
+++ b/bloc_signals_hydrate/test/hydrated_bloc_signal_test.dart
@@ -1,0 +1,191 @@
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:test/test.dart';
+
+class PrimitiveCounterCubit extends HydratedCubitSignal<int> {
+  PrimitiveCounterCubit({super.id, super.storage}) : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+
+  @override
+  int? fromJson(dynamic json) => json as int?;
+
+  @override
+  dynamic toJson(int state) => state;
+}
+
+class ListTodoListCubit extends HydratedCubitSignal<List<String>> {
+  ListTodoListCubit({super.id, super.storage})
+      : super(initialState: const []);
+
+  void addTodo(String item) => emit([...stateValue, item]);
+
+  @override
+  List<String>? fromJson(dynamic json) =>
+      (json as List?)?.map((e) => e.toString()).toList();
+
+  @override
+  dynamic toJson(List<String> state) => state;
+}
+
+class MapUserProfileCubit extends HydratedCubitSignal<Map<String, dynamic>> {
+  MapUserProfileCubit({super.id, super.storage})
+      : super(initialState: const {'name': 'Guest'});
+
+  void updateName(String name) => emit({...stateValue, 'name': name});
+
+  @override
+  Map<String, dynamic>? fromJson(dynamic json) =>
+      (json as Map?)?.cast<String, dynamic>();
+
+  @override
+  dynamic toJson(Map<String, dynamic> state) => state;
+}
+
+sealed class CounterEvent {}
+
+class IncrementEvent extends CounterEvent {}
+
+class HydratedCounterBloc extends HydratedBlocSignal<CounterEvent, int> {
+  HydratedCounterBloc({super.id, super.storage}) : super(initialState: 0) {
+    on<IncrementEvent>((event, emit) => emit(stateValue + 1));
+  }
+
+  @override
+  int? fromJson(dynamic json) => json as int?;
+
+  @override
+  dynamic toJson(int state) => state;
+}
+
+class ErrorProneCubit extends HydratedCubitSignal<int> {
+  ErrorProneCubit({super.storage}) : super(initialState: 0);
+
+  @override
+  int? fromJson(dynamic json) {
+    throw FormatException('Invalid JSON payload');
+  }
+
+  @override
+  dynamic toJson(int state) => state;
+}
+
+void main() {
+  late MemoryHydratedStorage storage;
+
+  setUp(() {
+    storage = MemoryHydratedStorage();
+    HydratedStorage.storage = storage;
+  });
+
+  tearDown(() {
+    HydratedStorage.storage = null;
+  });
+
+  group('HydratedCubitSignal & HydratedBlocSignal', () {
+    test('hydrates primitive int state directly without map wrapping', () {
+      storage.write('PrimitiveCounterCubit', 42);
+
+      final cubit = PrimitiveCounterCubit();
+      expect(cubit.stateValue, equals(42));
+    });
+
+    test('persists state change automatically on emit', () {
+      final cubit = PrimitiveCounterCubit();
+      expect(cubit.stateValue, equals(0));
+
+      cubit.increment();
+      expect(cubit.stateValue, equals(1));
+      expect(storage.read('PrimitiveCounterCubit'), equals(1));
+    });
+
+    test('hydrates List collection state directly', () {
+      storage.write('ListTodoListCubit', ['Buy milk', 'Walk dog']);
+
+      final cubit = ListTodoListCubit();
+      expect(cubit.stateValue, equals(['Buy milk', 'Walk dog']));
+
+      cubit.addTodo('Code Dart');
+      expect(
+        storage.read('ListTodoListCubit'),
+        equals(['Buy milk', 'Walk dog', 'Code Dart']),
+      );
+    });
+
+    test('hydrates Map state correctly', () {
+      storage.write('MapUserProfileCubit', {'name': 'Alice'});
+
+      final cubit = MapUserProfileCubit();
+      expect(cubit.stateValue, equals({'name': 'Alice'}));
+
+      cubit.updateName('Bob');
+      expect(storage.read('MapUserProfileCubit'), equals({'name': 'Bob'}));
+    });
+
+    test('isolates storage keys by instance id', () {
+      storage.write('PrimitiveCounterCubit_user_1', 10);
+      storage.write('PrimitiveCounterCubit_user_2', 20);
+
+      final cubit1 = PrimitiveCounterCubit(id: 'user_1');
+      final cubit2 = PrimitiveCounterCubit(id: 'user_2');
+
+      expect(cubit1.stateValue, equals(10));
+      expect(cubit2.stateValue, equals(20));
+
+      cubit1.increment();
+      expect(storage.read('PrimitiveCounterCubit_user_1'), equals(11));
+      expect(storage.read('PrimitiveCounterCubit_user_2'), equals(20));
+    });
+
+    test('supports HydratedBlocSignal event handling and persistence', () {
+      storage.write('HydratedCounterBloc', 99);
+
+      final bloc = HydratedCounterBloc();
+      expect(bloc.stateValue, equals(99));
+
+      bloc.add(IncrementEvent());
+      expect(bloc.stateValue, equals(100));
+      expect(storage.read('HydratedCounterBloc'), equals(100));
+    });
+
+    test('clears storage and resets state to initialState on clear()',
+        () async {
+      storage.write('PrimitiveCounterCubit', 50);
+
+      final cubit = PrimitiveCounterCubit();
+      expect(cubit.stateValue, equals(50));
+
+      await cubit.clear();
+      expect(cubit.stateValue, equals(0));
+      expect(storage.read('PrimitiveCounterCubit'), isNull);
+    });
+
+    test('handles fromJson exception gracefully via onError', () {
+      Object? capturedError;
+      BlocSignalObserver.observer = _TestObserver(
+        onErrorCallback: (bloc, error, stackTrace) {
+          capturedError = error;
+        },
+      );
+
+      storage.write('ErrorProneCubit', 'invalid_payload');
+
+      final cubit = ErrorProneCubit();
+      expect(cubit.stateValue, equals(0)); // Falls back to initialState
+      expect(capturedError, isA<FormatException>());
+    });
+  });
+}
+
+class _TestObserver extends BlocSignalObserver {
+  _TestObserver({this.onErrorCallback});
+
+  final void Function(BlocSignalBase bloc, Object error, StackTrace stackTrace)?
+      onErrorCallback;
+
+  @override
+  void onError(BlocSignalBase bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    onErrorCallback?.call(bloc, error, stackTrace);
+  }
+}

--- a/plugins/bloc-signals/skills/bloc-signals/hydration.md
+++ b/plugins/bloc-signals/skills/bloc-signals/hydration.md
@@ -1,0 +1,203 @@
+# State Persistence & Hydration Guide (`package:bloc_signals_hydrate`)
+
+This guide details state persistence and hydration in `BlocSignal` using `package:bloc_signals_hydrate`.
+
+`HydratedCubitSignal` and `HydratedBlocSignal` automatically persist state changes to disk/storage and restore state synchronously during container instantiation across app restarts.
+
+---
+
+## 🚀 Key Improvements Over `hydrated_bloc`
+
+- **`dynamic` / `Object?` JSON Support**:
+  `fromJson(dynamic json)` and `toJson(StateType state)` accept any valid JSON primitive or collection (`Map`, `List`, `String`, `num`, `bool`, `null`). Primitive states (e.g. `int`, `String`, `List<String>`) do **not** require map wrappers like `{"value": 42}`!
+- **Synchronous Initial Hydration**:
+  State is restored synchronously during constructor execution—meaning initial widget builds render hydrated data immediately with **zero frame flicker**.
+
+---
+
+## 1. Primitive State Hydration (e.g. `int`, `String`)
+
+```dart
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+
+class CounterCubit extends HydratedCubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+
+  @override
+  int? fromJson(dynamic json) => json as int?;
+
+  @override
+  dynamic toJson(int state) => state; // Directly return primitive value!
+}
+```
+
+---
+
+## 2. Collection & Map State Hydration
+
+```dart
+class TodosCubit extends HydratedCubitSignal<List<String>> {
+  TodosCubit() : super(initialState: const []);
+
+  void addTodo(String text) => emit([...stateValue, text]);
+
+  @override
+  List<String>? fromJson(dynamic json) =>
+      (json as List?)?.map((e) => e.toString()).toList();
+
+  @override
+  dynamic toJson(List<String> state) => state;
+}
+```
+
+---
+
+## 3. Instance Scoping & Clearing State
+
+```dart
+// Scope storage by instance ID for multi-user/multi-account features
+final user1Cubit = CounterCubit(id: 'user_123');
+final user2Cubit = CounterCubit(id: 'user_456');
+
+// Delete stored key and reset state to initialState
+await user1Cubit.clear();
+
+---
+
+## 4. Wiring `SharedPreferences` as `HydratedStorage`
+
+```dart
+import 'dart:convert';
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesHydratedStorage implements HydratedStorage {
+  SharedPreferencesHydratedStorage(this.prefs);
+
+  final SharedPreferences prefs;
+
+  @override
+  dynamic read(String key) {
+    final value = prefs.getString(key);
+    if (value == null) return null;
+    return jsonDecode(value);
+  }
+
+  @override
+  Future<void> write(String key, dynamic value) async {
+    await prefs.setString(key, jsonEncode(value));
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    await prefs.remove(key);
+  }
+
+  @override
+  Future<void> clear() async {
+    await prefs.clear();
+  }
+}
+
+// In main.dart before runApp():
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  HydratedStorage.storage = SharedPreferencesHydratedStorage(prefs);
+
+  runApp(const MyApp());
+}
+```
+
+---
+
+## 5. Complete Flutter Hydrated Counter App
+
+```dart
+import 'dart:convert';
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// 1. Define your Hydrated Cubit with zero map-wrapping!
+class CounterCubit extends HydratedCubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+
+  @override
+  int? fromJson(dynamic json) => json as int?;
+
+  @override
+  dynamic toJson(int state) => state;
+}
+
+// 2. Storage Adapter
+class SharedPreferencesHydratedStorage implements HydratedStorage {
+  SharedPreferencesHydratedStorage(this.prefs);
+  final SharedPreferences prefs;
+
+  @override
+  dynamic read(String key) {
+    final value = prefs.getString(key);
+    return value != null ? jsonDecode(value) : null;
+  }
+
+  @override
+  Future<void> write(String key, dynamic value) async =>
+      prefs.setString(key, jsonEncode(value));
+
+  @override
+  Future<void> delete(String key) async => prefs.remove(key);
+
+  @override
+  Future<void> clear() async => prefs.clear();
+}
+
+// 3. Entrypoint
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  HydratedStorage.storage = SharedPreferencesHydratedStorage(prefs);
+
+  runApp(
+    MaterialApp(
+      home: BlocSignalProvider<CounterCubit>(
+        create: (context) => CounterCubit(),
+        child: const CounterScreen(),
+      ),
+    ),
+  );
+}
+
+class CounterScreen extends StatelessWidget {
+  const CounterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final counterCubit = context.read<CounterCubit>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Hydrated Counter')),
+      body: Center(
+        child: BlocSignalBuilder<CounterCubit, int>(
+          builder: (context, count) {
+            return Text(
+              '$count',
+              style: Theme.of(context).textTheme.headlineLarge,
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: counterCubit.increment,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+```
+```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ workspace:
   - bloc_signals_test
   - bloc_signals_lint
   - bloc_signals_riverpod
+  - bloc_signals_hydrate
   - benchmarks
 
 dev_dependencies:


### PR DESCRIPTION
## Overview
This PR addresses **Issue [#40](https://github.com/RandalSchwartz/BlocSignal/issues/40)** by introducing the state persistence package **`bloc_signals_hydrate`** for `BlocSignal` and `CubitSignal` containers across app restarts.

## Proposed Changes
- **`bloc_signals_hydrate`**: Created new monorepo package with `HydratedStorage`, `MemoryHydratedStorage`, `HydratedMixin`, `HydratedCubitSignal`, and `HydratedBlocSignal`.
- **`Object?` / `dynamic` JSON Support**: Accepts Maps, Lists, Strings, Numbers, Booleans, or `null` in `fromJson` / `toJson` without forcing artificial `{ "value": 42 }` map wrappers for primitive states.
- **Synchronous Initial Hydration**: Restores state during constructor initialization for zero initial UI frame flickers.
- **Storage Scoping & Clearing**: Supports `id` scoping (`CounterCubit_user1`) and `clear()` method for resetting state and deleting storage keys.
- **Testing**: Added unit test suite `bloc_signals_hydrate/test/hydrated_bloc_signal_test.dart` (8 tests covering primitives, collections, maps, multi-instance isolation, `clear()`, and `onError` exception handling).
- **Skill Docs**: Created `hydration.md` skill file with `SharedPreferences` adapter and complete Flutter Hydrated Counter App recipes.

---

## 🧐 Pre-Commit Self-Critical Review (Five Pillars)

### 1. 🎯 Intent
- **Goal**: Implement automatic state persistence and synchronous hydration for `BlocSignal` and `CubitSignal` containers across app restarts.
- **Fulfillment**: Fully addresses all requirements of Issue #40.

### 2. 🧪 Verification (TDD Proof)
- **Isolated TDD Suite**: 8 unit tests in `bloc_signals_hydrate/test/hydrated_bloc_signal_test.dart` (100% passing).
- **Diagnostics**: `flutter analyze .` (0 issues), `validate_agent_plugin.dart` (pass).

### 3. 🏗️ Architecture
- **`Object?` JSON Support**: Accepts Maps, Lists, Strings, Numbers, Booleans, or `null`.
- **Synchronous Initial Hydration**: Zero frame flickers during widget initialization.
- **Zero-Dependency Default**: Ships with `MemoryHydratedStorage` for fast in-memory testing.

### 4. 💥 Blast Radius & Risks
- Clean addition of new workspace package `bloc_signals_hydrate`. 0 breaking changes.

### 5. 🛡️ Reviewer Defense
- **`clear()` Super Emission**: Calling `super.emit(initialState)` resets state without re-writing `initialState` back into storage.

Closes #40
