### PR TITLE
feat(hydrate): Add debug fallback and diagnostics for HydratedStorage (#116)

### DIFF
--- a/bloc_signals_hydrate/lib/src/hydrated_storage.dart
+++ b/bloc_signals_hydrate/lib/src/hydrated_storage.dart
@@ -14,8 +14,41 @@ abstract class HydratedStorage {
   /// Abstract const constructor for [HydratedStorage] subclasses.
   const HydratedStorage();
 
+  static HydratedStorage? _storage;
+
   /// The global default [HydratedStorage] instance used across hydrated blocs.
-  static HydratedStorage? storage;
+  ///
+  /// In debug mode (when assertions are enabled), if accessed while uninitialized,
+  /// this getter lazily falls back to a [MemoryHydratedStorage] instance and prints
+  /// a diagnostic warning so unit tests and prototypes work without boilerplate setup.
+  static HydratedStorage? get storage {
+    if (_storage == null) {
+      assert(() {
+        _storage = MemoryHydratedStorage();
+        // Print diagnostic guidance for developers
+        print(
+          '[bloc_signals_hydrate] HydratedStorage.storage was accessed before initialization.\n'
+          'Falling back to MemoryHydratedStorage for testing/debugging.\n'
+          'Make sure to set HydratedStorage.storage in main() before running in production.',
+        );
+        return true;
+      }());
+    }
+    return _storage;
+  }
+
+  /// Sets the global default storage backend.
+  static set storage(HydratedStorage? value) {
+    _storage = value;
+  }
+
+  /// Returns whether a global default [HydratedStorage] instance is currently set.
+  static bool get isInitialized => _storage != null;
+
+  /// Resets global default storage to uninitialized state (useful for test tearDown).
+  static void reset() {
+    _storage = null;
+  }
 
   /// Reads value associated with [key] from storage.
   dynamic read(String key);

--- a/bloc_signals_hydrate/test/hydrated_storage_uninitialized_test.dart
+++ b/bloc_signals_hydrate/test/hydrated_storage_uninitialized_test.dart
@@ -1,0 +1,51 @@
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:test/test.dart';
+
+class TestUninitializedCubit extends HydratedCubitSignal<int> {
+  TestUninitializedCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+}
+
+void main() {
+  tearDown(() {
+    HydratedStorage.reset();
+  });
+
+  group('HydratedStorage Uninitialized Fallback & Helpers', () {
+    test('isInitialized returns false when storage is uninitialized', () {
+      expect(HydratedStorage.isInitialized, isFalse);
+    });
+
+    test('lazily falls back to MemoryHydratedStorage when accessed while null',
+        () {
+      expect(HydratedStorage.isInitialized, isFalse);
+
+      final storage = HydratedStorage.storage;
+
+      expect(storage, isA<MemoryHydratedStorage>());
+      expect(HydratedStorage.isInitialized, isTrue);
+    });
+
+    test('instantiates HydratedCubitSignal without setting storage explicitly',
+        () {
+      expect(HydratedStorage.isInitialized, isFalse);
+
+      final cubit = TestUninitializedCubit();
+      expect(cubit.stateValue, equals(0));
+
+      cubit.increment();
+      expect(cubit.stateValue, equals(1));
+      expect(
+          HydratedStorage.storage!.read('TestUninitializedCubit'), equals(1));
+    });
+
+    test('reset() restores storage to uninitialized state', () {
+      HydratedStorage.storage = MemoryHydratedStorage();
+      expect(HydratedStorage.isInitialized, isTrue);
+
+      HydratedStorage.reset();
+      expect(HydratedStorage.isInitialized, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Resolves #116

### Summary of Changes
- Updated `HydratedStorage.storage` to lazily fall back to `MemoryHydratedStorage()` inside an assertion block when accessed while uninitialized in debug/testing mode.
- Printed a clear, actionable diagnostic warning in debug mode instructing developers to configure production storage in `main()`.
- Added `HydratedStorage.isInitialized` getter to inspect storage initialization state.
- Added `HydratedStorage.reset()` helper for test tearDowns.
- Preserved 100% production tree-shaking for release builds by keeping the fallback inside an `assert` block.
- Added comprehensive unit tests in `test/hydrated_storage_uninitialized_test.dart`.

### Self-Critical Review
## 1. Intent
- **Requirement**: Fall back to `MemoryHydratedStorage` or provide clear diagnostic when `HydratedStorage.storage` is uninitialized.
- **Fulfillment**: Implemented assertion-backed lazy fallback and diagnostic message in `HydratedStorage.storage` getter, plus `isInitialized` and `reset()`.

## 2. Verification
- All 25 unit tests in `bloc_signals_hydrate` pass green (`dart test`).

## 3. Architecture
- **Production Tree-Shaking**: Enclosed fallback inside `assert(() { ... return true; }())`. Stripped out completely during release compilation.

## 4. Blast Radius
- Zero breaking changes. Existing explicit storage configurations work identically.
