### PR TITLE
feat(hydrate): Add SharedPreferences and SecureStorage adapters (#114)

### DIFF
--- a/bloc_signals_hydrate/README.md
+++ b/bloc_signals_hydrate/README.md
@@ -115,39 +115,42 @@ class CounterCubit extends HydratedCubitSignal<int> {
 }
 ```
 
-### 4. Wiring Custom Storage (`SharedPreferences`)
+### 4. Built-in Storage Adapters (`SharedPreferences` & `FlutterSecureStorage`)
 
+`package:bloc_signals_hydrate` provides pre-built, tree-shakable adapters for `SharedPreferences` and `FlutterSecureStorage` via sub-library entrypoints:
+
+#### `SharedPreferences`
 ```dart
-import 'dart:convert';
 import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:bloc_signals_hydrate/shared_preferences.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class SharedPreferencesHydratedStorage implements HydratedStorage {
-  SharedPreferencesHydratedStorage(this.prefs);
-  final SharedPreferences prefs;
-
-  @override
-  dynamic read(String key) {
-    final value = prefs.getString(key);
-    return value != null ? jsonDecode(value) : null;
-  }
-
-  @override
-  Future<void> write(String key, dynamic value) async =>
-      prefs.setString(key, jsonEncode(value));
-
-  @override
-  Future<void> delete(String key) async => prefs.remove(key);
-
-  @override
-  Future<void> clear() async => prefs.clear();
-}
-
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
   HydratedStorage.storage = SharedPreferencesHydratedStorage(prefs);
+
+  runApp(const MyApp());
 }
 ```
+
+#### `FlutterSecureStorage` (Keychain / KeyStore / Web Crypto)
+```dart
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:bloc_signals_hydrate/secure_storage.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  
+  // Pre-load secure storage map for synchronous frame 1 hydration
+  final secureStorage = const FlutterSecureStorage();
+  HydratedStorage.storage = await SecureHydratedStorage.build(secureStorage);
+
+  runApp(const MyApp());
+}
+```
+
 
 ---
 

--- a/bloc_signals_hydrate/lib/secure_storage.dart
+++ b/bloc_signals_hydrate/lib/secure_storage.dart
@@ -1,0 +1,4 @@
+/// Secure state persistence adapter for `bloc_signals_hydrate`.
+library;
+
+export 'src/secure_hydrated_storage.dart';

--- a/bloc_signals_hydrate/lib/shared_preferences.dart
+++ b/bloc_signals_hydrate/lib/shared_preferences.dart
@@ -1,0 +1,4 @@
+/// SharedPreferences state persistence adapter for `bloc_signals_hydrate`.
+library;
+
+export 'src/shared_preferences_hydrated_storage.dart';

--- a/bloc_signals_hydrate/lib/src/secure_hydrated_storage.dart
+++ b/bloc_signals_hydrate/lib/src/secure_hydrated_storage.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:bloc_signals_hydrate/src/hydrated_storage.dart';
+
+/// A [HydratedStorage] backend implementation that persists state using
+/// secure key-value storage (such as `FlutterSecureStorage`).
+///
+/// Pre-loads all stored key-value pairs into an in-memory cache during [build]
+/// so that subsequent read requests are returned **synchronously on frame 1**
+/// without UI flickers.
+///
+/// Example:
+/// ```dart
+/// import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+/// import 'package:bloc_signals_hydrate/secure_storage.dart';
+/// import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+///
+/// void main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///   final secureStorage = const FlutterSecureStorage();
+///   HydratedStorage.storage = await SecureHydratedStorage.build(secureStorage);
+///
+///   runApp(const MyApp());
+/// }
+/// ```
+class SecureHydratedStorage implements HydratedStorage {
+  SecureHydratedStorage._(this._secureStorage, Map<String, String> initialCache)
+      : _cache = Map<String, dynamic>.from(
+          initialCache.map((key, value) {
+            try {
+              return MapEntry(key, jsonDecode(value));
+            } on Object {
+              return MapEntry(key, value);
+            }
+          }),
+        );
+
+  final dynamic _secureStorage;
+  final Map<String, dynamic> _cache;
+
+  /// Asynchronously pre-loads stored keys from [secureStorage] into memory,
+  /// returning a fully initialized [SecureHydratedStorage] ready for
+  /// synchronous frame 1 state hydration.
+  static Future<SecureHydratedStorage> build(dynamic secureStorage) async {
+    final dynamic rawAll = await secureStorage.readAll();
+    final Map<String, String> all = Map<String, String>.from(
+      (rawAll as Map).map((k, v) => MapEntry(k.toString(), v.toString())),
+    );
+    return SecureHydratedStorage._(secureStorage, all);
+  }
+
+  @override
+  dynamic read(String key) => _cache[key];
+
+  @override
+  FutureOr<void> write(String key, dynamic value) async {
+    _cache[key] = value;
+    final String encoded = jsonEncode(value);
+    await _secureStorage.write(key: key, value: encoded);
+  }
+
+  @override
+  FutureOr<void> delete(String key) async {
+    _cache.remove(key);
+    await _secureStorage.delete(key: key);
+  }
+
+  @override
+  FutureOr<void> clear() async {
+    _cache.clear();
+    await _secureStorage.deleteAll();
+  }
+}

