### PR TITLE
fix(test): configure test discovery paths & workspace runner (#79)

### DIFF
--- a/bloc_signals_test/dart_test.yaml
+++ b/bloc_signals_test/dart_test.yaml
@@ -1,0 +1,4 @@
+# Instruct package:test to only search the test/ directory for test files,
+# preventing lib/bloc_signals_test.dart from being scanned as a test suite.
+paths:
+  - test/

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,3 @@
+# Workspace-level test runner configuration for package:test
+paths:
+  - test/

--- a/test/workspace_test_discovery_test.dart
+++ b/test/workspace_test_discovery_test.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('Workspace Test Discovery (#79)', () {
+    test('dart_test.yaml exists in bloc_signals_test and restricts discovery to test/', () {
+      final configFile = File('bloc_signals_test/dart_test.yaml');
+      expect(configFile.existsSync(), isTrue);
+
+      final content = configFile.readAsStringSync();
+      expect(content, contains('paths:'));
+      expect(content, contains('test/'));
+    });
+
+    test('root dart_test.yaml exists and restricts test paths', () {
+      final configFile = File('dart_test.yaml');
+      expect(configFile.existsSync(), isTrue);
+
+      final content = configFile.readAsStringSync();
+      expect(content, contains('paths:'));
+      expect(content, contains('test/'));
+    });
+
+    test('tool/run_workspace_tests.dart exists and targets workspace packages', () {
+      final scriptFile = File('tool/run_workspace_tests.dart');
+      expect(scriptFile.existsSync(), isTrue);
+
+      final content = scriptFile.readAsStringSync();
+      expect(content, contains('bloc_signals'));
+      expect(content, contains('bloc_signals_test'));
+      expect(content, contains('bloc_signals_flutter'));
+    });
+  });
+}

--- a/tool/run_workspace_tests.dart
+++ b/tool/run_workspace_tests.dart
@@ -1,0 +1,56 @@
+import 'dart:io';
+
+/// Runs tests across all workspace packages in isolation to prevent
+/// path resolution and symbol compilation collisions.
+void main(List<String> args) {
+  final packages = [
+    '.', // Root workspace tests
+    'bloc_signals',
+    'bloc_signals_flutter',
+    'bloc_signals_otel',
+    'bloc_signals_test',
+    'bloc_signals_lint',
+    'bloc_signals_riverpod',
+    'bloc_signals_hydrate',
+    'bloc_signals_devtools',
+  ];
+
+  print('🧪 Running workspace tests across ${packages.length} targets...\n');
+
+  var failed = false;
+
+  for (final pkg in packages) {
+    final isFlutter = pkg == 'bloc_signals_flutter';
+    final executable = isFlutter ? 'flutter' : 'dart';
+    final commandArgs = ['test', ...args];
+
+    print('➡️ Running tests in $pkg ($executable test ${args.join(' ')})');
+
+    final process = Process.runSync(
+      executable,
+      commandArgs,
+      workingDirectory: Directory(pkg).absolute.path,
+    );
+
+    if (process.stdout.toString().isNotEmpty) {
+      stdout.write(process.stdout);
+    }
+    if (process.stderr.toString().isNotEmpty) {
+      stderr.write(process.stderr);
+    }
+
+    if (process.exitCode != 0) {
+      print('❌ Test failure in package $pkg');
+      failed = true;
+    } else {
+      print('✅ Passed package $pkg\n');
+    }
+  }
+
+  if (failed) {
+    print('💥 One or more package test suites failed.');
+    exit(1);
+  } else {
+    print('🎉 All workspace package tests passed successfully!');
+  }
+}


### PR DESCRIPTION
## Summary of Changes

- Added `bloc_signals_test/dart_test.yaml` and root `dart_test.yaml` configuring `paths: [test/]` to instruct `package:test` test discovery to ignore `lib/` files (resolving `lib/bloc_signals_test.dart` missing `main()` method load failure).
- Added `tool/run_workspace_tests.dart` script to execute workspace package tests in isolation per `AGENTS.md` rules.
- Added `test/workspace_test_discovery_test.dart` to verify test discovery configuration.

Fixes #79

---

## 🔍 Self-Critical Review

### 1. Intent
- **Problem Fixed**: Prevents test runner discovery from matching `bloc_signals_test/lib/bloc_signals_test.dart` as a test suite script (which previously failed due to missing `main()`).
- **Scope**: Surgical configuration (`dart_test.yaml`), workspace runner script (`tool/run_workspace_tests.dart`), and test verification. Zero piggybacking.

### 2. Verification
- **TDD Proof**: `test/workspace_test_discovery_test.dart` passes cleanly (`3/3 tests passed`).
- **Static Analysis**: `dart analyze` verified.

### 3. Architecture
- **Dart Workspace Rules**: Conforms to standard `package:test` configuration (`dart_test.yaml`).
- **Script Choice**: Uses Dart for `tool/run_workspace_tests.dart` (per user preference for Dart automation over Python).
- **Isolation**: Multi-package runner respects the *Testing Isolation* rule in `AGENTS.md`.

### 4. Blast Radius
- Zero runtime overhead or public API changes. Confined to test runner configuration and tooling scripts.

### 5. Reviewer Defense
- **Q**: Why create `dart_test.yaml` at both package and root level?
  - *A*: Package-level configuration protects `bloc_signals_test/` directly, while root `dart_test.yaml` ensures top-level workspace test discovery only scans `test/` subdirectories.
