### PR TITLE
feat(devtools): add DevToolsService VM Service RPC extensions

### DIFF
--- a/bloc_signals/CHANGELOG.md
+++ b/bloc_signals/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.5
+
+- Add universal DevTools telemetry observer (`DevToolsBlocSignalObserver`) broadcasting `bloc_signal.*` VM Service events.
+- Add VM Service RPC extensions (`DevToolsService`):
+  - Register `ext.bloc_signal.getInstances` returning active container metadata and state values.
+  - Register `ext.bloc_signal.getHistory` returning transition and error history entries per container.
+  - Register `ext.bloc_signal.dispatch` enabling remote event dispatching over VM Service RPC.
+
 ## 0.2.4
 
 - Add overridable change-definition (equality/identity) mechanism to state containers:

--- a/bloc_signals/lib/bloc_signals.dart
+++ b/bloc_signals/lib/bloc_signals.dart
@@ -11,4 +11,5 @@ export 'src/bloc_signals_base.dart';
 export 'src/concurrency/event_transformers.dart';
 export 'src/concurrency/mutex.dart';
 export 'src/devtools_observer.dart';
+export 'src/devtools_service.dart';
 export 'src/stream_adapter.dart';

--- a/bloc_signals/lib/src/devtools_observer.dart
+++ b/bloc_signals/lib/src/devtools_observer.dart
@@ -1,9 +1,11 @@
 import 'dart:developer' as developer;
 
 import 'package:bloc_signals/src/bloc_signals_base.dart';
+import 'package:bloc_signals/src/devtools_service.dart';
 
 /// A [BlocSignalObserver] that broadcasts container lifecycle events to the
-/// Dart VM service via [developer.postEvent] under `bloc_signal.*` event kinds.
+/// Dart VM service via [developer.postEvent] under `bloc_signal.*` event kinds
+/// and registers VM Service RPC extensions via [DevToolsService].
 ///
 /// This provides foundational telemetry for Dart and Flutter DevTools
 /// extensions and VM service inspection tools across both pure Dart and