--- a/bloc_signals_hydrate/lib/src/shared_preferences_hydrated_storage.dart
+++ b/bloc_signals_hydrate/lib/src/shared_preferences_hydrated_storage.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:bloc_signals_hydrate/src/hydrated_storage.dart';
+
+/// A [HydratedStorage] backend implementation that persists state using
+/// `SharedPreferences` (from `package:shared_preferences`).
+///
+/// Example:
+/// ```dart
+/// import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+/// import 'package:bloc_signals_hydrate/shared_preferences.dart';
+/// import 'package:shared_preferences/shared_preferences.dart';
+///
+/// void main() async {
+///   WidgetsFlutterBinding.ensureInitialized();
+///   final prefs = await SharedPreferences.getInstance();
+///   HydratedStorage.storage = SharedPreferencesHydratedStorage(prefs);
+///
+///   runApp(const MyApp());
+/// }
+/// ```
+class SharedPreferencesHydratedStorage implements HydratedStorage {
+  /// Creates a [SharedPreferencesHydratedStorage] adapter wrapping [prefs].
+  const SharedPreferencesHydratedStorage(this._prefs);
+
+  final dynamic _prefs;
+
+  @override
+  dynamic read(String key) {
+    try {
+      final dynamic value = _prefs.getString(key);
+      if (value == null || value is! String) return null;
+      try {
+        return jsonDecode(value);
+      } on Object {
+        return value;
+      }
+    } on Object {
+      return null;
+    }
+  }
+
+  @override
+  FutureOr<void> write(String key, dynamic value) async {
+    final String encoded = jsonEncode(value);
+    await _prefs.setString(key, encoded);
+  }
+
+  @override
+  FutureOr<void> delete(String key) async {
+    await _prefs.remove(key);
+  }
+
+  @override
+  FutureOr<void> clear() async {
+    await _prefs.clear();
+  }
+}

