### PR TITLE
fix(lint): resolve line length and comment reference diagnostics (#90)

### DIFF
--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -129,8 +129,8 @@ abstract class BlocSignalBase<StateType> {
   /// Compares [previous] and [current] state to determine if state has changed.
   ///
   /// Equality Evaluation Precedence Order:
-  /// 1. `options.equality` *(highest priority if passed via [options])*
-  /// 2. [equals] constructor parameter or `@override bool equals(...)` method
+  /// 1. `options.equality` *(highest priority if passed via `options`)*
+  /// 2. `equals` constructor parameter or `@override bool equals(...)` method
   /// 3. Default value equality (`previous == current`)
   ///
   /// Subclasses can override this method or pass `equals: identical` to force

--- a/bloc_signals/test/tostring_test.dart
+++ b/bloc_signals/test/tostring_test.dart
@@ -20,7 +20,7 @@ class TestCounterBloc extends BlocSignal<String, int> {
 void main() {
   group('BlocSignalBase.toString() (#78)', () {
     test('CubitSignal.toString() formats as ClassName(stateValue)', () {
-      final cubit = TestCounterCubit(0);
+      final cubit = TestCounterCubit();
       expect(cubit.toString(), equals('TestCounterCubit(0)'));
 
       cubit.increment();

--- a/bloc_signals_lint/lib/src/rules/avoid_manual_close_on_provided_bloc.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_manual_close_on_provided_bloc.dart
@@ -14,9 +14,11 @@ class AvoidManualCloseOnProvidedBloc extends DartLintRule {
   static const _code = LintCode(
     name: 'avoid_manual_close_on_provided_bloc',
     problemMessage:
-        'Do not manually call close() on state containers managed by BlocSignalProvider.',
+        'Do not manually call close() on state containers managed by '
+        'BlocSignalProvider.',
     correctionMessage:
-        'Let BlocSignalProvider manage container disposal automatically when unmounted.',
+        'Let BlocSignalProvider manage container disposal automatically when '
+        'unmounted.',
   );
 
   @override

--- a/bloc_signals_lint/lib/src/rules/avoid_providing_existing_instance_with_create.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_providing_existing_instance_with_create.dart
@@ -6,7 +6,8 @@ import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 /// A lint rule that flags passing pre-existing variable references to
-/// `BlocSignalProvider(create: ...)` instead of `BlocSignalProvider.value(value: ...)`.
+/// `BlocSignalProvider(create: ...)` instead of
+/// `BlocSignalProvider.value(value: ...)`.
 class AvoidProvidingExistingInstanceWithCreate extends DartLintRule {
   /// Creates an [AvoidProvidingExistingInstanceWithCreate] lint rule.
   const AvoidProvidingExistingInstanceWithCreate() : super(code: _code);
@@ -17,7 +18,8 @@ class AvoidProvidingExistingInstanceWithCreate extends DartLintRule {
         'Passing an existing instance "{0}" to BlocSignalProvider(create: ...) '
         'will cause it to be automatically closed when unmounted.',
     correctionMessage:
-        'Use BlocSignalProvider.value(value: ...) to provide existing instances without transferring disposal ownership.',
+        'Use BlocSignalProvider.value(value: ...) to provide existing '
+        'instances without transferring disposal ownership.',
   );
 
   @override

--- a/bloc_signals_lint/lib/src/rules/avoid_top_level_bloc_signal_instances.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_top_level_bloc_signal_instances.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
 /// A lint rule that flags top-level variable and static field declarations
-/// initialized directly with [BlocSignalBase] instances.
+/// initialized directly with `BlocSignalBase` instances.
 class AvoidTopLevelBlocSignalInstances extends DartLintRule {
   /// Creates an [AvoidTopLevelBlocSignalInstances] lint rule.
   const AvoidTopLevelBlocSignalInstances() : super(code: _code);
@@ -14,9 +14,12 @@ class AvoidTopLevelBlocSignalInstances extends DartLintRule {
   static const _code = LintCode(
     name: 'avoid_top_level_bloc_signal_instances',
     problemMessage:
-        'Stateful container "{0}" should not be declared as a top-level or static variable.',
+        'Stateful container "{0}" should not be declared as a top-level or '
+        'static variable.',
     correctionMessage:
-        'Scope containers using BlocSignalProvider, dependency injection, or factory getters. Primitive signals (e.g. signal(0)) can remain global.',
+        'Scope containers using BlocSignalProvider, dependency injection, or '
+        'factory getters. Primitive signals (e.g. signal(0)) can remain '
+        'global.',
   );
 
   static const _blocSignalBaseChecker = TypeChecker.fromName(

--- a/bloc_signals_lint/test/src/rules_test.dart
+++ b/bloc_signals_lint/test/src/rules_test.dart
@@ -175,7 +175,8 @@ void externalFunction(dynamic bloc) {
     );
 
     test(
-      'AvoidTopLevelBlocSignalInstances detects global top-level bloc declarations',
+      'AvoidTopLevelBlocSignalInstances detects global top-level bloc '
+      'declarations',
       () {
         const badCode = '''
 final counterBloc = CounterBloc();


### PR DESCRIPTION
## Summary of Changes

- Fixed `lines_longer_than_80_chars` diagnostics in `bloc_signals_lint` rule files and test suite.
- Resolved `comment_references` diagnostics in `bloc_signals_base.dart` and `avoid_top_level_bloc_signal_instances.dart`.
- Removed redundant default argument in `tostring_test.dart`.
- Achieved a 100% zero-diagnostic clean pass (`Analyzing BlocSignal... No issues found!`).

Fixes #90

---

## 🔍 Self-Critical Review

### 1. Intent
- **Problem Fixed**: Resolved all 10 `dart analyze` info diagnostics (`lines_longer_than_80_chars`, `comment_references`, `avoid_redundant_argument_values`).
- **Scope**: Clean pass achieved (`No issues found!`). Zero piggybacking.

### 2. Verification
- **Static Analysis & Validation**: `dart analyze` reports **No issues found!**; `dart run tool/validate_agent_plugin.dart` passes.
- **Workspace Tests**: `dart run tool/run_workspace_tests.dart` passes cleanly across all packages.

### 3. Architecture
- Preserved all rule implementations and test assertions; edits were strictly formatting, doc string reference fixes, and string wrapping.

### 4. Blast Radius
- Zero runtime code changes or API contract modifications.

### 5. Reviewer Defense
- **Q**: Did string wrapping change any lint error message content?
  - *A*: No, Dart adjacent string literals (`'a ' 'b'`) concatenate identically at compile-time.
