### PR TITLE
docs(riverpod): annotate src/internals import for Riverpod 2/3 (#80)

### DIFF
--- a/bloc_signals_riverpod/lib/src/riverpod_adapter.dart
+++ b/bloc_signals_riverpod/lib/src/riverpod_adapter.dart
@@ -1,4 +1,7 @@
 import 'package:bloc_signals/bloc_signals.dart';
+// `ProviderListenable` is exported via Riverpod's internal library entrypoint
+// (`package:riverpod/src/internals.dart`) for third-party adapter authors.
+// ignore: implementation_imports
 import 'package:riverpod/src/internals.dart'
     hide AsyncData, AsyncError, AsyncLoading;
 import 'package:signals_core/signals_core.dart';


### PR DESCRIPTION
## Summary of Changes

- Added `// ignore: implementation_imports` and explicit architectural doc comments to `bloc_signals_riverpod/lib/src/riverpod_adapter.dart` explaining why `package:riverpod/src/internals.dart` is imported to access `ProviderListenable` in Riverpod 3.x.
- Verified clean static analysis (`dart analyze`) and passing unit tests (`10/10 tests passed`).

Fixes #80

---

## 🔍 Self-Critical Review

### 1. Intent
- **Problem Fixed**: Clarified and annotated `package:riverpod/src/internals.dart` import in `bloc_signals_riverpod` with `// ignore: implementation_imports` and architectural documentation.
- **Scope**: Confined to import annotations in `lib/src/riverpod_adapter.dart`. Zero piggybacking.

### 2. Verification
- **Static Analysis**: `dart analyze` passes with 0 errors.
- **Unit Tests**: `dart test` passes (`10/10 tests passed`).

### 3. Architecture
- **Riverpod 2/3 Compatibility**: Preserves cross-version `ProviderListenable` bridging per Rule 9 in `AGENTS.md`.

### 4. Blast Radius
- Zero breaking API changes or runtime impact.

### 5. Reviewer Defense
- **Q**: Why keep `package:riverpod/src/internals.dart`?
  - *A*: Riverpod 3.x intentionally hides `ProviderListenable` from consumer entrypoints and directs framework authors to `src/internals.dart`.