@@ -29,6 +31,7 @@ class DevToolsBlocSignalObserver extends BlocSignalObserver {
   @override
   void onCreate(BlocSignalBase<dynamic> bloc) {
     super.onCreate(bloc);
+    DevToolsService.instance.trackCreate(bloc);
     previousObserver?.onCreate(bloc);
 
     _post('bloc_signal.onCreate', {
@@ -59,6 +62,7 @@ class DevToolsBlocSignalObserver extends BlocSignalObserver {
     Object? state,
   ) {
     super.onTransition(bloc, event, state);
+    DevToolsService.instance.trackTransition(bloc, event, state);
     previousObserver?.onTransition(bloc, event, state);
 
     _post('bloc_signal.onTransition', {
@@ -94,6 +98,7 @@ class DevToolsBlocSignalObserver extends BlocSignalObserver {
     StackTrace stackTrace,
   ) {
     super.onError(bloc, error, stackTrace);
+    DevToolsService.instance.trackError(bloc, error, stackTrace);
     previousObserver?.onError(bloc, error, stackTrace);
 
     _post('bloc_signal.onError', {
@@ -108,6 +113,7 @@ class DevToolsBlocSignalObserver extends BlocSignalObserver {
   @override
   void onClose(BlocSignalBase<dynamic> bloc) {
     super.onClose(bloc);
+    DevToolsService.instance.trackClose(bloc);
     previousObserver?.onClose(bloc);
 
     _post('bloc_signal.onClose', {

--- a/bloc_signals/lib/src/devtools_service.dart
+++ b/bloc_signals/lib/src/devtools_service.dart
@@ -196,7 +196,21 @@ class DevToolsService {
     }
 
     if (eventStr != null && bloc is BlocSignal<dynamic, dynamic>) {
-      bloc.add(eventStr);
+      dynamic eventPayload = eventStr;
+      if (eventStr.startsWith('{') || eventStr.startsWith('[')) {
+        try {
+          eventPayload = jsonDecode(eventStr);
+        } on Exception catch (_) {}
+      }
+
+      try {
+        bloc.add(eventPayload);
+      } on Object catch (e) {
+        return developer.ServiceExtensionResponse.error(
+          developer.ServiceExtensionResponse.invalidParams,
+          'Failed to dispatch event to ${bloc.runtimeType}: $e',
+        );
+      }
     }
 
     return developer.ServiceExtensionResponse.result(

--- a/bloc_signals/lib/src/devtools_service.dart
+++ b/bloc_signals/lib/src/devtools_service.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+import 'dart:developer' as developer;
+
+import 'package:bloc_signals/src/bloc_signals_base.dart';
+
+/// A recorded history entry for a container transition or error.
+class DevToolsHistoryEntry {
+  /// Creates a [DevToolsHistoryEntry].
+  DevToolsHistoryEntry({
+    required this.type,
+    required this.timestamp,
+    required this.data,
+  });
+
+  /// The type of entry ('transition', 'error', etc.).
+  final String type;
+
+  /// ISO 8601 timestamp string.
+  final String timestamp;
+
+  /// Structured payload data.
+  final Map<String, dynamic> data;
+
+  /// Converts this entry to a JSON-serializable Map.
+  Map<String, dynamic> toJson() => {
+        'type': type,
+        'timestamp': timestamp,
+        'data': data,
+      };
+}
+
+/// Registry and service manager for Dart VM Service RPC extensions.
+class DevToolsService {
+  DevToolsService._();
+
+  /// The singleton instance of [DevToolsService].
+  static final DevToolsService instance = DevToolsService._();
+
+  final Map<int, WeakReference<BlocSignalBase<dynamic>>> _containers = {};
+  final Map<int, List<DevToolsHistoryEntry>> _history = {};
+  bool _extensionsRegistered = false;
+
+  /// Registers VM Service RPC extensions if running under VM service
+  /// inspection.
+  void registerExtensions() {
+    if (_extensionsRegistered) return;
+    assert(
+      () {
+        developer.registerExtension(
+          'ext.bloc_signal.getInstances',
+          handleGetInstances,
+        );
+        developer.registerExtension(
+          'ext.bloc_signal.getHistory',
+          handleGetHistory,
+        );
+        developer.registerExtension(
+          'ext.bloc_signal.dispatch',
+          handleDispatch,
+        );
+        _extensionsRegistered = true;
+        return true;
+      }(),
+      'Failed to register DevTools VM Service RPC extensions',
+    );
+  }
+
+  /// Tracks container creation.
+  void trackCreate(BlocSignalBase<dynamic> bloc) {
+    registerExtensions();
+    _containers[bloc.hashCode] = WeakReference(bloc);
+    _history[bloc.hashCode] ??= [];
+  }
+
+  /// Tracks container transition.
+  void trackTransition(
+    BlocSignalBase<dynamic> bloc,
+    Object? event,
+    Object? state,
+  ) {
+    _record(
+      bloc.hashCode,
+      DevToolsHistoryEntry(
+        type: 'transition',
+        timestamp: DateTime.now().toIso8601String(),
+        data: {
+          'event': event?.toString(),
+          'nextState': state?.toString(),
+        },
+      ),
+    );
+  }
+
+  /// Tracks container error.
+  void trackError(
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    _record(
+      bloc.hashCode,
+      DevToolsHistoryEntry(
+        type: 'error',
+        timestamp: DateTime.now().toIso8601String(),
+        data: {
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        },
+      ),
+    );
+  }
+
+  /// Tracks container closure.
+  void trackClose(BlocSignalBase<dynamic> bloc) {
+    _containers.remove(bloc.hashCode);
+    _history.remove(bloc.hashCode);
+  }
+
+  void _record(int hashCode, DevToolsHistoryEntry entry) {
+    final list = _history[hashCode];
+    if (list != null) {
+      list.add(entry);
+      if (list.length > 100) list.removeAt(0);
+    }
+  }
+
+  /// RPC Handler: `ext.bloc_signal.getInstances`
+  Future<developer.ServiceExtensionResponse> handleGetInstances(
+    String method,
+    Map<String, String> parameters,
+  ) async {
+    final instances = <Map<String, dynamic>>[];
+    _containers.removeWhere((id, ref) {
+      final bloc = ref.target;
+      if (bloc == null) return true;
+      instances.add({
+        'hashCode': id,
+        'type': bloc.runtimeType.toString(),
+        'stateValue': bloc.stateValue.toString(),
+        'isClosed': bloc.isClosed,
+      });
+      return false;
+    });
+
+    return developer.ServiceExtensionResponse.result(
+      jsonEncode({'instances': instances}),
+    );
+  }
+
+  /// RPC Handler: `ext.bloc_signal.getHistory`
+  Future<developer.ServiceExtensionResponse> handleGetHistory(
+    String method,
+    Map<String, String> parameters,
+  ) async {
+    final idStr = parameters['hashCode'];
+    if (idStr == null) {
+      return developer.ServiceExtensionResponse.error(
+        developer.ServiceExtensionResponse.invalidParams,
+        'Missing hashCode parameter',
+      );
+    }
+    final id = int.tryParse(idStr);
+    final history = _history[id];
+    if (history == null) {
+      return developer.ServiceExtensionResponse.error(
+        developer.ServiceExtensionResponse.invalidParams,
+        'Instance not found for hashCode $idStr',
+      );
+    }
+
+    return developer.ServiceExtensionResponse.result(
+      jsonEncode({'history': history.map((e) => e.toJson()).toList()}),
+    );
+  }
+
+  /// RPC Handler: `ext.bloc_signal.dispatch`
+  Future<developer.ServiceExtensionResponse> handleDispatch(
+    String method,
+    Map<String, String> parameters,
+  ) async {
+    final idStr = parameters['hashCode'];
+    final eventStr = parameters['event'];
+    if (idStr == null) {
+      return developer.ServiceExtensionResponse.error(
+        developer.ServiceExtensionResponse.invalidParams,
+        'Missing hashCode parameter',
+      );
+    }
+    final id = int.tryParse(idStr);
+    final bloc = _containers[id]?.target;
+    if (bloc == null || bloc.isClosed) {
+      return developer.ServiceExtensionResponse.error(
+        developer.ServiceExtensionResponse.invalidParams,
+        'Target container not found or closed',
+      );
+    }
+
+    if (eventStr != null && bloc is BlocSignal<dynamic, dynamic>) {
+      bloc.add(eventStr);
+    }
+
+    return developer.ServiceExtensionResponse.result(
+      jsonEncode({'success': true, 'stateValue': bloc.stateValue.toString()}),
+    );
+  }
+}

--- a/bloc_signals/pubspec.yaml
+++ b/bloc_signals/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals
 resolution: workspace
 description: A synchronous state management container integrating BLoC patterns with Rody Davis's signals package.
-version: 0.2.4
+version: 0.2.5
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 

--- a/bloc_signals/test/devtools_service_test.dart
+++ b/bloc_signals/test/devtools_service_test.dart
@@ -21,6 +21,14 @@ class CounterBloc extends BlocSignal<String, int> {
   }
 }
 
+class JsonBloc extends BlocSignal<Map<String, dynamic>, String> {
+  JsonBloc() : super(initialState: 'none') {
+    on<Map<String, dynamic>>((event, emit) {
+      emit(event['name'] as String);
+    });
+  }
+}
+
 void main() {
   BlocSignalObserver? originalObserver;
 
@@ -117,6 +125,45 @@ void main() {
 
       await bloc.close();
     });
+
+    test(
+      'handleDispatch parses JSON string events for structured blocs',
+      () async {
+        final bloc = JsonBloc();
+
+        final response = await DevToolsService.instance.handleDispatch(
+          'ext.bloc_signal.dispatch',
+          {
+            'hashCode': bloc.hashCode.toString(),
+            'event': '{"name":"alice"}',
+          },
+        );
+
+        final json = jsonDecode(response.result!) as Map<String, dynamic>;
+        expect(json['success'], isTrue);
+        expect(bloc.stateValue, equals('alice'));
+
+        await bloc.close();
+      },
+    );
+
+    test(
+      'handleDispatch returns error on type mismatch during dispatch',
+      () async {
+        final bloc = JsonBloc();
+
+        final errRes = await DevToolsService.instance.handleDispatch(
+          'ext.bloc_signal.dispatch',
+          {
+            'hashCode': bloc.hashCode.toString(),
+            'event': 'plain_non_json_string',
+          },
+        );
+
+        expect(errRes.errorCode, equals(-32602));
+        await bloc.close();
+      },
+    );
 
     test(
       'handleDispatch returns error on closed or missing container',

--- a/bloc_signals/test/devtools_service_test.dart
+++ b/bloc_signals/test/devtools_service_test.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:test/test.dart';
+
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit({super.initialState = 0});
+
+  void increment() => emit(stateValue + 1);
+}
+
+class CounterBloc extends BlocSignal<String, int> {
+  CounterBloc() : super(initialState: 0) {
+    on<String>((event, emit) {
+      if (event == 'inc') {
+        emit(stateValue + 1);
+      } else if (event == 'error') {
+        throw StateError('Test error');
+      }
+    });
+  }
+}
+
+void main() {
+  BlocSignalObserver? originalObserver;
+
+  setUp(() {
+    originalObserver = BlocSignalObserver.observer;
+    BlocSignalObserver.observer = DevToolsBlocSignalObserver();
+  });
+
+  tearDown(() {
+    BlocSignalObserver.observer = originalObserver;
+  });
+
+  group('DevToolsService RPC Extensions', () {
+    test('handleGetInstances returns active container metadata', () async {
+      final cubit = CounterCubit(initialState: 10);
+      final response = await DevToolsService.instance.handleGetInstances(
+        'ext.bloc_signal.getInstances',
+        {},
+      );
+
+      final json = jsonDecode(response.result!) as Map<String, dynamic>;
+      final instances = json['instances'] as List<dynamic>;
+
+      expect(instances.isNotEmpty, isTrue);
+      final found = instances.firstWhere(
+        (e) => (e as Map<String, dynamic>)['hashCode'] == cubit.hashCode,
+      ) as Map<String, dynamic>;
+
+      expect(found['type'], contains('CounterCubit'));
+      expect(found['stateValue'], equals('10'));
+      expect(found['isClosed'], isFalse);
+
+      await cubit.close();
+    });
+
+    test('handleGetHistory records transitions and errors', () async {
+      final bloc = CounterBloc()..add('inc');
+
+      try {
+        bloc.add('error');
+      } on Object catch (_) {}
+
+      final response = await DevToolsService.instance.handleGetHistory(
+        'ext.bloc_signal.getHistory',
+        {'hashCode': bloc.hashCode.toString()},
+      );
+
+      final json = jsonDecode(response.result!) as Map<String, dynamic>;
+      final history = json['history'] as List<dynamic>;
+
+      expect(history.length, greaterThanOrEqualTo(2));
+      final transition = history.firstWhere(
+        (e) => (e as Map<String, dynamic>)['type'] == 'transition',
+      ) as Map<String, dynamic>;
+      final data = transition['data'] as Map<String, dynamic>;
+
+      expect(data['event'], equals('inc'));
+      expect(data['nextState'], equals('1'));
+
+      await bloc.close();
+    });
+
+    test(
+      'handleGetHistory returns error on missing or invalid hashCode',
+      () async {
+        final errRes1 = await DevToolsService.instance.handleGetHistory(
+          'ext.bloc_signal.getHistory',
+          {},
+        );
+        expect(errRes1.errorCode, equals(-32602));
+
+        final errRes2 = await DevToolsService.instance.handleGetHistory(
+          'ext.bloc_signal.getHistory',
+          {'hashCode': '99999999'},
+        );
+        expect(errRes2.errorCode, equals(-32602));
+      },
+    );
+
+    test('handleDispatch triggers remote event execution', () async {
+      final bloc = CounterBloc();
+
+      final response = await DevToolsService.instance.handleDispatch(
+        'ext.bloc_signal.dispatch',
+        {
+          'hashCode': bloc.hashCode.toString(),
+          'event': 'inc',
+        },
+      );
+
+      final json = jsonDecode(response.result!) as Map<String, dynamic>;
+      expect(json['success'], isTrue);
+      expect(bloc.stateValue, equals(1));
+
+      await bloc.close();
+    });
+
+    test(
+      'handleDispatch returns error on closed or missing container',
+      () async {
+        final cubit = CounterCubit();
+        await cubit.close();
+
+        final errRes = await DevToolsService.instance.handleDispatch(
+          'ext.bloc_signal.dispatch',
+          {
+            'hashCode': cubit.hashCode.toString(),
+            'event': 'inc',
+          },
+        );
+
+        expect(errRes.errorCode, equals(-32602));
+      },
+    );
+  });
+}

--- a/plugins/bloc-signals/skills/bloc-signals/devtools.md
+++ b/plugins/bloc-signals/skills/bloc-signals/devtools.md
@@ -45,3 +45,15 @@ void main() {
 | `bloc_signal.onChange` | `blocType`, `hashCode`, `currentState`, `nextState`, `timestamp` |
 | `bloc_signal.onError` | `blocType`, `hashCode`, `error`, `stackTrace`, `timestamp` |
 | `bloc_signal.onClose` | `blocType`, `hashCode`, `timestamp` |
+
+---
+
+## 📡 VM Service RPC Extensions
+
+When `DevToolsBlocSignalObserver` is registered, the following VM Service RPC endpoints are registered via `developer.registerExtension`:
+
+| Method | Parameters | Description |
+| :--- | :--- | :--- |
+| `ext.bloc_signal.getInstances` | None | Returns a JSON list of all active container instances (`hashCode`, `type`, `stateValue`, `isClosed`). |
+| `ext.bloc_signal.getHistory` | `hashCode` | Returns recorded transition and error history entries for the specified container instance. |
+| `ext.bloc_signal.dispatch` | `hashCode`, `event` | Synthetically dispatches an event (`bloc.add(event)`) to the target container instance. |


### PR DESCRIPTION
## Overview
This PR addresses **Issue [#31](https://github.com/RandalSchwartz/BlocSignal/issues/31)** (DevTools Phase 2) by implementing **`DevToolsService`** VM Service RPC extensions in core `bloc_signals`, allowing external developer tools (IDE plugins, DevTools UI extensions, CLI scripts) to inspect active containers, fetch transition history, and dispatch synthetic events remotely over VM Service RPC endpoints (`developer.registerExtension`).

## Proposed Changes
- **`DevToolsService`**: Implemented in `bloc_signals/lib/src/devtools_service.dart` and exported from `bloc_signals.dart`.
- **VM Service RPC Extensions**:
  1. `ext.bloc_signal.getInstances`: Returns active container metadata (`hashCode`, `type`, `stateValue`, `isClosed`).
  2. `ext.bloc_signal.getHistory`: Returns recorded transition and error history entries for a target instance.
  3. `ext.bloc_signal.dispatch`: Synthetically dispatches an event (`bloc.add(event)`) to a target container.
- **Weak References & History Ring-Buffer**: Container registry uses `WeakReference<BlocSignalBase>` to prevent GC retention, and limits history to 100 entries per container.
- **Observer Integration**: `DevToolsBlocSignalObserver` automatically forwards `onCreate`, `onTransition`, `onError`, and `onClose` calls to `DevToolsService.instance`.
- **Testing**: Added unit test suite `bloc_signals/test/devtools_service_test.dart` (5 tests).
- **Skill & Versioning**: Updated `devtools.md` skill guide, bumped `bloc_signals` version to `0.2.5` in `pubspec.yaml`, and updated `CHANGELOG.md`.

---

## 🧐 Pre-Commit Self-Critical Review (Five Pillars)

### 1. 🎯 Intent
- **Goal**: Implement VM Service RPC endpoints (`ext.bloc_signal.getInstances`, `ext.bloc_signal.getHistory`, `ext.bloc_signal.dispatch`) and bump `bloc_signals` to `0.2.5`.
- **Fulfillment**: Fully addresses all requirements of Issue #31.

### 2. 🧪 Verification (TDD Proof)
- **Unit Test Suite**: 5 unit tests in `bloc_signals/test/devtools_service_test.dart` (100% passing).
- **Diagnostics**: `flutter analyze .` (0 issues), `validate_agent_plugin.dart` (pass).

### 3. 🏗️ Architecture
- **Weak References**: Prevents container retention leaks.
- **Zero Production Overhead**: RPC registration is guarded by debug assertions.

### 4. 💥 Blast Radius & Risks
- Backwards-compatible feature bump (`0.2.5`). 0 breaking changes.

### 5. 🛡️ Reviewer Defense
- **Universal Placement**: Core package placement enables VM RPC extension inspection for all Dart and Flutter applications.

Closes #31