--- a/bloc_signals_hydrate/test/secure_hydrated_storage_test.dart
+++ b/bloc_signals_hydrate/test/secure_hydrated_storage_test.dart
@@ -1,0 +1,99 @@
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:bloc_signals_hydrate/secure_storage.dart';
+import 'package:test/test.dart';
+
+class FakeFlutterSecureStorage {
+  final Map<String, String> _storage = {};
+
+  Future<Map<String, String>> readAll() async => Map.from(_storage);
+
+  Future<String?> read({required String key}) async => _storage[key];
+
+  Future<void> write({required String key, required String value}) async {
+    _storage[key] = value;
+  }
+
+  Future<void> delete({required String key}) async {
+    _storage.remove(key);
+  }
+
+  Future<void> deleteAll() async {
+    _storage.clear();
+  }
+}
+
+class TestAuthTokenCubit extends HydratedCubitSignal<String?> {
+  TestAuthTokenCubit({super.storage}) : super(initialState: null);
+
+  void setToken(String token) => emit(token);
+}
+
+void main() {
+  late FakeFlutterSecureStorage secureStorage;
+
+  setUp(() {
+    secureStorage = FakeFlutterSecureStorage();
+  });
+
+  group('SecureHydratedStorage', () {
+    test('pre-loads existing storage values via build()', () async {
+      await secureStorage.write(key: 'auth_token', value: '"secret_jwt_token"');
+      await secureStorage.write(key: 'user_id', value: '12345');
+      await secureStorage.write(key: 'raw_string', value: 'not_json_string');
+
+      final storage = await SecureHydratedStorage.build(secureStorage);
+
+      expect(storage.read('auth_token'), equals('secret_jwt_token'));
+      expect(storage.read('user_id'), equals(12345));
+      expect(storage.read('raw_string'), equals('not_json_string'));
+    });
+
+    test('synchronously reads and asynchronously writes new values', () async {
+      final storage = await SecureHydratedStorage.build(secureStorage);
+
+      await storage.write('session_key', 'abc-987');
+      expect(storage.read('session_key'), equals('abc-987'));
+
+      final storedValue = await secureStorage.read(key: 'session_key');
+      expect(storedValue, equals('"abc-987"'));
+    });
+
+    test('handles delete and clear across cache and underlying secure storage',
+        () async {
+      final storage = await SecureHydratedStorage.build(secureStorage);
+
+      await storage.write('k1', 'v1');
+      await storage.write('k2', 'v2');
+
+      await storage.delete('k1');
+      expect(storage.read('k1'), isNull);
+      expect(await secureStorage.read(key: 'k1'), isNull);
+      expect(storage.read('k2'), equals('v2'));
+
+      await storage.clear();
+      expect(storage.read('k2'), isNull);
+      expect(await secureStorage.readAll(), isEmpty);
+    });
+
+    test(
+        'integrates seamlessly with HydratedCubitSignal for zero-flicker reads',
+        () async {
+      await secureStorage.write(
+        key: 'TestAuthTokenCubit',
+        value: '"pre_existing_session_token"',
+      );
+
+      final storage = await SecureHydratedStorage.build(secureStorage);
+      final cubit = TestAuthTokenCubit(storage: storage);
+
+      expect(cubit.stateValue, equals('pre_existing_session_token'));
+
+      cubit.setToken('new_updated_token');
+      expect(cubit.stateValue, equals('new_updated_token'));
+
+      final updatedInSecureStorage =
+          await secureStorage.read(key: 'TestAuthTokenCubit');
+      expect(updatedInSecureStorage, equals('"new_updated_token"'));
+    });
+  });
+}

--- a/bloc_signals_hydrate/test/shared_preferences_hydrated_storage_test.dart
+++ b/bloc_signals_hydrate/test/shared_preferences_hydrated_storage_test.dart
@@ -1,0 +1,102 @@
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:bloc_signals_hydrate/shared_preferences.dart';
+import 'package:test/test.dart';
+
+class FakeSharedPreferences {
+  final Map<String, String> _storage = {};
+
+  String? getString(String key) => _storage[key];
+
+  Future<bool> setString(String key, String value) async {
+    _storage[key] = value;
+    return true;
+  }
+
+  Future<bool> remove(String key) async {
+    _storage.remove(key);
+    return true;
+  }
+
+  Future<bool> clear() async {
+    _storage.clear();
+    return true;
+  }
+}
+
+class TestCounterCubit extends HydratedCubitSignal<int> {
+  TestCounterCubit({super.storage}) : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+}
+
+class TestListCubit extends HydratedCubitSignal<List<String>> {
+  TestListCubit({super.storage}) : super(initialState: const []);
+
+  void add(String item) => emit([...stateValue, item]);
+}
+
+void main() {
+  late FakeSharedPreferences prefs;
+  late SharedPreferencesHydratedStorage storage;
+
+  setUp(() {
+    prefs = FakeSharedPreferences();
+    storage = SharedPreferencesHydratedStorage(prefs);
+  });
+
+  group('SharedPreferencesHydratedStorage', () {
+    test('reads and writes primitive values', () async {
+      await storage.write('counter', 42);
+      expect(storage.read('counter'), equals(42));
+      expect(prefs.getString('counter'), equals('42'));
+    });
+
+    test('reads and writes collections (lists & maps)', () async {
+      await storage.write('items', ['apple', 'banana']);
+      expect(storage.read('items'), equals(['apple', 'banana']));
+
+      await storage.write('scores', {'Alice': 100});
+      expect(storage.read('scores'), equals({'Alice': 100}));
+    });
+
+    test('deletes values correctly', () async {
+      await storage.write('key', 'value');
+      expect(storage.read('key'), equals('value'));
+
+      await storage.delete('key');
+      expect(storage.read('key'), isNull);
+      expect(prefs.getString('key'), isNull);
+    });
+
+    test('clears all storage', () async {
+      await storage.write('k1', 'v1');
+      await storage.write('k2', 'v2');
+
+      await storage.clear();
+      expect(storage.read('k1'), isNull);
+      expect(storage.read('k2'), isNull);
+    });
+
+    test('handles exceptions and non-json raw strings gracefully in read()',
+        () async {
+      final throwingPrefs = _ThrowingSharedPreferences();
+      final throwingStorage = SharedPreferencesHydratedStorage(throwingPrefs);
+      expect(throwingStorage.read('key'), isNull);
+    });
+
+    test('integrates seamlessly with HydratedCubitSignal', () async {
+      prefs.setString('TestCounterCubit', '10');
+
+      final cubit = TestCounterCubit(storage: storage);
+      expect(cubit.stateValue, equals(10));
+
+      cubit.increment();
+      expect(cubit.stateValue, equals(11));
+      expect(prefs.getString('TestCounterCubit'), equals('11'));
+    });
+  });
+}
+
+class _ThrowingSharedPreferences {
+  String? getString(String key) => throw Exception('Storage failure');
+}

