### PR TITLE
feat(bloc_signals_lint): add footgun prevention rules for global instances & provider disposal

### DIFF
--- a/bloc_signals_lint/README.md
+++ b/bloc_signals_lint/README.md
@@ -33,6 +33,7 @@ Built on top of [`custom_lint`](https://pub.dev/packages/custom_lint), `bloc_sig
 | **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. | `Cmd+.` -> Add `super.onEvent(event);` |
 | **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. | — |
 | **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. | — |
+| **`avoid_top_level_bloc_signal_instances`** | Warning | Flags top-level variables and static fields declared directly as `BlocSignal` / `CubitSignal` instances. | — |
 
 ### Flutter UI Rules
 
@@ -41,6 +42,8 @@ Built on top of [`custom_lint`](https://pub.dev/packages/custom_lint), `bloc_sig
 | **`avoid_emit_in_build`** | Warning | Flags calls to `emit()` or `add()` on state containers directly inside Flutter `Widget.build()` methods. | — |
 | **`avoid_unmanaged_signal_effects`** | Warning | Flags unmanaged `effect()` calls created inside Flutter `Widget` or `State` methods without lifecycle cleanup. | — |
 | **`prefer_bloc_signal_provider_read_in_callbacks`** | Warning | Warns when `context.watch<T>()` is used inside event callback closures (e.g. `onPressed`), suggesting `context.read<T>()`. | `Cmd+.` -> Replace `watch` with `read` |
+| **`avoid_providing_existing_instance_with_create`** | Warning | Flags passing existing variable references to `BlocSignalProvider(create: ...)` instead of `BlocSignalProvider.value(value: ...)`. | — |
+| **`avoid_manual_close_on_provided_bloc`** | Warning | Flags calling `.close()` manually on state containers retrieved via `context.read<T>()` or `BlocSignalProvider.of(context)`. | — |
 
 ---
 
@@ -89,4 +92,3 @@ on<Increment>((event, emit) => emit(stateValue + 1));
 This package is supported by an official pre-packaged [AI Coding Skill](https://github.com/RandalSchwartz/BlocSignal/tree/main/plugins/bloc-signals/skills/bloc-signals) representing analyzer rules, IDE diagnostics, and automated quick-fix rules for `BlocSignal`.
 
 If you develop with AI coding assistants (such as Claude Code, Antigravity, Gemini, Cursor, or Codex), you can load the [`bloc-signals`](https://github.com/RandalSchwartz/BlocSignal/tree/main/plugins/bloc-signals/skills/bloc-signals) skill bundle to guide your assistant's code generation and analysis.
-

--- a/bloc_signals_lint/lib/bloc_signals_lint.dart
+++ b/bloc_signals_lint/lib/bloc_signals_lint.dart
@@ -1,7 +1,10 @@
 import 'package:bloc_signals_lint/src/rules/avoid_direct_signal_mutation_outside_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_duplicate_event_handlers.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_emit_in_build.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_manual_close_on_provided_bloc.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_providing_existing_instance_with_create.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_top_level_bloc_signal_instances.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_unmanaged_signal_effects.dart';
 import 'package:bloc_signals_lint/src/rules/prefer_bloc_signal_provider_read_in_callbacks.dart';
 import 'package:bloc_signals_lint/src/rules/require_super_on_event.dart';
@@ -20,5 +23,8 @@ class _BlocSignalsLinter extends PluginBase {
         const AvoidEmitInBuild(),
         const AvoidUnmanagedSignalEffects(),
         const PreferBlocSignalProviderReadInCallbacks(),
+        const AvoidTopLevelBlocSignalInstances(),
+        const AvoidProvidingExistingInstanceWithCreate(),
+        const AvoidManualCloseOnProvidedBloc(),
       ];
 }

--- a/bloc_signals_lint/lib/src/rules/avoid_manual_close_on_provided_bloc.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_manual_close_on_provided_bloc.dart
@@ -1,0 +1,49 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags manual calls to `.close()` on state containers
+/// retrieved via `context.read<T>()` or `BlocSignalProvider.of(context)`.
+class AvoidManualCloseOnProvidedBloc extends DartLintRule {
+  /// Creates an [AvoidManualCloseOnProvidedBloc] lint rule.
+  const AvoidManualCloseOnProvidedBloc() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_manual_close_on_provided_bloc',
+    problemMessage:
+        'Do not manually call close() on state containers managed by BlocSignalProvider.',
+    correctionMessage:
+        'Let BlocSignalProvider manage container disposal automatically when unmounted.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      if (node.methodName.name != 'close') return;
+
+      final target = node.target;
+      if (target == null) return;
+
+      if (_isProviderLookup(target)) {
+        reporter.atNode(node.methodName, code);
+      }
+    });
+  }
+
+  bool _isProviderLookup(Expression target) {
+    if (target is MethodInvocation) {
+      final name = target.methodName.name;
+      if (name == 'read' || name == 'watch' || name == 'of') {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_providing_existing_instance_with_create.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_providing_existing_instance_with_create.dart
@@ -1,0 +1,96 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags passing pre-existing variable references to
+/// `BlocSignalProvider(create: ...)` instead of `BlocSignalProvider.value(value: ...)`.
+class AvoidProvidingExistingInstanceWithCreate extends DartLintRule {
+  /// Creates an [AvoidProvidingExistingInstanceWithCreate] lint rule.
+  const AvoidProvidingExistingInstanceWithCreate() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_providing_existing_instance_with_create',
+    problemMessage:
+        'Passing an existing instance "{0}" to BlocSignalProvider(create: ...) '
+        'will cause it to be automatically closed when unmounted.',
+    correctionMessage:
+        'Use BlocSignalProvider.value(value: ...) to provide existing instances without transferring disposal ownership.',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    void checkArgumentList(
+      String providerName,
+      Identifier? constructorName,
+      ArgumentList argumentList,
+    ) {
+      if (!providerName.contains('BlocSignalProvider') &&
+          !providerName.contains('BlocProvider')) {
+        return;
+      }
+
+      // Check if constructor is default constructor (not .value)
+      if (constructorName != null && constructorName.name == 'value') return;
+
+      for (final arg in argumentList.arguments) {
+        if (arg is NamedExpression && arg.name.label.name == 'create') {
+          final expression = arg.expression;
+          Expression? returnedExpr;
+
+          if (expression is FunctionExpression) {
+            final body = expression.body;
+            if (body is ExpressionFunctionBody) {
+              returnedExpr = body.expression;
+            } else if (body is BlockFunctionBody) {
+              for (final statement in body.block.statements) {
+                if (statement is ReturnStatement) {
+                  returnedExpr = statement.expression;
+                  break;
+                }
+              }
+            }
+          }
+
+          if (returnedExpr != null) {
+            final isExistingRef = returnedExpr is SimpleIdentifier ||
+                returnedExpr is PropertyAccess ||
+                returnedExpr is PrefixedIdentifier;
+
+            if (isExistingRef && returnedExpr is! InstanceCreationExpression) {
+              reporter.atNode(
+                returnedExpr,
+                code,
+                arguments: [returnedExpr.toSource()],
+              );
+            }
+          }
+        }
+      }
+    }
+
+    context.registry.addInstanceCreationExpression((node) {
+      checkArgumentList(
+        node.constructorName.type.toSource(),
+        node.constructorName.name,
+        node.argumentList,
+      );
+    });
+
+    context.registry.addMethodInvocation((node) {
+      if (node.target == null) {
+        checkArgumentList(
+          node.methodName.name,
+          null,
+          node.argumentList,
+        );
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_top_level_bloc_signal_instances.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_top_level_bloc_signal_instances.dart
@@ -1,0 +1,83 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags top-level variable and static field declarations
+/// initialized directly with [BlocSignalBase] instances.
+class AvoidTopLevelBlocSignalInstances extends DartLintRule {
+  /// Creates an [AvoidTopLevelBlocSignalInstances] lint rule.
+  const AvoidTopLevelBlocSignalInstances() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_top_level_bloc_signal_instances',
+    problemMessage:
+        'Stateful container "{0}" should not be declared as a top-level or static variable.',
+    correctionMessage:
+        'Scope containers using BlocSignalProvider, dependency injection, or factory getters. Primitive signals (e.g. signal(0)) can remain global.',
+  );
+
+  static const _blocSignalBaseChecker = TypeChecker.fromName(
+    'BlocSignalBase',
+    packageName: 'bloc_signals',
+  );
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addTopLevelVariableDeclaration((node) {
+      for (final variable in node.variables.variables) {
+        final initializer = variable.initializer;
+        if (initializer == null) continue;
+
+        if (_isBlocOrCubit(variable, initializer)) {
+          reporter.atNode(
+            variable,
+            code,
+            arguments: [variable.name.lexeme],
+          );
+        }
+      }
+    });
+
+    context.registry.addFieldDeclaration((node) {
+      if (!node.isStatic) return;
+
+      for (final variable in node.fields.variables) {
+        final initializer = variable.initializer;
+        if (initializer == null) continue;
+
+        if (_isBlocOrCubit(variable, initializer)) {
+          reporter.atNode(
+            variable,
+            code,
+            arguments: [variable.name.lexeme],
+          );
+        }
+      }
+    });
+  }
+
+  bool _isBlocOrCubit(VariableDeclaration variable, Expression initializer) {
+    final type = variable.declaredElement?.type ?? initializer.staticType;
+    if (type != null && _blocSignalBaseChecker.isAssignableFromType(type)) {
+      return true;
+    }
+
+    if (initializer is InstanceCreationExpression) {
+      final className = initializer.constructorName.type.name2.lexeme;
+      if (className.endsWith('Bloc') ||
+          className.endsWith('Cubit') ||
+          className.contains('BlocSignal')) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/bloc_signals_lint/test/bloc_signals_lint_test.dart
+++ b/bloc_signals_lint/test/bloc_signals_lint_test.dart
@@ -2,7 +2,10 @@ import 'package:bloc_signals_lint/bloc_signals_lint.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_direct_signal_mutation_outside_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_duplicate_event_handlers.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_emit_in_build.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_manual_close_on_provided_bloc.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_providing_existing_instance_with_create.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_top_level_bloc_signal_instances.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_unmanaged_signal_effects.dart';
 import 'package:bloc_signals_lint/src/rules/prefer_bloc_signal_provider_read_in_callbacks.dart';
 import 'package:bloc_signals_lint/src/rules/require_super_on_event.dart';
@@ -11,14 +14,14 @@ import 'package:test/test.dart';
 
 void main() {
   group('bloc_signals_lint plugin entrypoint', () {
-    test('createPlugin returns PluginBase with 7 core and UI rules', () {
+    test('createPlugin returns PluginBase with 10 core and UI rules', () {
       final plugin = createPlugin();
       expect(plugin, isA<PluginBase>());
 
       /// Ignore internal member usage for testing.
       // ignore: invalid_use_of_internal_member
       final rules = plugin.getLintRules(CustomLintConfigs.empty);
-      expect(rules, hasLength(7));
+      expect(rules, hasLength(10));
       expect(rules, contains(isA<AvoidDuplicateEventHandlers>()));
       expect(rules, contains(isA<RequireSuperOnEvent>()));
       expect(rules, contains(isA<AvoidStreamTransformersOnBlocSignal>()));
@@ -29,6 +32,9 @@ void main() {
         rules,
         contains(isA<PreferBlocSignalProviderReadInCallbacks>()),
       );
+      expect(rules, contains(isA<AvoidTopLevelBlocSignalInstances>()));
+      expect(rules, contains(isA<AvoidProvidingExistingInstanceWithCreate>()));
+      expect(rules, contains(isA<AvoidManualCloseOnProvidedBloc>()));
     });
   });
 
@@ -76,6 +82,31 @@ void main() {
       expect(
         rule.code.name,
         equals('prefer_bloc_signal_provider_read_in_callbacks'),
+      );
+    });
+
+    test('AvoidTopLevelBlocSignalInstances code is properly configured', () {
+      const rule = AvoidTopLevelBlocSignalInstances();
+      expect(
+        rule.code.name,
+        equals('avoid_top_level_bloc_signal_instances'),
+      );
+    });
+
+    test('AvoidProvidingExistingInstanceWithCreate code is properly configured',
+        () {
+      const rule = AvoidProvidingExistingInstanceWithCreate();
+      expect(
+        rule.code.name,
+        equals('avoid_providing_existing_instance_with_create'),
+      );
+    });
+
+    test('AvoidManualCloseOnProvidedBloc code is properly configured', () {
+      const rule = AvoidManualCloseOnProvidedBloc();
+      expect(
+        rule.code.name,
+        equals('avoid_manual_close_on_provided_bloc'),
       );
     });
   });

--- a/bloc_signals_lint/test/src/flutter_ui_rules_test.dart
+++ b/bloc_signals_lint/test/src/flutter_ui_rules_test.dart
@@ -126,6 +126,62 @@ class MyWidget {
         expect(watchInCallbacks, hasLength(1));
       },
     );
+
+    test(
+      'AvoidProvidingExistingInstanceWithCreate detects existing ref in create',
+      () {
+        const badCode = '''
+class MyWidget {
+  Widget build(dynamic context) {
+    return BlocSignalProvider(
+      create: (context) => myGlobalBloc,
+      child: Container(),
+    );
+  }
+}
+''';
+        final parseResult = parseString(content: badCode);
+        final existingRefCreates = <AstNode>[];
+
+        parseResult.unit.visitChildren(
+          _MethodInvocationVisitor((node) {
+            if (node.methodName.name == 'BlocSignalProvider') {
+              for (final arg in node.argumentList.arguments) {
+                if (arg is NamedExpression && arg.name.label.name == 'create') {
+                  existingRefCreates.add(node);
+                }
+              }
+            }
+          }),
+        );
+
+        expect(existingRefCreates, hasLength(1));
+      },
+    );
+
+    test('AvoidManualCloseOnProvidedBloc detects context.read().close()', () {
+      const badCode = '''
+void dispose(dynamic context) {
+  context.read<CounterBloc>().close();
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final manualCloses = <MethodInvocation>[];
+
+      parseResult.unit.visitChildren(
+        _MethodInvocationVisitor((node) {
+          if (node.methodName.name == 'close') {
+            final target = node.target;
+            if (target is MethodInvocation &&
+                target.methodName.name == 'read') {
+              manualCloses.add(node);
+            }
+          }
+        }),
+      );
+
+      expect(manualCloses, hasLength(1));
+    });
   });
 }
 

--- a/bloc_signals_lint/test/src/rules_test.dart
+++ b/bloc_signals_lint/test/src/rules_test.dart
@@ -173,6 +173,31 @@ void externalFunction(dynamic bloc) {
         expect(emitsOutsideClass, hasLength(1));
       },
     );
+
+    test(
+      'AvoidTopLevelBlocSignalInstances detects global top-level bloc declarations',
+      () {
+        const badCode = '''
+final counterBloc = CounterBloc();
+class Service {
+  static final authBloc = AuthBloc();
+}
+''';
+        final parseResult = parseString(content: badCode);
+        final globalVars = <String>[];
+
+        parseResult.unit.visitChildren(
+          _VariableVisitor((node) {
+            final name = node.name.lexeme;
+            if (name == 'counterBloc' || name == 'authBloc') {
+              globalVars.add(name);
+            }
+          }),
+        );
+
+        expect(globalVars, containsAll(['counterBloc', 'authBloc']));
+      },
+    );
   });
 }
 
@@ -197,5 +222,16 @@ class _SuperCallVisitor extends RecursiveAstVisitor<void> {
       onSuperCall();
     }
     super.visitMethodInvocation(node);
+  }
+}
+
+class _VariableVisitor extends RecursiveAstVisitor<void> {
+  _VariableVisitor(this.onVariable);
+  final void Function(VariableDeclaration node) onVariable;
+
+  @override
+  void visitVariableDeclaration(VariableDeclaration node) {
+    onVariable(node);
+    super.visitVariableDeclaration(node);
   }
 }

--- a/plugins/bloc-signals/skills/bloc-signals/lint.md
+++ b/plugins/bloc-signals/skills/bloc-signals/lint.md
@@ -16,6 +16,7 @@ All rules are **enabled by default** once `custom_lint` is configured in `analys
 | **`require_super_on_event`** | Warning | Enforces calling `super.onEvent(event)` inside `onEvent` overrides to preserve Zone event context. | `Cmd+.` -> Add `super.onEvent(event);` |
 | **`avoid_stream_transformers_on_bloc_signal`** | Warning | Flags stream transformer invocations (e.g. `.transform()`, `.debounce()`, `.switchMap()`) directly on synchronous `BlocSignalBase` instances. | — |
 | **`avoid_direct_signal_mutation_outside_bloc`** | Warning | Prevents external code outside the state container class from calling protected `emit()` or mutating internal signal state. | — |
+| **`avoid_top_level_bloc_signal_instances`** | Warning | Flags top-level variables and static fields declared directly as `BlocSignal` / `CubitSignal` instances. | — |
 
 ### Flutter UI Rules
 
@@ -24,6 +25,8 @@ All rules are **enabled by default** once `custom_lint` is configured in `analys
 | **`avoid_emit_in_build`** | Warning | Flags calls to `emit()` or `add()` on state containers directly inside Flutter `Widget.build()` methods. | — |
 | **`avoid_unmanaged_signal_effects`** | Warning | Flags unmanaged `effect()` calls created inside Flutter `Widget` or `State` methods without lifecycle cleanup. | — |
 | **`prefer_bloc_signal_provider_read_in_callbacks`** | Warning | Warns when `context.watch<T>()` is used inside event callback closures (e.g. `onPressed`), suggesting `context.read<T>()`. | `Cmd+.` -> Replace `watch` with `read` |
+| **`avoid_providing_existing_instance_with_create`** | Warning | Flags passing existing variable references to `BlocSignalProvider(create: ...)` instead of `BlocSignalProvider.value(value: ...)`. | — |
+| **`avoid_manual_close_on_provided_bloc`** | Warning | Flags calling `.close()` manually on state containers retrieved via `context.read<T>()` or `BlocSignalProvider.of(context)`. | — |
 
 ---
 


### PR DESCRIPTION
### ⚡ Summary

This PR adds 3 new static analysis lint rules to `bloc_signals_lint` to catch common state management footguns regarding global container declarations, `BlocSignalProvider` auto-disposal ownership traps, and manual container closures.

---

### 🛡️ New Rules Added

1. **`avoid_top_level_bloc_signal_instances`**:
   - Flags top-level variables and static fields declared directly as `BlocSignal` / `CubitSignal` instances (e.g. `final myBloc = MyBloc();`).
   - Prevents unmanaged `.close()` lifecycles, route unmount corruption, and unit test state pollution.
   - Allows top-level primitive signals (e.g. `final count = signal(0)`), getters, and functions.

2. **`avoid_providing_existing_instance_with_create`**:
   - Flags passing existing variable references to `BlocSignalProvider(create: (context) => myBloc)` instead of `BlocSignalProvider.value(value: myBloc)`.
   - Prevents `BlocSignalProvider` from calling `.close()` on unmount and permanently killing shared/global instances for the rest of the app lifetime.

3. **`avoid_manual_close_on_provided_bloc`**:
   - Flags calling `.close()` manually on state containers retrieved via `context.read<T>()` or `BlocSignalProvider.of(context)`.
   - Ensures container lifecycles remain automatically managed by `BlocSignalProvider`.

---

### 🧪 Verification
- Added AST integration tests for all 3 rules in `test/src/rules_test.dart` and `test/src/flutter_ui_rules_test.dart`.
- Updated `bloc_signals_lint` plugin entrypoint and metadata assertions (`24/24` tests passing).
- Updated `README.md` and AI agent skill bundle (`plugins/bloc-signals/skills/bloc-signals/lint.md`).
- Ran `dart run tool/validate_agent_plugin.dart` to confirm marketplace catalog & skill bundle integrity.