### PR TITLE
feat(core): add baseline toString print-string on BlocSignalBase (#78)

### DIFF
--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -238,6 +238,9 @@ abstract class BlocSignalBase<StateType> {
     _lifecycleModel.dispose();
     BlocSignalObserver.observer?.onClose(this);
   }
+
+  @override
+  String toString() => '$runtimeType($stateValue)';
 }
 
 /// A clean base class for method-driven state management.

--- a/bloc_signals/test/tostring_test.dart
+++ b/bloc_signals/test/tostring_test.dart
@@ -1,0 +1,38 @@
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:test/test.dart';
+
+class TestCounterCubit extends CubitSignal<int> {
+  TestCounterCubit([int initial = 0]) : super(initialState: initial);
+
+  void increment() => emit(stateValue + 1);
+}
+
+class TestCounterBloc extends BlocSignal<String, int> {
+  TestCounterBloc([int initial = 0]) : super(initialState: initial) {
+    on<String>((event, emit) {
+      if (event == 'inc') {
+        emit(stateValue + 1);
+      }
+    });
+  }
+}
+
+void main() {
+  group('BlocSignalBase.toString() (#78)', () {
+    test('CubitSignal.toString() formats as ClassName(stateValue)', () {
+      final cubit = TestCounterCubit(0);
+      expect(cubit.toString(), equals('TestCounterCubit(0)'));
+
+      cubit.increment();
+      expect(cubit.toString(), equals('TestCounterCubit(1)'));
+    });
+
+    test('BlocSignal.toString() formats as ClassName(stateValue)', () {
+      final bloc = TestCounterBloc(10);
+      expect(bloc.toString(), equals('TestCounterBloc(10)'));
+
+      bloc.add('inc');
+      expect(bloc.toString(), equals('TestCounterBloc(11)'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary of Changes

- Implemented `@override String toString() => '$runtimeType($stateValue)';` on `BlocSignalBase`.
- Added unit tests in `bloc_signals/test/tostring_test.dart` verifying `toString()` formatting for `CubitSignal` and `BlocSignal` instances.

Fixes #78

---

## 🔍 Self-Critical Review

### 1. Intent
- **Problem Fixed**: Overrides default `Object.toString()` output (`Instance of 'CounterCubit'`) with informative string representation (`CounterCubit(0)`).
- **Scope**: `BlocSignalBase` implementation and dedicated unit test. Zero piggybacking.

### 2. Verification
- **TDD Proof**: `bloc_signals/test/tostring_test.dart` passes cleanly (`2/2 tests passed`).
- **Static Analysis & Formatting**: Verified clean via `dart analyze` and `dart format`.

### 3. Architecture
- **Alignment**: Standard BLoC / Signals diagnostic format (`$runtimeType($stateValue)`).
- **Inheritance Scoping**: Defined on `BlocSignalBase` to cover `CubitSignal`, `BlocSignal`, and custom derived containers.

### 4. Blast Radius
- Zero breaking changes to state signals or event dispatching. Only affects `toString()` output for printing/debugging.

### 5. Reviewer Defense
- **Q**: Why place `toString()` in `BlocSignalBase` instead of subclasses?
  - *A*: `BlocSignalBase` owns `stateValue`, ensuring single-source-of-truth implementation across all state container types.