--- a/examples/persist_shared_preferences/lib/main.dart
+++ b/examples/persist_shared_preferences/lib/main.dart
@@ -9,7 +9,9 @@ library;
 
 import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
 import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:bloc_signals_hydrate/shared_preferences.dart';
 import 'package:flutter/material.dart';
+
 
 // =============================================================================
 // 1. ThemeCubit Implementation


### PR DESCRIPTION
Resolves #114

### Summary of Changes
- Added built-in `SharedPreferencesHydratedStorage` adapter in `lib/src/shared_preferences_hydrated_storage.dart` exported via dedicated sub-library `import 'package:bloc_signals_hydrate/shared_preferences.dart';`.
- Added built-in `SecureHydratedStorage` adapter in `lib/src/secure_hydrated_storage.dart` with `SecureHydratedStorage.build(secureStorage)` pre-loading for synchronous frame 1 hydration, exported via `import 'package:bloc_signals_hydrate/secure_storage.dart';`.
- Retained 100% pure Dart package compatibility for `bloc_signals_hydrate` (`pubspec.yaml` contains no Flutter dependencies).
- Added comprehensive unit tests in `test/shared_preferences_hydrated_storage_test.dart` and `test/secure_hydrated_storage_test.dart`.
- Updated `examples/persist_shared_preferences` and package README documentation.

### Self-Critical Review
## 1. Intent
- **Requirement**: Provide zero-boilerplate, pre-built storage adapters for `SharedPreferences` and `FlutterSecureStorage` as part of `package:bloc_signals_hydrate`.
- **Fulfillment**: Implemented `SharedPreferencesHydratedStorage` and `SecureHydratedStorage` as pure Dart adapters behind dedicated sub-library entrypoints.

## 2. Verification
- All 21 unit tests in `bloc_signals_hydrate` and widget tests in `examples/persist_shared_preferences` pass cleanly (`dart test`, `flutter test`).

## 3. Architecture
- **Pure Dart & Tree-Shaking Isolation**: Adapters use dynamic duck-typing for storage instances (`SharedPreferences` and `FlutterSecureStorage`), keeping `pubspec.yaml` free of Flutter dependencies.
- Sub-library exports (`lib/shared_preferences.dart`, `lib/secure_storage.dart`) allow full compiler tree-shaking for projects that do not use these specific storage backends.

## 4. Blast Radius
- Purely additive sub-library exports in `package:bloc_signals_hydrate`. Zero breaking changes.

## 5. Reviewer Defense
- **Q: Why separate sub-library entrypoints?**
  - **A**: Isolating them to `package:bloc_signals_hydrate/shared_preferences.dart` and `package:bloc_signals_hydrate/secure_storage.dart` ensures strict modularity and enables Dart tree-shaking so applications only compile the storage adapters they explicitly import.
