### PR TITLE
feat(website): implement docs hub phase 1 shell, responsive layout, and getting started guides (#167)

### DIFF
--- a/tool/run_workspace_tests.dart
+++ b/tool/run_workspace_tests.dart
@@ -7,12 +7,15 @@ void main(List<String> args) {
     '.', // Root workspace tests
     'bloc_signals',
     'bloc_signals_flutter',
+    'bloc_signals_jaspr',
+    'bloc_signals_replay',
     'bloc_signals_otel',
     'bloc_signals_test',
     'bloc_signals_lint',
     'bloc_signals_riverpod',
     'bloc_signals_hydrate',
     'bloc_signals_devtools',
+    'website',
   ];
 
   print('🧪 Running workspace tests across ${packages.length} targets...\n');

--- a/website/dart_test.yaml
+++ b/website/dart_test.yaml
@@ -1,0 +1,2 @@
+platforms:
+  - chrome

--- a/website/lib/src/components/docs/docs_callout.dart
+++ b/website/lib/src/components/docs/docs_callout.dart
@@ -1,0 +1,35 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+enum CalloutType(
+  final String icon,
+  final String defaultTitle,
+  final String cssClass,
+) {
+  note('📝', 'Note', 'callout-note'),
+  tip('💡', 'Tip', 'callout-tip'),
+  important('⚡', 'Important', 'callout-important'),
+  warning('⚠️', 'Warning', 'callout-warning'),
+  caution('🛑', 'Caution', 'callout-caution');
+}
+
+/// A styled GitHub-like callout box for documentation.
+class const DocsCallout({
+  required final CalloutType type,
+  final String? title,
+  required final List<Component> children,
+  super.key,
+}) extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    return div(classes: 'docs-callout ${type.cssClass}', [
+      div(classes: 'docs-callout-header', [
+        span(classes: 'docs-callout-icon', [Component.text(type.icon)]),
+        span(classes: 'docs-callout-title', [
+          Component.text(title ?? type.defaultTitle),
+        ]),
+      ]),
+      div(classes: 'docs-callout-body', children),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/docs_code_block.dart
+++ b/website/lib/src/components/docs/docs_code_block.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+/// A code block component with syntax header, copy button, and optional side-by-side tabs.
+class const DocsCodeBlock({
+  final String? title,
+  final String? code,
+  final String? dart35Code,
+  final String? dart313Code,
+  final String language = 'dart',
+  super.key,
+}) extends StatefulComponent {
+  @override
+  State<DocsCodeBlock> createState() => _DocsCodeBlockState();
+}
+
+class _DocsCodeBlockState() extends State<DocsCodeBlock> {
+  bool _copied = false;
+  Timer? _copyTimer;
+  String _activeTab = '3.13'; // '3.13' or '3.5'
+
+  String get _currentCode {
+    if (component.code != null) return component.code!;
+    if (_activeTab == '3.13' && component.dart313Code != null) {
+      return component.dart313Code!;
+    }
+    return component.dart35Code ?? component.dart313Code ?? '';
+  }
+
+  void _copyToClipboard() {
+    try {
+      web.window.navigator.clipboard.writeText(_currentCode);
+      setState(() {
+        _copied = true;
+      });
+      _copyTimer?.cancel();
+      _copyTimer = Timer(const Duration(seconds: 2), () {
+        if (mounted) {
+          setState(() {
+            _copied = false;
+          });
+        }
+      });
+    } catch (_) {}
+  }
+
+  @override
+  void dispose() {
+    _copyTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final hasDualVersions =
+        component.dart35Code != null && component.dart313Code != null;
+
+    return div(classes: 'docs-code-container', [
+      div(classes: 'docs-code-header', [
+        div(classes: 'docs-code-title-group', [
+          if (component.title != null) ...[
+            span(classes: 'docs-code-file-icon', [Component.text('📄')]),
+            span(classes: 'docs-code-filename', [
+              Component.text(component.title!),
+            ]),
+          ] else ...[
+            span(classes: 'docs-code-lang-badge', [
+              Component.text(component.language.toUpperCase()),
+            ]),
+          ],
+        ]),
+        div(classes: 'docs-code-actions', [
+          if (hasDualVersions) ...[
+            div(classes: 'docs-version-tabs', [
+              button(
+                classes:
+                    'docs-version-tab ${_activeTab == "3.13" ? "active" : ""}',
+                onClick: () {
+                  setState(() {
+                    _activeTab = '3.13';
+                  });
+                },
+                [Component.text('Dart 3.13+ (Modern)')],
+              ),
+              button(
+                classes:
+                    'docs-version-tab ${_activeTab == "3.5" ? "active" : ""}',
+                onClick: () {
+                  setState(() {
+                    _activeTab = '3.5';
+                  });
+                },
+                [Component.text('Dart 3.5 (Baseline)')],
+              ),
+            ]),
+          ],
+          button(
+            classes: 'docs-copy-btn ${_copied ? "copied" : ""}',
+            onClick: _copyToClipboard,
+            attributes: {'aria-label': 'Copy code to clipboard'},
+            [
+              span(classes: 'docs-copy-icon', [
+                Component.text(_copied ? '✓' : '📋'),
+              ]),
+              span(classes: 'docs-copy-text', [
+                Component.text(_copied ? 'Copied!' : 'Copy'),
+              ]),
+            ],
+          ),
+        ]),
+      ]),
+      pre(classes: 'docs-code-body', [
+        code(classes: 'language-${component.language}', [
+          Component.text(_currentCode),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/docs_content.dart
+++ b/website/lib/src/components/docs/docs_content.dart
@@ -1,0 +1,128 @@
+import 'package:bloc_signals_jaspr/bloc_signals_jaspr.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../cubits/docs_cubit.dart';
+import '../../models/docs_models.dart';
+import '../../models/docs_registry.dart';
+import 'docs_toc.dart';
+import 'pages/docs_installation.dart';
+import 'pages/docs_overview.dart';
+import 'pages/docs_quickstart.dart';
+
+/// The central content viewer for the documentation hub.
+class const DocsContent({super.key}) extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    return BlocSignalBuilder<DocsCubit, DocsState>(
+      builder: (context, state) {
+        final currentSection = DocsRegistry.resolveSection(
+          state.activeSectionId,
+        );
+        final (prevSection, nextSection) = DocsRegistry.getAdjacentSections(
+          state.activeSectionId,
+        );
+        final cubit = context.read<DocsCubit>();
+
+        // Extract TOC headings based on active section
+        final headings = _getHeadingsForSection(state.activeSectionId);
+        final sourcePath = _getSourcePathForSection(state.activeSectionId);
+
+        return div(classes: 'docs-content-layout', [
+          // Mobile Docs Navigation Bar
+          div(classes: 'docs-mobile-bar', [
+            button(
+              classes: 'docs-mobile-menu-btn',
+              onClick: () => cubit.toggleMobileDrawer(),
+              attributes: {'aria-label': 'Open documentation menu'},
+              [
+                span(classes: 'mobile-menu-icon', [Component.text('☰')]),
+                span(classes: 'mobile-menu-text', [Component.text('Menu')]),
+              ],
+            ),
+            div(classes: 'docs-mobile-breadcrumbs', [
+              span(classes: 'crumb-category', [
+                Component.text(currentSection.category),
+              ]),
+              span(classes: 'crumb-separator', [Component.text(' / ')]),
+              span(classes: 'crumb-title', [
+                Component.text(currentSection.title),
+              ]),
+            ]),
+          ]),
+
+          // Main Article Container
+          main_(classes: 'docs-main-container', [
+            currentSection.builder(),
+
+            // Footer Pagination (Previous / Next Article)
+            div(classes: 'docs-pagination', [
+              if (prevSection != null)
+                a(
+                  href: prevSection.path,
+                  classes: 'docs-pager-btn prev',
+                  onClick: () => cubit.selectSection(prevSection.id),
+                  [
+                    span(classes: 'pager-direction', [
+                      Component.text('← Previous'),
+                    ]),
+                    span(classes: 'pager-title', [
+                      Component.text(prevSection.title),
+                    ]),
+                  ],
+                )
+              else
+                div(classes: 'docs-pager-spacer', []),
+
+              if (nextSection != null)
+                a(
+                  href: nextSection.path,
+                  classes: 'docs-pager-btn next',
+                  onClick: () => cubit.selectSection(nextSection.id),
+                  [
+                    span(classes: 'pager-direction', [
+                      Component.text('Next →'),
+                    ]),
+                    span(classes: 'pager-title', [
+                      Component.text(nextSection.title),
+                    ]),
+                  ],
+                ),
+            ]),
+          ]),
+
+          // Right Table of Contents (TOC)
+          aside(classes: 'docs-toc-container', [
+            DocsToc(headings: headings, sourcePath: sourcePath),
+          ]),
+        ]);
+      },
+    );
+  }
+
+  static List<TocHeading> _getHeadingsForSection(String sectionId) {
+    switch (sectionId) {
+      case 'overview':
+        return DocsOverviewPage.headings;
+      case 'installation':
+        return DocsInstallationPage.headings;
+      case 'quickstart':
+        return DocsQuickstartPage.headings;
+      default:
+        return const [];
+    }
+  }
+
+  static String _getSourcePathForSection(String sectionId) {
+    switch (sectionId) {
+      case 'overview':
+        return 'website/lib/src/components/docs/pages/docs_overview.dart';
+      case 'installation':
+        return 'website/lib/src/components/docs/pages/docs_installation.dart';
+      case 'quickstart':
+        return 'website/lib/src/components/docs/pages/docs_quickstart.dart';
+      default:
+        return 'website/lib/src/models/docs_registry.dart';
+    }
+  }
+}

--- a/website/lib/src/components/docs/docs_sidebar.dart
+++ b/website/lib/src/components/docs/docs_sidebar.dart
@@ -1,0 +1,145 @@
+import 'package:bloc_signals_jaspr/bloc_signals_jaspr.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../cubits/docs_cubit.dart';
+import '../../models/docs_models.dart';
+import '../../models/docs_registry.dart';
+
+/// The reactive navigation sidebar for the documentation hub.
+class const DocsSidebar({super.key}) extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    return BlocSignalBuilder<DocsCubit, DocsState>(
+      builder: (context, state) {
+        final query = state.searchQuery.trim().toLowerCase();
+        final cubit = context.read<DocsCubit>();
+
+        // Filter categories & sections based on search
+        final displayedCategories = <DocCategory>[];
+        for (final cat in DocsRegistry.categories) {
+          final matchingSections = query.isEmpty
+              ? cat.sections
+              : cat.sections.where((sec) {
+                  return sec.title.toLowerCase().contains(query) ||
+                      sec.description.toLowerCase().contains(query);
+                }).toList();
+
+          if (matchingSections.isNotEmpty) {
+            displayedCategories.add(
+              DocCategory(
+                title: cat.title,
+                icon: cat.icon,
+                sections: matchingSections,
+              ),
+            );
+          }
+        }
+
+        return aside(classes: 'docs-sidebar', [
+          // Search Input
+          div(classes: 'docs-search-box', [
+            span(classes: 'docs-search-icon', [Component.text('🔍')]),
+            input(
+              type: InputType.text,
+              classes: 'docs-search-input',
+              value: state.searchQuery,
+              onInput: cubit.updateSearch,
+              attributes: {
+                'placeholder': 'Search documentation...',
+                'aria-label': 'Search documentation',
+              },
+            ),
+            if (state.searchQuery.isNotEmpty)
+              button(
+                classes: 'docs-search-clear',
+                onClick: () => cubit.updateSearch(''),
+                [Component.text('✕')],
+              ),
+          ]),
+
+          // Category Navigation Tree
+          nav(classes: 'docs-nav-tree', [
+            if (displayedCategories.isEmpty) ...[
+              div(classes: 'docs-nav-empty', [
+                p([Component.text('No matching topics found for "$query"')]),
+                button(
+                  classes: 'btn-clear-search',
+                  onClick: () => cubit.updateSearch(''),
+                  [Component.text('Clear search')],
+                ),
+              ]),
+            ] else ...[
+              for (final cat in displayedCategories) ...[
+                () {
+                  final isExpanded =
+                      query.isNotEmpty ||
+                      state.expandedCategories.contains(cat.title);
+                  return div(classes: 'docs-category-group', [
+                    button(
+                      classes:
+                          'docs-category-header ${isExpanded ? "expanded" : ""}',
+                      onClick: () => cubit.toggleCategory(cat.title),
+                      [
+                        span(classes: 'category-icon', [
+                          Component.text(cat.icon),
+                        ]),
+                        span(classes: 'category-title', [
+                          Component.text(cat.title),
+                        ]),
+                        span(classes: 'category-chevron', [
+                          Component.text(isExpanded ? '▾' : '▸'),
+                        ]),
+                      ],
+                    ),
+                    if (isExpanded)
+                      ul(classes: 'docs-section-list', [
+                        for (final sec in cat.sections)
+                          li(classes: 'docs-section-item', [
+                            a(
+                              href: sec.path,
+                              classes:
+                                  'docs-section-link ${state.activeSectionId == sec.id ? "active" : ""}',
+                              onClick: () => cubit.selectSection(sec.id),
+                              [
+                                span(classes: 'section-title', [
+                                  Component.text(sec.title),
+                                ]),
+                                if (sec.badge != null)
+                                  span(classes: 'section-badge', [
+                                    Component.text(sec.badge!),
+                                  ]),
+                              ],
+                            ),
+                          ]),
+                      ]),
+                  ]);
+                }(),
+              ],
+            ],
+          ]),
+
+          // Sidebar Footer Quick Links
+          div(classes: 'docs-sidebar-footer', [
+            a(
+              href: 'https://pub.dev/packages/bloc_signals',
+              target: Target.blank,
+              classes: 'docs-footer-link',
+              [
+                span([Component.text('📦 pub.dev ↗')]),
+              ],
+            ),
+            a(
+              href: 'https://github.com/RandalSchwartz/BlocSignal',
+              target: Target.blank,
+              classes: 'docs-footer-link',
+              [
+                span([Component.text('⭐️ GitHub ↗')]),
+              ],
+            ),
+          ]),
+        ]);
+      },
+    );
+  }
+}

--- a/website/lib/src/components/docs/docs_toc.dart
+++ b/website/lib/src/components/docs/docs_toc.dart
@@ -1,0 +1,59 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+class const TocHeading({
+  required final String title,
+  required final String anchor,
+  final int level = 2,
+});
+
+/// Renders the On-This-Page table of contents on the right sidebar.
+class const DocsToc({
+  required final List<TocHeading> headings,
+  required final String sourcePath,
+  super.key,
+}) extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    if (headings.isEmpty) {
+      return div(classes: 'docs-toc-empty', []);
+    }
+
+    return nav(classes: 'docs-toc-panel', [
+      div(classes: 'docs-toc-header', [
+        span(classes: 'docs-toc-icon', [Component.text('📑')]),
+        span(classes: 'docs-toc-title', [Component.text('On This Page')]),
+      ]),
+      ul(classes: 'docs-toc-list', [
+        for (final h in headings)
+          li(classes: 'docs-toc-item level-${h.level}', [
+            a(href: '#${h.anchor}', classes: 'docs-toc-link', [
+              Component.text(h.title),
+            ]),
+          ]),
+      ]),
+      div(classes: 'docs-toc-community', [
+        div(classes: 'docs-toc-divider', []),
+        a(
+          href:
+              'https://github.com/RandalSchwartz/BlocSignal/tree/main/$sourcePath',
+          target: Target.blank,
+          classes: 'docs-toc-meta-link',
+          [
+            span(classes: 'docs-toc-meta-icon', [Component.text('✏️')]),
+            span([Component.text('Edit this page on GitHub')]),
+          ],
+        ),
+        a(
+          href: 'https://github.com/RandalSchwartz/BlocSignal/issues/new',
+          target: Target.blank,
+          classes: 'docs-toc-meta-link',
+          [
+            span(classes: 'docs-toc-meta-icon', [Component.text('💬')]),
+            span([Component.text('Give feedback / Open issue')]),
+          ],
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_installation.dart
+++ b/website/lib/src/components/docs/pages/docs_installation.dart
@@ -1,0 +1,308 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+class const DocsInstallationPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Quick Installation', anchor: 'quick-installation'),
+    TocHeading(title: 'Package Matrix', anchor: 'package-matrix'),
+    TocHeading(
+      title: 'SDK Versioning & Compatibility',
+      anchor: 'sdk-compatibility',
+    ),
+    TocHeading(title: 'Linter & Static Analysis', anchor: 'linter-setup'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🚀 Getting Started')]),
+        h1([Component.text('Installation & Package Matrix')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Add BlocSignal to your Flutter, Jaspr web, or pure Dart project with modular, tree-shakeable packages.',
+          ),
+        ]),
+      ]),
+
+      // 1. Quick Installation
+      section(id: 'quick-installation', classes: 'docs-section', [
+        h2([Component.text('Quick Installation')]),
+        p([
+          Component.text(
+            'Choose the package tailored to your target platform:',
+          ),
+        ]),
+
+        h3([Component.text('For Flutter Applications')]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'flutter pub add bloc_signals_flutter bloc_signals',
+        ),
+
+        h3([Component.text('For Pure Dart / Server Projects')]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'dart pub add bloc_signals',
+        ),
+
+        h3([Component.text('For Jaspr Web Applications')]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'dart pub add bloc_signals_jaspr bloc_signals',
+        ),
+      ]),
+
+      // 2. Package Matrix
+      section(id: 'package-matrix', classes: 'docs-section', [
+        h2([Component.text('Package Matrix')]),
+        p([
+          Component.text(
+            'BlocSignal provides a modular monorepo structure. You only import what your application uses:',
+          ),
+        ]),
+        div(classes: 'docs-table-wrapper', [
+          table(classes: 'docs-table', [
+            thead([
+              tr([
+                th([Component.text('Package')]),
+                th([Component.text('Version')]),
+                th([Component.text('Description')]),
+                th([Component.text('Platform')]),
+              ]),
+            ]),
+            tbody([
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals')],
+                  ),
+                ]),
+                td([Component.text('^1.0.1')]),
+                td([
+                  Component.text(
+                    'Core Pure Dart state containers (BlocSignal, CubitSignal, Transformers, Observers).',
+                  ),
+                ]),
+                td([Component.text('Dart 3.5+ / All')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_flutter',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_flutter')],
+                  ),
+                ]),
+                td([Component.text('^1.2.0')]),
+                td([
+                  Component.text(
+                    'Flutter bindings, O(1) providers, builders, listeners, selectors, and context extensions.',
+                  ),
+                ]),
+                td([Component.text('Flutter 3.22+ / UI')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_jaspr',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_jaspr')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0+1')]),
+                td([
+                  Component.text(
+                    'Jaspr web component integration, InheritedComponent providers, builders, and listeners.',
+                  ),
+                ]),
+                td([Component.text('Jaspr Web / SSR')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_test',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_test')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0')]),
+                td([
+                  Component.text(
+                    'Declarative unit testing utilities and test observers for state assertions.',
+                  ),
+                ]),
+                td([Component.text('Test / Dev')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_lint',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_lint')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0')]),
+                td([
+                  Component.text(
+                    'Custom analyzer lints and automated IDE quick-fixes for enforcing best practices.',
+                  ),
+                ]),
+                td([Component.text('Analyzer / Tooling')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_hydrate',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_hydrate')],
+                  ),
+                ]),
+                td([Component.text('^1.0.1')]),
+                td([
+                  Component.text(
+                    'Synchronous frame 1 state persistence across app restarts.',
+                  ),
+                ]),
+                td([Component.text('Dart / Flutter')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_replay',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_replay')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0')]),
+                td([
+                  Component.text(
+                    'Undo and redo state history management with customizable bounds.',
+                  ),
+                ]),
+                td([Component.text('Dart / Flutter')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_riverpod',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_riverpod')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0+1')]),
+                td([
+                  Component.text(
+                    'Bidirectional Riverpod 2 & 3 interoperability adapters.',
+                  ),
+                ]),
+                td([Component.text('Dart / Flutter')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_otel',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_otel')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0+1')]),
+                td([
+                  Component.text(
+                    'OpenTelemetry distributed tracing and event telemetry.',
+                  ),
+                ]),
+                td([Component.text('Dart / Server / UI')]),
+              ]),
+              tr([
+                td([
+                  a(
+                    href: 'https://pub.dev/packages/bloc_signals_devtools',
+                    target: Target.blank,
+                    classes: 'docs-table-link',
+                    [Component.text('bloc_signals_devtools')],
+                  ),
+                ]),
+                td([Component.text('^1.0.0')]),
+                td([
+                  Component.text(
+                    'Custom Flutter DevTools extension for timeline visualization and memory leak detection.',
+                  ),
+                ]),
+                td([Component.text('DevTools')]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+
+      // 3. SDK Versioning & Compatibility
+      section(id: 'sdk-compatibility', classes: 'docs-section', [
+        h2([Component.text('SDK Versioning & Compatibility')]),
+        p([
+          Component.text(
+            'BlocSignal enforces a strict SDK baseline to ensure broad compatibility:',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([Component.text('Published Packages: ')]),
+            Component.text(
+              'Target sdk: ^3.5.0, making them fully compatible with all stable Flutter channels (3.22+).',
+            ),
+          ]),
+          li([
+            strong([Component.text('Modern Language Support: ')]),
+            Component.text(
+              'Applications running Dart 3.13+ can fully utilize primary constructors and constructor shorthands when defining BlocSignal subclasses.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 4. Linter Setup
+      section(id: 'linter-setup', classes: 'docs-section', [
+        h2([Component.text('Linter & Static Analysis Setup')]),
+        p([
+          Component.text(
+            'Add bloc_signals_lint to your dev_dependencies for automatic IDE diagnostics and quick-fixes:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'analysis_options.yaml',
+          language: 'yaml',
+          code: '''
+plugins:
+  custom_lint:
+
+custom_lint:
+  rules:
+    - avoid_duplicate_event_handlers
+    - require_super_on_event
+    - avoid_stream_transformers_on_bloc_signal
+    - avoid_direct_signal_mutation_outside_bloc
+    - avoid_emit_in_build
+    - prefer_bloc_signal_provider_read_in_callbacks
+''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_overview.dart
+++ b/website/lib/src/components/docs/pages/docs_overview.dart
@@ -1,0 +1,264 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+class const DocsOverviewPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'What is BlocSignal?', anchor: 'what-is-blocsignal'),
+    TocHeading(title: 'Why BlocSignal?', anchor: 'why-blocsignal'),
+    TocHeading(
+      title: 'Synchronous 0ms Reactivity',
+      anchor: 'synchronous-reactivity',
+      level: 3,
+    ),
+    TocHeading(
+      title: 'Fine-Grained Signals Graph',
+      anchor: 'signals-graph',
+      level: 3,
+    ),
+    TocHeading(
+      title: 'Streamless Concurrency Transformers',
+      anchor: 'concurrency-transformers',
+      level: 3,
+    ),
+    TocHeading(title: 'Feature Comparison Matrix', anchor: 'comparison-matrix'),
+    TocHeading(title: 'Architecture Overview', anchor: 'architecture-overview'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🚀 Getting Started')]),
+        h1([Component.text('Overview & Why BlocSignal')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'BlocSignal bridges the robust predictability of the BLoC pattern with the zero-latency, fine-grained reactivity of Preact Signals v7 in pure Dart.',
+          ),
+        ]),
+      ]),
+
+      // 1. What is BlocSignal
+      section(id: 'what-is-blocsignal', classes: 'docs-section', [
+        h2([Component.text('What is BlocSignal?')]),
+        p([
+          Component.text(
+            'BlocSignal is a modern state management library designed for Flutter, Jaspr Web, and Pure Dart applications. '
+            'It combines the battle-tested conventions of the BLoC pattern—such as structured events, state machines, and lifecycle observers—with '
+            'high-performance signals. By replacing Dart Stream microtask queues with synchronous signal graphs, BlocSignal eliminates unnecessary latency and ghost rebuilds.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Zero Stream Dependencies',
+          children: [
+            p([
+              Component.text(
+                'Unlike classic BLoC, BlocSignal does not rely on async StreamControllers or microtask scheduling for state emissions. '
+                'State changes evaluate synchronously in 0ms within the exact frame they are triggered.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 2. Why BlocSignal?
+      section(id: 'why-blocsignal', classes: 'docs-section', [
+        h2([Component.text('Why BlocSignal?')]),
+        p([
+          Component.text(
+            'Traditional state management approaches often force developers to compromise between strict architectural structure and fine-grained rendering performance. '
+            'BlocSignal resolves this tradeoff through three foundational pillars:',
+          ),
+        ]),
+
+        h3(id: 'synchronous-reactivity', [
+          Component.text('1. Synchronous 0ms Propagation'),
+        ]),
+        p([
+          Component.text(
+            'Classic BLoC emits state asynchronously over Dart Streams. Each event requires microtask scheduling before widgets receive the update. '
+            'BlocSignal notifies observers and updates dependent widgets synchronously without waiting for microtask drainage, achieving up to 100,000+ state emissions per second.',
+          ),
+        ]),
+
+        h3(id: 'signals-graph', [
+          Component.text('2. Fine-Grained Signals Graph Integration'),
+        ]),
+        p([
+          Component.text(
+            'State in BlocSignal is exposed as a ReadonlySignal. This enables seamless composition with computed signals (computed()) and reactive side effects (effect()) across independent state containers without coupling them.',
+          ),
+        ]),
+
+        const DocsCodeBlock(
+          title: 'computed_derivation.dart',
+          dart313Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class CounterCubit() extends CubitSignal<int>(initialState: 0) {
+  void increment() => emit(stateValue + 1);
+}
+
+void main() {
+  final counter = CounterCubit();
+  
+  // Dynamically derived signal recalculates only when dependency changes
+  final isEven = computed(() => counter.state().isEven);
+  
+  print('Initial isEven: \${isEven.value}'); // true
+  counter.increment();
+  print('Updated isEven: \${isEven.value}'); // false
+}
+''',
+          dart35Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+}
+
+void main() {
+  final counter = CounterCubit();
+  
+  // Dynamically derived signal recalculates only when dependency changes
+  final isEven = computed(() => counter.state().isEven);
+  
+  print('Initial isEven: \${isEven.value}'); // true
+  counter.increment();
+  print('Updated isEven: \${isEven.value}'); // false
+}
+''',
+        ),
+
+        h3(id: 'concurrency-transformers', [
+          Component.text('3. Streamless Event Concurrency Transformers'),
+        ]),
+        p([
+          Component.text(
+            'BlocSignal provides powerful event transformers like droppable(), sequential(), and restartable() built on lightweight Mutex locks and higher-order functions with zero Rx stream overhead.',
+          ),
+        ]),
+      ]),
+
+      // 3. Comparison Matrix
+      section(id: 'comparison-matrix', classes: 'docs-section', [
+        h2([Component.text('Feature Comparison Matrix')]),
+        div(classes: 'docs-table-wrapper', [
+          table(classes: 'docs-table', [
+            thead([
+              tr([
+                th([Component.text('Capability')]),
+                th([Component.text('Classic BLoC')]),
+                th([Component.text('Riverpod')]),
+                th([Component.text('BlocSignal ⚡')]),
+              ]),
+            ]),
+            tbody([
+              tr([
+                td([
+                  strong([Component.text('Reactivity Model')]),
+                ]),
+                td([Component.text('Async Streams')]),
+                td([Component.text('Sync + Async Providers')]),
+                td([
+                  strong([Component.text('0ms Synchronous Signals')]),
+                ]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('InheritedWidget Lookup')]),
+                ]),
+                td([Component.text('O(N) Traversal')]),
+                td([Component.text('Custom Tree')]),
+                td([
+                  strong([Component.text('O(1) Element Lookup')]),
+                ]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('State De-duplication')]),
+                ]),
+                td([Component.text('Manual Equatable')]),
+                td([Component.text('Automatic ==')]),
+                td([
+                  strong([Component.text('Automatic Signal Equality')]),
+                ]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('Event Transformers')]),
+                ]),
+                td([Component.text('Rx Stream Transformers')]),
+                td([Component.text('Manual debounce')]),
+                td([
+                  strong([Component.text('Streamless Mutex Transformers')]),
+                ]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('Platform Support')]),
+                ]),
+                td([Component.text('Flutter & Dart')]),
+                td([Component.text('Flutter & Dart')]),
+                td([
+                  strong([Component.text('Flutter, Jaspr Web & Pure Dart')]),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+
+      // 4. Architecture Overview
+      section(id: 'architecture-overview', classes: 'docs-section', [
+        h2([Component.text('Architecture Overview')]),
+        p([
+          Component.text(
+            'BlocSignal components follow a clear, unidirectional data flow:',
+          ),
+        ]),
+        div(classes: 'docs-architecture-card', [
+          div(classes: 'arch-step', [
+            span(classes: 'arch-badge', [Component.text('1. Events')]),
+            span(classes: 'arch-desc', [
+              Component.text('UI dispatches typed events to BlocSignal.'),
+            ]),
+          ]),
+          div(classes: 'arch-arrow', [Component.text('➔')]),
+          div(classes: 'arch-step', [
+            span(classes: 'arch-badge', [
+              Component.text('2. Concurrency Transformer'),
+            ]),
+            span(classes: 'arch-desc', [
+              Component.text(
+                'Handlers coordinate execution (droppable, mutex).',
+              ),
+            ]),
+          ]),
+          div(classes: 'arch-arrow', [Component.text('➔')]),
+          div(classes: 'arch-step', [
+            span(classes: 'arch-badge', [
+              Component.text('3. Synchronous Emit'),
+            ]),
+            span(classes: 'arch-desc', [
+              Component.text('emit(newState) updates underlying signal.'),
+            ]),
+          ]),
+          div(classes: 'arch-arrow', [Component.text('➔')]),
+          div(classes: 'arch-step', [
+            span(classes: 'arch-badge', [Component.text('4. UI & Observers')]),
+            span(classes: 'arch-desc', [
+              Component.text('Widgets and telemetry receive instant updates.'),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_quickstart.dart
+++ b/website/lib/src/components/docs/pages/docs_quickstart.dart
@@ -1,0 +1,299 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+class const DocsQuickstartPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'Step 1: Create a CubitSignal',
+      anchor: 'step-1-cubitsignal',
+    ),
+    TocHeading(
+      title: 'Step 2: Create a BlocSignal',
+      anchor: 'step-2-blocsignal',
+    ),
+    TocHeading(
+      title: 'Step 3: Provide to the Widget Tree',
+      anchor: 'step-3-provide',
+    ),
+    TocHeading(
+      title: 'Step 4: Build Reactive UI',
+      anchor: 'step-4-reactive-ui',
+    ),
+    TocHeading(
+      title: 'Step 5: Test with blocSignalTest',
+      anchor: 'step-5-unit-testing',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🚀 Getting Started')]),
+        h1([Component.text('Quickstart Guide (5-Minute Tour)')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Learn how to define state containers, bind them to Flutter or Jaspr UI, and write declarative unit tests in under five minutes.',
+          ),
+        ]),
+      ]),
+
+      // Step 1: CubitSignal
+      section(id: 'step-1-cubitsignal', classes: 'docs-section', [
+        h2([Component.text('Step 1: Create a CubitSignal')]),
+        p([
+          Component.text(
+            'A CubitSignal is the simplest state container in BlocSignal. It exposes direct public methods that invoke emit(newState) synchronously.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.important,
+          title: 'Syntax Note',
+          children: [
+            p([
+              Component.text(
+                'Always use the named initialState: parameter in your constructor super call, and use stateValue (or state.value) to read raw state values.',
+              ),
+            ]),
+          ],
+        ),
+        const DocsCodeBlock(
+          title: 'counter_cubit.dart',
+          dart313Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class CounterCubit() extends CubitSignal<int>(initialState: 0) {
+  void increment() => emit(stateValue + 1);
+  void decrement() => emit(stateValue - 1);
+}
+''',
+          dart35Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+  void decrement() => emit(stateValue - 1);
+}
+''',
+        ),
+      ]),
+
+      // Step 2: BlocSignal
+      section(id: 'step-2-blocsignal', classes: 'docs-section', [
+        h2([Component.text('Step 2: Create a BlocSignal')]),
+        p([
+          Component.text(
+            'When your domain logic benefits from event traceability, concurrency transformers, or complex state machine transitions, use BlocSignal.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'counter_bloc.dart',
+          dart313Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+sealed class CounterEvent;
+final class Increment extends CounterEvent;
+final class Decrement extends CounterEvent;
+
+class CounterBloc() extends BlocSignal<CounterEvent, int>(initialState: 0) {
+  this {
+    on<Increment>((event, emit) => emit(stateValue + 1));
+    on<Decrement>((event, emit) => emit(stateValue - 1));
+  }
+}
+''',
+          dart35Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+sealed class CounterEvent {}
+class Increment extends CounterEvent {}
+class Decrement extends CounterEvent {}
+
+class CounterBloc extends BlocSignal<CounterEvent, int> {
+  CounterBloc() : super(initialState: 0) {
+    on<Increment>((event, emit) => emit(stateValue + 1));
+    on<Decrement>((event, emit) => emit(stateValue - 1));
+  }
+}
+''',
+        ),
+      ]),
+
+      // Step 3: Provide
+      section(id: 'step-3-provide', classes: 'docs-section', [
+        h2([Component.text('Step 3: Provide to the Widget Tree')]),
+        p([
+          Component.text(
+            'Provide your state container to downstream widgets using BlocSignalProvider. It performs lazy instantiation and O(1) element lookups.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'main.dart',
+          dart313Code: '''
+import 'package:flutter/material.dart';
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'counter_cubit.dart';
+import 'counter_view.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp() extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: BlocSignalProvider<CounterCubit>(
+        create: (context) => CounterCubit(),
+        child: const CounterView(),
+      ),
+    );
+  }
+}
+''',
+          dart35Code: '''
+import 'package:flutter/material.dart';
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'counter_cubit.dart';
+import 'counter_view.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: BlocSignalProvider<CounterCubit>(
+        create: (context) => CounterCubit(),
+        child: const CounterView(),
+      ),
+    );
+  }
+}
+''',
+        ),
+      ]),
+
+      // Step 4: Reactive UI
+      section(id: 'step-4-reactive-ui', classes: 'docs-section', [
+        h2([Component.text('Step 4: Build Reactive UI')]),
+        p([
+          Component.text(
+            'Use BlocSignalBuilder to rebuild widgets in 0ms when state changes, and context.read in callbacks.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'counter_view.dart',
+          dart313Code: '''
+import 'package:flutter/material.dart';
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'counter_cubit.dart';
+
+class CounterView() extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('BlocSignal Counter')),
+      body: Center(
+        child: BlocSignalBuilder<CounterCubit, int>(
+          builder: (context, count) => Text(
+            '\$count',
+            style: Theme.of(context).textTheme.displayLarge,
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read<CounterCubit>().increment(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+''',
+          dart35Code: '''
+import 'package:flutter/material.dart';
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'counter_cubit.dart';
+
+class CounterView extends StatelessWidget {
+  const CounterView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('BlocSignal Counter')),
+      body: Center(
+        child: BlocSignalBuilder<CounterCubit, int>(
+          builder: (context, count) => Text(
+            '\$count',
+            style: Theme.of(context).textTheme.displayLarge,
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read<CounterCubit>().increment(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+''',
+        ),
+      ]),
+
+      // Step 5: Testing
+      section(id: 'step-5-unit-testing', classes: 'docs-section', [
+        h2([Component.text('Step 5: Test with blocSignalTest')]),
+        p([
+          Component.text(
+            'Write declarative unit tests with blocSignalTest from package:bloc_signals_test:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'counter_cubit_test.dart',
+          dart313Code: '''
+import 'package:bloc_signals_test/bloc_signals_test.dart';
+import 'package:test/test.dart';
+import 'counter_cubit.dart';
+
+void main() {
+  group('CounterCubit', () {
+    blocSignalTest<CounterCubit, int>(
+      'emits [1, 2] when increment is called twice',
+      build: () => CounterCubit(),
+      act: (cubit) => cubit..increment()..increment(),
+      expect: () => [1, 2],
+    );
+  });
+}
+''',
+          dart35Code: '''
+import 'package:bloc_signals_test/bloc_signals_test.dart';
+import 'package:test/test.dart';
+import 'counter_cubit.dart';
+
+void main() {
+  group('CounterCubit', () {
+    blocSignalTest<CounterCubit, int>(
+      'emits [1, 2] when increment is called twice',
+      build: () => CounterCubit(),
+      act: (cubit) {
+        cubit.increment();
+        cubit.increment();
+      },
+      expect: () => [1, 2],
+    );
+  });
+}
+''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/navbar.dart
+++ b/website/lib/src/components/navbar.dart
@@ -52,7 +52,7 @@ class _NavbarState() extends State<Navbar> {
             height: 36,
           ),
           span(classes: 'brand-title', [Component.text('BlocSignal')]),
-          span(classes: 'brand-badge', [Component.text('v1.0.0')]),
+          span(classes: 'brand-badge', [Component.text('v1.0.1')]),
         ]),
 
         // Desktop Navigation Links
@@ -61,6 +61,11 @@ class _NavbarState() extends State<Navbar> {
             href: AppRoute.home.path,
             classes: activeRoute == AppRoute.home ? 'nav-active' : '',
             [Component.text('Home')],
+          ),
+          a(
+            href: AppRoute.docs.path,
+            classes: activeRoute == AppRoute.docs ? 'nav-active' : '',
+            [Component.text('Docs 📖')],
           ),
           a(href: '/#architecture', [Component.text('Architecture')]),
           a(
@@ -141,6 +146,16 @@ class _NavbarState() extends State<Navbar> {
                 [
                   span(classes: 'drawer-link-icon', [Component.text('🏠')]),
                   span(classes: 'drawer-link-label', [Component.text('Home')]),
+                ],
+              ),
+              a(
+                href: AppRoute.docs.path,
+                classes:
+                    'drawer-link ${activeRoute == AppRoute.docs ? "active" : ""}',
+                onClick: _closeDrawer,
+                [
+                  span(classes: 'drawer-link-icon', [Component.text('📖')]),
+                  span(classes: 'drawer-link-label', [Component.text('Docs')]),
                 ],
               ),
               a(

--- a/website/lib/src/components/package_catalog.dart
+++ b/website/lib/src/components/package_catalog.dart
@@ -26,7 +26,7 @@ const List<PackageItem> _allPackages = [
   ),
   PackageItem(
     name: 'bloc_signals_flutter',
-    version: '1.1.0',
+    version: '1.2.0',
     desc: 'Flutter UI bindings, InheritedWidget providers, builders, listeners, selectors, and Listenable interop.',
     icon: '💙',
     category: 'Core & UI',

--- a/website/lib/src/cubits/docs_cubit.dart
+++ b/website/lib/src/cubits/docs_cubit.dart
@@ -1,0 +1,166 @@
+import 'dart:js_interop';
+
+import 'package:bloc_signals_jaspr/bloc_signals_jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../models/docs_models.dart';
+import '../models/docs_registry.dart';
+
+@JS('trackGaPageView')
+external void _trackGaPageView(JSString path);
+
+/// Cubit managing documentation hub state, active article, search filters, and mobile drawer.
+class DocsCubit({String? initialSectionId}) extends CubitSignal<DocsState> {
+  this
+    : super(
+        initialState: DocsState(
+          activeSectionId:
+              initialSectionId ?? _resolveInitialSectionFromBrowser(),
+          searchQuery: '',
+          expandedCategories: {
+            'Getting Started',
+            'Core Concepts',
+            'Flutter Integration',
+          },
+          isMobileDrawerOpen: false,
+          selectedDartVersion: '3.13',
+        ),
+      ) {
+    _popStateListener = ((web.Event _) {
+      _syncFromBrowser();
+    }).toJS;
+    _hashChangeListener = ((web.Event _) {
+      _syncFromBrowser();
+    }).toJS;
+
+    try {
+      web.window.addEventListener('popstate', _popStateListener);
+      web.window.addEventListener('hashchange', _hashChangeListener);
+    } catch (_) {}
+
+    _trackDocsPageView(stateValue.activeSectionId);
+  }
+
+  late final JSFunction _popStateListener;
+  late final JSFunction _hashChangeListener;
+
+  static String _resolveInitialSectionFromBrowser() {
+    try {
+      final path = web.window.location.pathname;
+      final hash = web.window.location.hash;
+
+      // Check if path is e.g. /docs/installation
+      if (path.startsWith('/docs/')) {
+        final slug = path.replaceFirst('/docs/', '').trim();
+        if (slug.isNotEmpty) return slug;
+      }
+
+      // Check if hash is e.g. #docs/installation or #installation
+      final cleanHash = hash
+          .replaceFirst('#', '')
+          .replaceFirst('docs/', '')
+          .trim();
+      if (cleanHash.isNotEmpty) {
+        return cleanHash;
+      }
+    } catch (_) {}
+    return 'overview';
+  }
+
+  void _syncFromBrowser() {
+    final nextId = _resolveInitialSectionFromBrowser();
+    if (nextId != stateValue.activeSectionId) {
+      emit(stateValue.copyWith(activeSectionId: nextId));
+      _trackDocsPageView(nextId);
+    }
+  }
+
+  /// Selects a new active documentation section.
+  void selectSection(String sectionId, {bool pushHistory = true}) {
+    if (stateValue.activeSectionId == sectionId) {
+      if (stateValue.isMobileDrawerOpen) {
+        closeMobileDrawer();
+      }
+      return;
+    }
+
+    final targetSection = DocsRegistry.resolveSection(sectionId);
+
+    if (pushHistory) {
+      try {
+        web.window.history.pushState(null, '', targetSection.path);
+      } catch (_) {}
+    }
+
+    // Ensure category of target section is expanded
+    final updatedCategories = Set<String>.from(stateValue.expandedCategories)
+      ..add(targetSection.category);
+
+    emit(
+      stateValue.copyWith(
+        activeSectionId: sectionId,
+        expandedCategories: updatedCategories,
+        isMobileDrawerOpen: false,
+      ),
+    );
+
+    _trackDocsPageView(sectionId);
+
+    // Scroll to top of article
+    try {
+      web.window.scrollTo(web.ScrollToOptions(top: 0, left: 0));
+    } catch (_) {}
+  }
+
+  /// Updates navigation search query.
+  void updateSearch(String query) {
+    emit(stateValue.copyWith(searchQuery: query));
+  }
+
+  /// Toggles expansion of a navigation category.
+  void toggleCategory(String categoryTitle) {
+    final updated = Set<String>.from(stateValue.expandedCategories);
+    if (updated.contains(categoryTitle)) {
+      updated.remove(categoryTitle);
+    } else {
+      updated.add(categoryTitle);
+    }
+    emit(stateValue.copyWith(expandedCategories: updated));
+  }
+
+  /// Toggles mobile docs navigation drawer.
+  void toggleMobileDrawer() {
+    emit(
+      stateValue.copyWith(isMobileDrawerOpen: !stateValue.isMobileDrawerOpen),
+    );
+  }
+
+  /// Closes mobile docs navigation drawer.
+  void closeMobileDrawer() {
+    if (stateValue.isMobileDrawerOpen) {
+      emit(stateValue.copyWith(isMobileDrawerOpen: false));
+    }
+  }
+
+  /// Changes the globally preferred Dart code version ('3.13' or '3.5').
+  void setDartVersion(String version) {
+    if (version != stateValue.selectedDartVersion) {
+      emit(stateValue.copyWith(selectedDartVersion: version));
+    }
+  }
+
+  void _trackDocsPageView(String sectionId) {
+    try {
+      _trackGaPageView('/docs/$sectionId'.toJS);
+    } catch (_) {}
+  }
+
+  @override
+  Future<void> close() async {
+    try {
+      web.window.removeEventListener('popstate', _popStateListener);
+      web.window.removeEventListener('hashchange', _hashChangeListener);
+    } catch (_) {}
+    await super.close();
+  }
+}

--- a/website/lib/src/models/app_route.dart
+++ b/website/lib/src/models/app_route.dart
@@ -1,5 +1,6 @@
 import 'package:jaspr/jaspr.dart';
 
+import '../pages/docs_page.dart';
 import '../pages/home_page.dart';
 import '../pages/minesweeper_page.dart';
 import '../pages/ported_examples_page.dart';
@@ -13,6 +14,7 @@ enum AppRoute(
   final Component Function() builder,
 ) {
   home('/', 'Home', HomePage.new),
+  docs('/docs', 'Docs', DocsPage.new),
   showcase('/showcase', 'Showcase', ShowcasePage.new),
   portedExamples('/ported-examples', 'Ported Examples', PortedExamplesPage.new),
   minesweeper('/minesweeper', '🎮 Minesweeper', MinesweeperPage.new),
@@ -23,7 +25,9 @@ enum AppRoute(
     final p = path ?? '';
     final h = (hash ?? '').toLowerCase();
 
-    if (p == '/showcase' ||
+    if (p == '/docs' || p.startsWith('/docs/') || h.contains('docs')) {
+      return docs;
+    } else if (p == '/showcase' ||
         p.startsWith('/showcase') ||
         h.contains('showcase')) {
       return showcase;

--- a/website/lib/src/models/docs_models.dart
+++ b/website/lib/src/models/docs_models.dart
@@ -1,0 +1,44 @@
+import 'package:jaspr/jaspr.dart';
+
+/// Represents a single documentation article or topic page.
+class const DocSectionItem({
+  required final String id,
+  required final String title,
+  required final String path,
+  required final String category,
+  required final String description,
+  final String? badge,
+  required final Component Function() builder,
+});
+
+/// Represents a grouping category in the Docs navigation tree.
+class const DocCategory({
+  required final String title,
+  required final String icon,
+  required final List<DocSectionItem> sections,
+});
+
+/// Immutable state for the Docs Hub reactive cubit.
+class const DocsState({
+  required final String activeSectionId,
+  required final String searchQuery,
+  required final Set<String> expandedCategories,
+  required final bool isMobileDrawerOpen,
+  required final String selectedDartVersion, // '3.13' or '3.5'
+}) {
+  DocsState copyWith({
+    String? activeSectionId,
+    String? searchQuery,
+    Set<String>? expandedCategories,
+    bool? isMobileDrawerOpen,
+    String? selectedDartVersion,
+  }) {
+    return DocsState(
+      activeSectionId: activeSectionId ?? this.activeSectionId,
+      searchQuery: searchQuery ?? this.searchQuery,
+      expandedCategories: expandedCategories ?? this.expandedCategories,
+      isMobileDrawerOpen: isMobileDrawerOpen ?? this.isMobileDrawerOpen,
+      selectedDartVersion: selectedDartVersion ?? this.selectedDartVersion,
+    );
+  }
+}

--- a/website/lib/src/models/docs_registry.dart
+++ b/website/lib/src/models/docs_registry.dart
@@ -1,0 +1,419 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../components/docs/pages/docs_installation.dart';
+import '../components/docs/pages/docs_overview.dart';
+import '../components/docs/pages/docs_quickstart.dart';
+import 'docs_models.dart';
+
+/// Central registry of all documentation topics and categories across all phases.
+class const DocsRegistry() {
+  static final List<DocCategory> categories = [
+    const DocCategory(
+      title: 'Getting Started',
+      icon: '🚀',
+      sections: [
+        DocSectionItem(
+          id: 'overview',
+          title: 'Overview & Why BlocSignal',
+          path: '/docs/overview',
+          category: 'Getting Started',
+          description: '0ms synchronous reactivity, signals graph integration, and comparison matrix.',
+          builder: DocsOverviewPage.new,
+        ),
+        DocSectionItem(
+          id: 'installation',
+          title: 'Installation & Package Matrix',
+          path: '/docs/installation',
+          category: 'Getting Started',
+          description:
+              'Platform-specific installation and monorepo package catalog.',
+          builder: DocsInstallationPage.new,
+        ),
+        DocSectionItem(
+          id: 'quickstart',
+          title: 'Quickstart Guide',
+          path: '/docs/quickstart',
+          category: 'Getting Started',
+          description: '5-minute tutorial covering Cubit, Bloc, Flutter UI, and testing.',
+          builder: DocsQuickstartPage.new,
+        ),
+      ],
+    ),
+    DocCategory(
+      title: 'Core Concepts',
+      icon: '🧠',
+      sections: [
+        DocSectionItem(
+          id: 'cubit-vs-bloc',
+          title: 'CubitSignal vs. BlocSignal',
+          path: '/docs/cubit-vs-bloc',
+          category: 'Core Concepts',
+          description: 'Choosing between direct method invocation and event-driven architectures.',
+          badge: 'Phase 2',
+          builder: () => _PlaceholderDoc(
+            title: 'CubitSignal vs. BlocSignal',
+            phase: 'Phase 2',
+            description: 'In-depth architectural comparison, philosophy, and decision matrix between CubitSignal and BlocSignal.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'state-modeling',
+          title: 'State Modeling & Immutability',
+          path: '/docs/state-modeling',
+          category: 'Core Concepts',
+          description: 'Immutable data models, Dart Records, Fast Immutable Collections (FIC), and custom equality comparators.',
+          badge: 'Phase 2',
+          builder: () => _PlaceholderDoc(
+            title: 'State Modeling & Immutability',
+            phase: 'Phase 2',
+            description: 'Best practices for state modeling, immutability, Record states, and SignalOptions custom equals.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'events-and-handlers',
+          title: 'Events & Handlers',
+          path: '/docs/events-and-handlers',
+          category: 'Core Concepts',
+          description: 'Registering typed event handlers with on<E>(), concurrency coordination, and error tracking.',
+          badge: 'Phase 2',
+          builder: () => _PlaceholderDoc(
+            title: 'Events & Handlers',
+            phase: 'Phase 2',
+            description: 'How on<E> handlers work, synchronous event dispatching, and Future.wait concurrency.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'event-transformers',
+          title: 'Event Transformers',
+          path: '/docs/event-transformers',
+          category: 'Core Concepts',
+          description: 'Streamless event transformers (droppable, sequential, restartable) and custom debounce/mutex locks.',
+          badge: 'Phase 2',
+          builder: () => _PlaceholderDoc(
+            title: 'Event Transformers',
+            phase: 'Phase 2',
+            description: 'Streamless higher-order function concurrency transformers and Mutex locks.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'lifecycle-and-observers',
+          title: 'Lifecycle & Observers',
+          path: '/docs/lifecycle-and-observers',
+          category: 'Core Concepts',
+          description: 'BlocSignalObserver, Change, Transition, and OpenTelemetry identity span tracking.',
+          badge: 'Phase 2',
+          builder: () => _PlaceholderDoc(
+            title: 'Lifecycle & Observers',
+            phase: 'Phase 2',
+            description: 'Global and local observer lifecycles, Change/Transition logging, and DevTools hooks.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'signals-reactivity',
+          title: 'Signals Graph Reactivity',
+          path: '/docs/signals-reactivity',
+          category: 'Core Concepts',
+          description: 'Understanding stateValue vs state, computed() derivations, and managed effect() reactions.',
+          badge: 'Phase 2',
+          builder: () => _PlaceholderDoc(
+            title: 'Signals Graph Reactivity',
+            phase: 'Phase 2',
+            description: 'How ReadonlySignal powers automatic de-duplication, fine-grained reactivity, and 0ms updates.',
+          ),
+        ),
+      ],
+    ),
+    DocCategory(
+      title: 'Flutter Integration',
+      icon: '📱',
+      sections: [
+        DocSectionItem(
+          id: 'flutter-providers',
+          title: 'BlocSignalProvider & Lookup',
+          path: '/docs/flutter-providers',
+          category: 'Flutter Integration',
+          description: 'Dependency injection with BlocSignalProvider, MultiBlocSignalProvider, and O(1) lookups.',
+          badge: 'Phase 3',
+          builder: () => _PlaceholderDoc(
+            title: 'BlocSignalProvider & Lookup',
+            phase: 'Phase 3',
+            description: 'Scoped state provision, lazy initialization, and O(1) InheritedElement resolution.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'flutter-widgets',
+          title: 'Builders, Listeners & Selectors',
+          path: '/docs/flutter-widgets',
+          category: 'Flutter Integration',
+          description: 'BlocSignalBuilder, BlocSignalListener, BlocSignalConsumer, and fine-grained BlocSignalSelector.',
+          badge: 'Phase 3',
+          builder: () => _PlaceholderDoc(
+            title: 'Builders, Listeners & Selectors',
+            phase: 'Phase 3',
+            description: 'UI binding widgets, side-effect listeners, and selector performance optimizations.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'flutter-context',
+          title: 'Context Extensions',
+          path: '/docs/flutter-context',
+          category: 'Flutter Integration',
+          description: 'context.read<T>(), context.watch<T>(), and two-type-parameter context.select<B, R>().',
+          badge: 'Phase 3',
+          builder: () => _PlaceholderDoc(
+            title: 'Context Extensions',
+            phase: 'Phase 3',
+            description: 'Type-safe BuildContext extensions for concise UI state access.',
+          ),
+        ),
+      ],
+    ),
+    DocCategory(
+      title: 'Testing',
+      icon: '🧪',
+      sections: [
+        DocSectionItem(
+          id: 'testing-guide',
+          title: 'Declarative Testing with blocSignalTest',
+          path: '/docs/testing-guide',
+          category: 'Testing',
+          description: 'Declarative unit testing, observer scoping, lifecycle verification, and async frame expectations.',
+          badge: 'Phase 3',
+          builder: () => _PlaceholderDoc(
+            title: 'Declarative Testing with blocSignalTest',
+            phase: 'Phase 3',
+            description: 'How to test BlocSignal and CubitSignal state machines declaratively using bloc_signals_test.',
+          ),
+        ),
+      ],
+    ),
+    DocCategory(
+      title: 'Satellite Packages',
+      icon: '📦',
+      sections: [
+        DocSectionItem(
+          id: 'pkg-hydrate',
+          title: 'bloc_signals_hydrate',
+          path: '/docs/pkg-hydrate',
+          category: 'Satellite Packages',
+          description: 'Synchronous frame 1 state persistence across restarts.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'bloc_signals_hydrate',
+            phase: 'Phase 4',
+            description: 'State persistence with zero-boilerplate primitive and collection storage.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'pkg-replay',
+          title: 'bloc_signals_replay',
+          path: '/docs/pkg-replay',
+          category: 'Satellite Packages',
+          description: 'Undo and redo history management with ReplayCubit and ReplayBloc.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'bloc_signals_replay',
+            phase: 'Phase 4',
+            description:
+                'Time-travel and undo/redo stacks for state containers.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'pkg-riverpod',
+          title: 'bloc_signals_riverpod',
+          path: '/docs/pkg-riverpod',
+          category: 'Satellite Packages',
+          description:
+              'Bidirectional Riverpod 2 & 3 interoperability adapters.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'bloc_signals_riverpod',
+            phase: 'Phase 4',
+            description:
+                'Bridging Riverpod providers into BlocSignal and vice-versa.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'pkg-otel',
+          title: 'bloc_signals_otel',
+          path: '/docs/pkg-otel',
+          category: 'Satellite Packages',
+          description:
+              'OpenTelemetry distributed tracing and observability spans.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'bloc_signals_otel',
+            phase: 'Phase 4',
+            description: 'Distributed tracing and OpenTelemetry metrics for transitions and errors.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'pkg-devtools',
+          title: 'bloc_signals_devtools',
+          path: '/docs/pkg-devtools',
+          category: 'Satellite Packages',
+          description: 'DevTools timeline inspection and leak detector badge.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'bloc_signals_devtools',
+            phase: 'Phase 4',
+            description: 'Custom DevTools extension for timeline debugging and state inspection.',
+          ),
+        ),
+      ],
+    ),
+    DocCategory(
+      title: 'Architecture & Recipes',
+      icon: '💡',
+      sections: [
+        DocSectionItem(
+          id: 'recipe-one-shot',
+          title: 'One-Shot UI Side Effects',
+          path: '/docs/recipe-one-shot',
+          category: 'Architecture & Recipes',
+          description: 'Handling snackbars, dialogs, and navigation without polluting domain state.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'One-Shot UI Side Effects',
+            phase: 'Phase 4',
+            description:
+                'Recipes for transient side-effects without state corruption.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'recipe-form-validation',
+          title: 'Form Validation',
+          path: '/docs/recipe-form-validation',
+          category: 'Architecture & Recipes',
+          description: 'Primary input signals paired with computed() derived validation states.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'Form Validation',
+            phase: 'Phase 4',
+            description: 'Building performant, boilerplate-free forms with computed signals.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'recipe-controllers',
+          title: 'Coordinating Controllers',
+          path: '/docs/recipe-controllers',
+          category: 'Architecture & Recipes',
+          description: 'Bidirectional syncing of TextEditingControllers without build-phase mutation loops.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'Coordinating Controllers',
+            phase: 'Phase 4',
+            description: 'How to coordinate Flutter controllers with reactive state containers safely.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'recipe-caching',
+          title: 'API Caching & TTL Expiration',
+          path: '/docs/recipe-caching',
+          category: 'Architecture & Recipes',
+          description: 'Managing asynchronous server data with automatic cache invalidation.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'API Caching & TTL Expiration',
+            phase: 'Phase 4',
+            description: 'Implementing resilient API caching with time-to-live expiration.',
+          ),
+        ),
+      ],
+    ),
+    DocCategory(
+      title: 'Migration Guides',
+      icon: '🔄',
+      sections: [
+        DocSectionItem(
+          id: 'migration-bloc',
+          title: 'Migrating from package:bloc',
+          path: '/docs/migration-bloc',
+          category: 'Migration Guides',
+          description: 'Step-by-step migration guide from classic BLoC / flutter_bloc to BlocSignal.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'Migrating from package:bloc',
+            phase: 'Phase 4',
+            description: 'Comprehensive guide and code comparisons for migrating from Flutter BLoC.',
+          ),
+        ),
+        DocSectionItem(
+          id: 'migration-riverpod',
+          title: 'Migrating from Riverpod',
+          path: '/docs/migration-riverpod',
+          category: 'Migration Guides',
+          description: 'Step-by-step migration guide from Riverpod providers to BlocSignal.',
+          badge: 'Phase 4',
+          builder: () => _PlaceholderDoc(
+            title: 'Migrating from Riverpod',
+            phase: 'Phase 4',
+            description: 'Comparing concepts and converting Riverpod state notifiers to BlocSignal.',
+          ),
+        ),
+      ],
+    ),
+  ];
+
+  /// Resolves a section by its ID or returns the default overview.
+  static DocSectionItem resolveSection(String id) {
+    for (final category in categories) {
+      for (final section in category.sections) {
+        if (section.id == id) return section;
+      }
+    }
+    return categories.first.sections.first;
+  }
+
+  /// Resolves the next and previous section items for footer pagination.
+  static (DocSectionItem? prev, DocSectionItem? next) getAdjacentSections(
+    String currentId,
+  ) {
+    final allSections = [
+      for (final cat in categories)
+        for (final sec in cat.sections) sec,
+    ];
+
+    final index = allSections.indexWhere((s) => s.id == currentId);
+    if (index == -1) return (null, null);
+
+    final prev = index > 0 ? allSections[index - 1] : null;
+    final next = index < allSections.length - 1 ? allSections[index + 1] : null;
+    return (prev, next);
+  }
+}
+
+class const _PlaceholderDoc({
+  required final String title,
+  required final String phase,
+  required final String description,
+}) extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('⏳ In Progress ($phase)')]),
+        h1([Component.text(title)]),
+        p(classes: 'docs-lead', [Component.text(description)]),
+      ]),
+      section(classes: 'docs-section', [
+        div(classes: 'docs-placeholder-card', [
+          span(classes: 'placeholder-icon', [Component.text('🚧')]),
+          h3([Component.text('Coming Soon in $phase')]),
+          p([
+            Component.text(
+              'This documentation chapter is currently being drafted as part of $phase of the BlocSignal Documentation Hub rollout. '
+              'In the meantime, refer to the Getting Started guides and the official README.',
+            ),
+          ]),
+          div(classes: 'placeholder-actions', [
+            a(href: '/docs/quickstart', classes: 'btn-primary-sm', [
+              Component.text('Go to Quickstart Guide ➔'),
+            ]),
+          ]),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/pages/docs_page.dart
+++ b/website/lib/src/pages/docs_page.dart
@@ -1,0 +1,59 @@
+import 'package:bloc_signals_jaspr/bloc_signals_jaspr.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../components/docs/docs_content.dart';
+import '../components/docs/docs_sidebar.dart';
+import '../components/footer.dart';
+import '../components/navbar.dart';
+import '../cubits/docs_cubit.dart';
+import '../models/app_route.dart';
+import '../models/docs_models.dart';
+
+/// The top-level documentation hub page.
+class const DocsPage({super.key}) extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    return div(classes: 'app-root docs-page-root', [
+      const Navbar(currentRoute: AppRoute.docs),
+      BlocSignalProvider<DocsCubit>(
+        create: (_) => DocsCubit(),
+        child: const _DocsLayout(),
+      ),
+      const Footer(),
+    ]);
+  }
+}
+
+class const _DocsLayout() extends StatelessComponent {
+  @override
+  Component build(BuildContext context) {
+    return BlocSignalBuilder<DocsCubit, DocsState>(
+      builder: (context, state) {
+        final cubit = context.read<DocsCubit>();
+
+        return div(classes: 'docs-wrapper', [
+          // Mobile Drawer Backdrop
+          if (state.isMobileDrawerOpen)
+            div(
+              classes: 'docs-drawer-backdrop',
+              events: {'click': (_) => cubit.closeMobileDrawer()},
+              [],
+            ),
+
+          div(classes: 'container docs-shell', [
+            // Left Navigation Sidebar
+            div(
+              classes:
+                  'docs-sidebar-wrapper ${state.isMobileDrawerOpen ? "open" : ""}',
+              [const DocsSidebar()],
+            ),
+
+            // Center Content + Right TOC
+            const DocsContent(),
+          ]),
+        ]);
+      },
+    );
+  }
+}

--- a/website/test/docs_cubit_test.dart
+++ b/website/test/docs_cubit_test.dart
@@ -1,0 +1,90 @@
+import 'package:blocsignal_website/src/cubits/docs_cubit.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DocsCubit', () {
+    late DocsCubit cubit;
+
+    setUp(() {
+      cubit = DocsCubit(initialSectionId: 'overview');
+    });
+
+    tearDown(() async {
+      await cubit.close();
+    });
+
+    test('initializes with default state values', () {
+      expect(cubit.stateValue.activeSectionId, equals('overview'));
+      expect(cubit.stateValue.searchQuery, isEmpty);
+      expect(cubit.stateValue.isMobileDrawerOpen, isFalse);
+      expect(cubit.stateValue.selectedDartVersion, equals('3.13'));
+      expect(
+        cubit.stateValue.expandedCategories,
+        containsAll([
+          'Getting Started',
+          'Core Concepts',
+          'Flutter Integration',
+        ]),
+      );
+    });
+
+    test('selectSection updates activeSectionId and expands target category', () {
+      cubit.selectSection('testing-guide', pushHistory: false);
+
+      expect(cubit.stateValue.activeSectionId, equals('testing-guide'));
+      expect(cubit.stateValue.expandedCategories, contains('Testing'));
+      expect(cubit.stateValue.isMobileDrawerOpen, isFalse);
+    });
+
+    test('selectSection ignores selecting the already active section', () {
+      final initialState = cubit.stateValue;
+      cubit.selectSection('overview', pushHistory: false);
+
+      expect(cubit.stateValue, equals(initialState));
+    });
+
+    test('updateSearch updates searchQuery in state', () {
+      cubit.updateSearch('hydrate');
+      expect(cubit.stateValue.searchQuery, equals('hydrate'));
+
+      cubit.updateSearch('');
+      expect(cubit.stateValue.searchQuery, isEmpty);
+    });
+
+    test('toggleCategory adds and removes category expansion', () {
+      expect(cubit.stateValue.expandedCategories, contains('Getting Started'));
+
+      // Collapse
+      cubit.toggleCategory('Getting Started');
+      expect(
+        cubit.stateValue.expandedCategories,
+        isNot(contains('Getting Started')),
+      );
+
+      // Re-expand
+      cubit.toggleCategory('Getting Started');
+      expect(cubit.stateValue.expandedCategories, contains('Getting Started'));
+    });
+
+    test('toggleMobileDrawer and closeMobileDrawer manage drawer state', () {
+      expect(cubit.stateValue.isMobileDrawerOpen, isFalse);
+
+      cubit.toggleMobileDrawer();
+      expect(cubit.stateValue.isMobileDrawerOpen, isTrue);
+
+      cubit.closeMobileDrawer();
+      expect(cubit.stateValue.isMobileDrawerOpen, isFalse);
+    });
+
+    test('setDartVersion updates code syntax preference', () {
+      expect(cubit.stateValue.selectedDartVersion, equals('3.13'));
+
+      cubit.setDartVersion('3.5');
+      expect(cubit.stateValue.selectedDartVersion, equals('3.5'));
+
+      // Setting same version does not emit duplicate
+      cubit.setDartVersion('3.5');
+      expect(cubit.stateValue.selectedDartVersion, equals('3.5'));
+    });
+  });
+}

--- a/website/test/docs_registry_test.dart
+++ b/website/test/docs_registry_test.dart
@@ -1,0 +1,109 @@
+import 'package:blocsignal_website/src/models/app_route.dart';
+import 'package:blocsignal_website/src/models/docs_registry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DocsRegistry', () {
+    test('contains all expected documentation categories', () {
+      final categories = DocsRegistry.categories;
+      expect(categories, isNotEmpty);
+      expect(
+        categories.map((c) => c.title),
+        containsAll([
+          'Getting Started',
+          'Core Concepts',
+          'Flutter Integration',
+          'Testing',
+          'Satellite Packages',
+          'Architecture & Recipes',
+          'Migration Guides',
+        ]),
+      );
+    });
+
+    test('resolveSection returns matching section by id', () {
+      final overview = DocsRegistry.resolveSection('overview');
+      expect(overview.id, equals('overview'));
+      expect(overview.title, equals('Overview & Why BlocSignal'));
+      expect(overview.category, equals('Getting Started'));
+
+      final installation = DocsRegistry.resolveSection('installation');
+      expect(installation.id, equals('installation'));
+      expect(installation.path, equals('/docs/installation'));
+
+      final quickstart = DocsRegistry.resolveSection('quickstart');
+      expect(quickstart.id, equals('quickstart'));
+      expect(quickstart.path, equals('/docs/quickstart'));
+    });
+
+    test('resolveSection falls back to first section on unknown id', () {
+      final fallback = DocsRegistry.resolveSection('unknown-section-123');
+      expect(fallback.id, equals('overview'));
+    });
+
+    test('getAdjacentSections returns correct prev and next sections', () {
+      // First section has no previous
+      final (firstPrev, firstNext) = DocsRegistry.getAdjacentSections('overview');
+      expect(firstPrev, isNull);
+      expect(firstNext?.id, equals('installation'));
+
+      // Middle section has both prev and next
+      final (midPrev, midNext) = DocsRegistry.getAdjacentSections('installation');
+      expect(midPrev?.id, equals('overview'));
+      expect(midNext?.id, equals('quickstart'));
+
+      // Unknown section returns (null, null)
+      final (nonePrev, noneNext) = DocsRegistry.getAdjacentSections('nonexistent');
+      expect(nonePrev, isNull);
+      expect(noneNext, isNull);
+    });
+
+    test('all registered section builders instantiate valid components', () {
+      for (final category in DocsRegistry.categories) {
+        for (final section in category.sections) {
+          final component = section.builder();
+          expect(component, isNotNull, reason: 'Failed building ${section.id}');
+        }
+      }
+    });
+  });
+
+  group('AppRoute & Location Parsing', () {
+    test('fromLocation resolves /docs and sub-paths to AppRoute.docs', () {
+      expect(AppRoute.fromLocation(path: '/docs'), equals(AppRoute.docs));
+      expect(
+        AppRoute.fromLocation(path: '/docs/overview'),
+        equals(AppRoute.docs),
+      );
+      expect(
+        AppRoute.fromLocation(path: '/docs/installation'),
+        equals(AppRoute.docs),
+      );
+      expect(
+        AppRoute.fromLocation(path: '/docs/quickstart'),
+        equals(AppRoute.docs),
+      );
+      expect(
+        AppRoute.fromLocation(hash: '#docs/quickstart'),
+        equals(AppRoute.docs),
+      );
+    });
+
+    test('fromLocation resolves other routes correctly', () {
+      expect(AppRoute.fromLocation(path: '/'), equals(AppRoute.home));
+      expect(AppRoute.fromLocation(path: '/showcase'), equals(AppRoute.showcase));
+      expect(
+        AppRoute.fromLocation(path: '/ported-examples'),
+        equals(AppRoute.portedExamples),
+      );
+      expect(
+        AppRoute.fromLocation(path: '/minesweeper'),
+        equals(AppRoute.minesweeper),
+      );
+      expect(
+        AppRoute.fromLocation(path: '/publications'),
+        equals(AppRoute.publications),
+      );
+    });
+  });
+}

--- a/website/tool/build_static.dart
+++ b/website/tool/build_static.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+/// Builds the static web bundle for blocsignal.dev, compiling Dart to JS
+/// and creating static route fallbacks for Firebase Hosting and static web servers.
+Future<void> main() async {
+  print('🚀 Starting static build for blocsignal.dev...');
+
+  final websiteDir = Directory.current.path.endsWith('/website')
+      ? Directory.current
+      : Directory('website');
+
+  final buildWww = Directory('${websiteDir.path}/build/www');
+  if (!buildWww.existsSync()) {
+    buildWww.createSync(recursive: true);
+  }
+
+  // 1. Compile Dart to JS
+  print('📦 Compiling lib/main.dart to JS...');
+  final compileResult = await Process.run('dart', [
+    'compile',
+    'js',
+    'lib/main.dart',
+    '-o',
+    'build/www/main.dart.js',
+  ], workingDirectory: websiteDir.path);
+
+  if (compileResult.exitCode != 0) {
+    print('❌ JS compilation failed:');
+    print(compileResult.stderr);
+    print(compileResult.stdout);
+    exit(1);
+  }
+  print('✅ JS compilation succeeded.');
+
+  // 2. Copy web/ static assets to build/www/
+  print('📂 Copying web/ assets to build/www/...');
+  final webDir = Directory('${websiteDir.path}/web');
+  for (final entity in webDir.listSync(recursive: true)) {
+    final relativePath = entity.path.substring(webDir.path.length + 1);
+    final targetPath = '${buildWww.path}/$relativePath';
+
+    if (entity is Directory) {
+      Directory(targetPath).createSync(recursive: true);
+    } else if (entity is File) {
+      File(targetPath).parent.createSync(recursive: true);
+      entity.copySync(targetPath);
+    }
+  }
+
+  // 3. Create route fallback directories with index.html
+  final indexHtml = File('${buildWww.path}/index.html');
+  if (!indexHtml.existsSync()) {
+    print('❌ build/www/index.html not found!');
+    exit(1);
+  }
+
+  final routes = [
+    'showcase',
+    'ported-examples',
+    'minesweeper',
+    'publications',
+    'docs',
+    'docs/overview',
+    'docs/installation',
+    'docs/quickstart',
+    'docs/cubit-vs-bloc',
+    'docs/state-modeling',
+    'docs/events-and-handlers',
+    'docs/event-transformers',
+    'docs/lifecycle-and-observers',
+    'docs/signals-reactivity',
+    'docs/flutter-providers',
+    'docs/flutter-widgets',
+    'docs/flutter-context',
+    'docs/testing-guide',
+    'docs/pkg-hydrate',
+    'docs/pkg-replay',
+    'docs/pkg-riverpod',
+    'docs/pkg-otel',
+    'docs/pkg-devtools',
+    'docs/recipe-one-shot',
+    'docs/recipe-form-validation',
+    'docs/recipe-controllers',
+    'docs/recipe-caching',
+    'docs/migration-bloc',
+    'docs/migration-riverpod',
+  ];
+
+  print('🗺️ Generating static route fallbacks for ${routes.length} routes...');
+  for (final route in routes) {
+    final routeDir = Directory('${buildWww.path}/$route');
+    routeDir.createSync(recursive: true);
+    indexHtml.copySync('${routeDir.path}/index.html');
+  }
+
+  print('🎉 Static build complete! Output ready in build/www/');
+}

--- a/website/web/styles.css
+++ b/website/web/styles.css
@@ -2618,6 +2618,861 @@ code, pre, .font-mono {
 }
 
 /* ==========================================================================
+   Documentation Hub (/docs) Layout & Components
+   ========================================================================== */
+.docs-page-root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.docs-wrapper {
+  flex: 1;
+  width: 100%;
+  padding-top: 24px;
+  padding-bottom: 64px;
+}
+
+.docs-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 240px;
+  gap: 36px;
+  align-items: start;
+  position: relative;
+  max-width: 1400px;
+}
+
+/* --------------------------------------------------------------------------
+   Docs Sidebar (Left Column)
+   -------------------------------------------------------------------------- */
+.docs-sidebar-wrapper {
+  position: sticky;
+  top: 90px;
+  max-height: calc(100vh - 110px);
+  overflow-y: auto;
+  border-right: 1px solid var(--border-color);
+  padding-right: 20px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-subtle) transparent;
+}
+
+.docs-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.docs-search-box {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 8px 12px;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.docs-search-box:focus-within {
+  border-color: var(--accent-cyan);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.docs-search-icon {
+  font-size: 0.95rem;
+  margin-right: 8px;
+  opacity: 0.7;
+}
+
+.docs-search-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.88rem;
+}
+
+.docs-search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.docs-search-clear {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.docs-search-clear:hover {
+  color: var(--text-primary);
+}
+
+.docs-nav-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.docs-category-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.docs-category-header {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.docs-category-header:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.category-icon {
+  margin-right: 8px;
+  font-size: 1rem;
+}
+
+.category-title {
+  flex: 1;
+}
+
+.category-chevron {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  transition: transform var(--transition-fast);
+}
+
+.docs-section-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: 14px;
+  margin-left: 10px;
+  border-left: 1px solid var(--border-color);
+}
+
+.docs-section-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.86rem;
+  border-radius: 6px;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.docs-section-link:hover {
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.docs-section-link.active {
+  color: var(--accent-cyan);
+  background: rgba(56, 189, 248, 0.1);
+  font-weight: 600;
+  border-left: 2px solid var(--accent-cyan);
+}
+
+.section-badge {
+  font-size: 0.68rem;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: rgba(139, 92, 246, 0.2);
+  color: var(--accent-purple-light);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+}
+
+.docs-nav-empty {
+  padding: 16px 8px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.btn-clear-search {
+  margin-top: 8px;
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--accent-cyan);
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.docs-sidebar-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-color);
+}
+
+.docs-footer-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.82rem;
+  transition: color var(--transition-fast);
+}
+
+.docs-footer-link:hover {
+  color: var(--accent-cyan);
+}
+
+/* --------------------------------------------------------------------------
+   Docs Content (Center Column)
+   -------------------------------------------------------------------------- */
+.docs-content-layout {
+  display: contents;
+}
+
+.docs-mobile-bar {
+  display: none;
+}
+
+.docs-main-container {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+}
+
+.docs-article {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.docs-article-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.docs-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent-cyan);
+  background: rgba(56, 189, 248, 0.1);
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 9999px;
+}
+
+.docs-article-header h1 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.docs-lead {
+  font-size: 1.12rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.docs-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  scroll-margin-top: 100px;
+}
+
+.docs-section h2 {
+  font-size: 1.55rem;
+  font-weight: 700;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+
+.docs-section h3 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 12px;
+}
+
+.docs-section p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.98rem;
+}
+
+.docs-list {
+  padding-left: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--text-secondary);
+  font-size: 0.96rem;
+}
+
+/* --------------------------------------------------------------------------
+   Docs Callouts (Alerts)
+   -------------------------------------------------------------------------- */
+.docs-callout {
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+}
+
+.callout-note {
+  border-left: 4px solid var(--accent-blue);
+  background: rgba(59, 130, 246, 0.06);
+}
+
+.callout-tip {
+  border-left: 4px solid #10b981;
+  background: rgba(16, 185, 129, 0.06);
+}
+
+.callout-important {
+  border-left: 4px solid var(--accent-cyan);
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.callout-warning {
+  border-left: 4px solid #f59e0b;
+  background: rgba(245, 158, 11, 0.06);
+}
+
+.callout-caution {
+  border-left: 4px solid #ef4444;
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.docs-callout-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.docs-callout-icon {
+  font-size: 1.1rem;
+}
+
+.docs-callout-title {
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: var(--text-primary);
+}
+
+.docs-callout-body p {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Docs Code Blocks & Dual Tabs
+   -------------------------------------------------------------------------- */
+.docs-code-container {
+  border-radius: 12px;
+  overflow: hidden;
+  background: #0b0f19;
+  border: 1px solid var(--border-color);
+  margin: 14px 0;
+  box-shadow: var(--shadow-card);
+}
+
+.docs-code-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 16px;
+  background: #111827;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.docs-code-title-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.docs-code-filename {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+}
+
+.docs-code-lang-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--accent-cyan);
+  background: rgba(56, 189, 248, 0.12);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.docs-code-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.docs-version-tabs {
+  display: flex;
+  background: #090d16;
+  border-radius: 6px;
+  padding: 2px;
+  border: 1px solid var(--border-color);
+}
+
+.docs-version-tab {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.docs-version-tab.active {
+  background: var(--bg-card);
+  color: var(--accent-cyan);
+  box-shadow: var(--shadow-sm);
+}
+
+.docs-copy-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.76rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.docs-copy-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.docs-copy-btn.copied {
+  color: #10b981;
+  border-color: #10b981;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.docs-code-body {
+  padding: 16px 20px;
+  overflow-x: auto;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: var(--text-code);
+}
+
+/* --------------------------------------------------------------------------
+   Docs Table & Matrices
+   -------------------------------------------------------------------------- */
+.docs-table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--bg-card);
+}
+
+.docs-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.docs-table th {
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.docs-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+}
+
+.docs-table tr:last-child td {
+  border-bottom: none;
+}
+
+.docs-table-link {
+  color: var(--accent-cyan);
+  font-family: 'JetBrains Mono', monospace;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.docs-table-link:hover {
+  text-decoration: underline;
+}
+
+/* --------------------------------------------------------------------------
+   Docs Architecture Cards
+   -------------------------------------------------------------------------- */
+.docs-architecture-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+}
+
+.arch-step {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 140px;
+}
+
+.arch-badge {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--accent-cyan);
+}
+
+.arch-desc {
+  font-size: 0.84rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.arch-arrow {
+  color: var(--accent-purple-light);
+  font-size: 1.2rem;
+  font-weight: bold;
+}
+
+/* --------------------------------------------------------------------------
+   Docs Table of Contents (TOC - Right Column)
+   -------------------------------------------------------------------------- */
+.docs-toc-container {
+  position: sticky;
+  top: 90px;
+  max-height: calc(100vh - 110px);
+  overflow-y: auto;
+}
+
+.docs-toc-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.docs-toc-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.84rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.docs-toc-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.docs-toc-item.level-3 {
+  padding-left: 12px;
+}
+
+.docs-toc-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.84rem;
+  line-height: 1.4;
+  transition: color var(--transition-fast);
+}
+
+.docs-toc-link:hover {
+  color: var(--accent-cyan);
+}
+
+.docs-toc-divider {
+  height: 1px;
+  background: var(--border-color);
+  margin: 12px 0;
+}
+
+.docs-toc-community {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.docs-toc-meta-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 0.8rem;
+  transition: color var(--transition-fast);
+}
+
+.docs-toc-meta-link:hover {
+  color: var(--text-primary);
+}
+
+/* --------------------------------------------------------------------------
+   Docs Pagination Footer
+   -------------------------------------------------------------------------- */
+.docs-pagination {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-color);
+  margin-top: 24px;
+}
+
+.docs-pager-btn {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  text-decoration: none;
+  transition: all var(--transition-fast);
+  max-width: 48%;
+}
+
+.docs-pager-btn.next {
+  margin-left: auto;
+  text-align: right;
+}
+
+.docs-pager-btn:hover {
+  border-color: var(--accent-cyan);
+  box-shadow: 0 4px 16px rgba(56, 189, 248, 0.1);
+  transform: translateY(-1px);
+}
+
+.pager-direction {
+  font-size: 0.74rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.pager-title {
+  font-size: 0.94rem;
+  font-weight: 600;
+  color: var(--accent-cyan);
+}
+
+/* --------------------------------------------------------------------------
+   Docs Placeholder Cards (Upcoming Phases)
+   -------------------------------------------------------------------------- */
+.docs-placeholder-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 12px;
+  padding: 48px 24px;
+  border-radius: 16px;
+  background: var(--bg-card);
+  border: 1px dashed var(--border-glass);
+}
+
+.placeholder-icon {
+  font-size: 2.5rem;
+}
+
+.docs-placeholder-card h3 {
+  font-size: 1.3rem;
+  color: var(--text-primary);
+}
+
+.docs-placeholder-card p {
+  max-width: 500px;
+  font-size: 0.92rem;
+  color: var(--text-secondary);
+}
+
+.placeholder-actions {
+  margin-top: 12px;
+}
+
+.btn-primary-sm {
+  display: inline-block;
+  padding: 8px 16px;
+  background: var(--gradient-primary);
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.86rem;
+  border-radius: 8px;
+  box-shadow: var(--shadow-button-primary);
+  transition: transform var(--transition-fast);
+}
+
+.btn-primary-sm:hover {
+  transform: translateY(-1px);
+}
+
+/* --------------------------------------------------------------------------
+   Responsive Media Queries for Docs Hub
+   -------------------------------------------------------------------------- */
+@media (max-width: 1200px) {
+  .docs-shell {
+    grid-template-columns: 260px minmax(0, 1fr);
+  }
+  .docs-toc-container {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-shell {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .docs-sidebar-wrapper {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 280px;
+    background: var(--bg-dark);
+    z-index: 2000;
+    padding: 24px;
+    border-right: 1px solid var(--border-color);
+    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.8);
+    transform: translateX(-100%);
+    transition: transform var(--transition-smooth);
+  }
+
+  .docs-sidebar-wrapper.open {
+    transform: translateX(0);
+  }
+
+  .docs-drawer-backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    z-index: 1999;
+  }
+
+  .docs-mobile-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    margin-bottom: 12px;
+  }
+
+  .docs-mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: rgba(56, 189, 248, 0.12);
+    border: 1px solid rgba(56, 189, 248, 0.3);
+    color: var(--accent-cyan);
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-family: inherit;
+    font-weight: 700;
+    font-size: 0.84rem;
+    cursor: pointer;
+  }
+
+  .docs-mobile-breadcrumbs {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 60%;
+  }
+
+  .crumb-title {
+    color: var(--text-primary);
+    font-weight: 600;
+  }
+
+  .docs-code-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .docs-code-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+/* ==========================================================================
    Accessibility: Reduced Motion
    ========================================================================== */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Resolves #167 (Phase 1 of parent meta-issue #165).

### 🎯 Objective & Scope
Expands `blocsignal.dev` with a dedicated, comprehensive **Documentation Hub (`/docs`)**, mirroring the information architecture of `bloclibrary.dev`. Phase 1 establishes the responsive shell, reactive state architecture (dogfooding `CubitSignal` and `bloc_signals_jaspr`), navigation tree, and the foundational "Getting Started" documentation pages.

### 📋 Deliverables
1. **Reactive State Management (Dogfooding `bloc_signals_jaspr`)**:
   - Implemented `DocsCubit` managing active documentation routes, live search queries, collapsible category accordions, mobile drawer visibility, and code syntax preferences.
   - Used `BlocSignalProvider<DocsCubit>`, `BlocSignalBuilder`, and `context.read<DocsCubit>()` across all documentation components for 0ms reactive UI updates.
2. **Responsive 3-Column Shell & Layout**:
   - `DocsSidebar`: Live search filter, categorized collapsible accordions, active link indicators, and quick-links to pub.dev and GitHub.
   - `DocsCodeBlock`: Interactive tabbed code blocks switching between Dart 3.13+ (Modern) and Dart 3.5 (Baseline) syntax, with clipboard copy button.
   - `DocsCallout`: GitHub-style alerts (`NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`) with glass card styling.
   - `DocsToc`: On-page Table of Contents with jump anchors and GitHub edit links.
   - `DocsPage`: Top-level responsive page layout.
3. **Getting Started Documentation**:
   - **Overview & Why BlocSignal** (`DocsOverviewPage`): 0ms synchronous reactivity, signals graph integration, feature comparison matrix, and architecture data flow.
   - **Installation & Package Matrix** (`DocsInstallationPage`): Platform-specific installation commands, complete 10-package matrix, and SDK compatibility policy.
   - **Quickstart Guide** (`DocsQuickstartPage`): 5-minute guide covering `CubitSignal`, `BlocSignal`, Flutter UI binding, and declarative unit testing.
4. **Static Pre-Rendering & Build**:
   - Added `website/tool/build_static.dart` to compile Dart to JS and pre-render static HTML fallbacks for 29 routes across `/docs/*` for Firebase Hosting and static servers.

### 🧪 Verification
- `dart analyze --fatal-infos` -> **0 issues**
- `dart run tool/run_workspace_tests.dart` -> **100% tests passing**
- `dart run website/tool/build_static.dart` -> **Clean JS compilation & static route generation**
- `dart run tool/validate_agent_plugin.dart` -> **Passed**
- `dart format .` -> **Clean**