### PR TITLE
feat(website): author core concepts docs & resilient SPA navigation (#168)

### DIFF
--- a/website/lib/src/components/docs/docs_code_block.dart
+++ b/website/lib/src/components/docs/docs_code_block.dart
@@ -7,12 +7,15 @@ import 'package:web/web.dart' as web;
 /// A code block component with syntax header, copy button, and optional side-by-side tabs.
 class const DocsCodeBlock({
   final String? title,
+  final String? filename,
   final String? code,
   final String? dart35Code,
   final String? dart313Code,
   final String language = 'dart',
   super.key,
 }) extends StatefulComponent {
+  String? get displayTitle => title ?? filename;
+
   @override
   State<DocsCodeBlock> createState() => _DocsCodeBlockState();
 }
@@ -61,10 +64,10 @@ class _DocsCodeBlockState() extends State<DocsCodeBlock> {
     return div(classes: 'docs-code-container', [
       div(classes: 'docs-code-header', [
         div(classes: 'docs-code-title-group', [
-          if (component.title != null) ...[
+          if (component.displayTitle != null) ...[
             span(classes: 'docs-code-file-icon', [Component.text('📄')]),
             span(classes: 'docs-code-filename', [
-              Component.text(component.title!),
+              Component.text(component.displayTitle!),
             ]),
           ] else ...[
             span(classes: 'docs-code-lang-badge', [

--- a/website/lib/src/components/docs/docs_content.dart
+++ b/website/lib/src/components/docs/docs_content.dart
@@ -6,9 +6,15 @@ import '../../cubits/docs_cubit.dart';
 import '../../models/docs_models.dart';
 import '../../models/docs_registry.dart';
 import 'docs_toc.dart';
+import 'pages/docs_cubit_vs_bloc.dart';
+import 'pages/docs_event_transformers.dart';
+import 'pages/docs_events_and_handlers.dart';
 import 'pages/docs_installation.dart';
+import 'pages/docs_lifecycle_and_observers.dart';
 import 'pages/docs_overview.dart';
 import 'pages/docs_quickstart.dart';
+import 'pages/docs_signals_reactivity.dart';
+import 'pages/docs_state_modeling.dart';
 
 /// The central content viewer for the documentation hub.
 class const DocsContent({super.key}) extends StatelessComponent {
@@ -37,7 +43,9 @@ class const DocsContent({super.key}) extends StatelessComponent {
               attributes: {'aria-label': 'Open documentation menu'},
               [
                 span(classes: 'docs-mobile-menu-icon', [Component.text('☰')]),
-                span(classes: 'docs-mobile-menu-text', [Component.text('Menu')]),
+                span(classes: 'docs-mobile-menu-text', [
+                  Component.text('Menu'),
+                ]),
               ],
             ),
             div(classes: 'docs-mobile-breadcrumbs', [
@@ -61,7 +69,14 @@ class const DocsContent({super.key}) extends StatelessComponent {
                 a(
                   href: prevSection.path,
                   classes: 'docs-pager-btn prev',
-                  onClick: () => cubit.selectSection(prevSection.id),
+                  events: {
+                    'click': (dynamic event) {
+                      try {
+                        (event as dynamic).preventDefault();
+                      } catch (_) {}
+                      cubit.selectSection(prevSection.id);
+                    },
+                  },
                   [
                     span(classes: 'docs-pager-direction', [
                       Component.text('← Previous'),
@@ -78,7 +93,14 @@ class const DocsContent({super.key}) extends StatelessComponent {
                 a(
                   href: nextSection.path,
                   classes: 'docs-pager-btn next',
-                  onClick: () => cubit.selectSection(nextSection.id),
+                  events: {
+                    'click': (dynamic event) {
+                      try {
+                        (event as dynamic).preventDefault();
+                      } catch (_) {}
+                      cubit.selectSection(nextSection.id);
+                    },
+                  },
                   [
                     span(classes: 'docs-pager-direction', [
                       Component.text('Next →'),
@@ -108,6 +130,18 @@ class const DocsContent({super.key}) extends StatelessComponent {
         return DocsInstallationPage.headings;
       case 'quickstart':
         return DocsQuickstartPage.headings;
+      case 'cubit-vs-bloc':
+        return DocsCubitVsBlocPage.headings;
+      case 'state-modeling':
+        return DocsStateModelingPage.headings;
+      case 'events-and-handlers':
+        return DocsEventsAndHandlersPage.headings;
+      case 'event-transformers':
+        return DocsEventTransformersPage.headings;
+      case 'lifecycle-and-observers':
+        return DocsLifecycleAndObserversPage.headings;
+      case 'signals-reactivity':
+        return DocsSignalsReactivityPage.headings;
       default:
         return const [];
     }
@@ -121,6 +155,18 @@ class const DocsContent({super.key}) extends StatelessComponent {
         return 'website/lib/src/components/docs/pages/docs_installation.dart';
       case 'quickstart':
         return 'website/lib/src/components/docs/pages/docs_quickstart.dart';
+      case 'cubit-vs-bloc':
+        return 'website/lib/src/components/docs/pages/docs_cubit_vs_bloc.dart';
+      case 'state-modeling':
+        return 'website/lib/src/components/docs/pages/docs_state_modeling.dart';
+      case 'events-and-handlers':
+        return 'website/lib/src/components/docs/pages/docs_events_and_handlers.dart';
+      case 'event-transformers':
+        return 'website/lib/src/components/docs/pages/docs_event_transformers.dart';
+      case 'lifecycle-and-observers':
+        return 'website/lib/src/components/docs/pages/docs_lifecycle_and_observers.dart';
+      case 'signals-reactivity':
+        return 'website/lib/src/components/docs/pages/docs_signals_reactivity.dart';
       default:
         return 'website/lib/src/models/docs_registry.dart';
     }

--- a/website/lib/src/components/docs/docs_sidebar.dart
+++ b/website/lib/src/components/docs/docs_sidebar.dart
@@ -100,7 +100,14 @@ class const DocsSidebar({super.key}) extends StatelessComponent {
                               href: sec.path,
                               classes:
                                   'docs-section-link ${state.activeSectionId == sec.id ? "active" : ""}',
-                              onClick: () => cubit.selectSection(sec.id),
+                              events: {
+                                'click': (dynamic event) {
+                                  try {
+                                    (event as dynamic).preventDefault();
+                                  } catch (_) {}
+                                  cubit.selectSection(sec.id);
+                                },
+                              },
                               [
                                 span(classes: 'docs-nav-link-title', [
                                   Component.text(sec.title),

--- a/website/lib/src/components/docs/pages/docs_cubit_vs_bloc.dart
+++ b/website/lib/src/components/docs/pages/docs_cubit_vs_bloc.dart
@@ -1,0 +1,325 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering the architectural comparison between CubitSignal and BlocSignal.
+class const DocsCubitVsBlocPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Philosophy', anchor: 'overview-philosophy'),
+    TocHeading(
+      title: 'Architectural Comparison',
+      anchor: 'architectural-comparison',
+    ),
+    TocHeading(title: 'When to Use CubitSignal', anchor: 'when-to-use-cubit'),
+    TocHeading(title: 'When to Use BlocSignal', anchor: 'when-to-use-bloc'),
+    TocHeading(title: 'Decision Matrix', anchor: 'decision-matrix'),
+    TocHeading(title: 'Side-by-Side Example', anchor: 'side-by-side-example'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🧠 Core Concepts')]),
+        h1([Component.text('CubitSignal vs. BlocSignal')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Understand the fundamental tradeoffs between direct method invocation in CubitSignal and declarative, event-driven pipelines in BlocSignal.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Philosophy
+      section(id: 'overview-philosophy', classes: 'docs-section', [
+        h2([Component.text('Overview & Philosophy')]),
+        p([
+          Component.text(
+            'Both CubitSignal and BlocSignal extend the same underlying state container, BlocSignalBase. '
+            'They share identical reactive signal graph integration, 0ms synchronous state propagation, and observer traceability. '
+            'The key distinction lies entirely in how mutations are initiated.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Shared Signal Foundation',
+          children: [
+            p([
+              Component.text(
+                'Because both classes extend BlocSignalBase, UI widgets (BlocSignalBuilder, BlocSignalListener, context.select) '
+                'interact with both Cubits and Blocs interchangeably. You can even migrate from CubitSignal to BlocSignal without changing a single line of widget code.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 2. Architectural Comparison
+      section(id: 'architectural-comparison', classes: 'docs-section', [
+        h2([Component.text('Architectural Comparison')]),
+        p([
+          Component.text(
+            'The primary architectural difference is the presence of an Event layer:',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([Component.text('CubitSignal: ')]),
+            Component.text(
+              'Functions are exposed directly as public methods (for example, increment() or login()). '
+              'State transitions occur immediately when the method executes emit().',
+            ),
+          ]),
+          li([
+            strong([Component.text('BlocSignal: ')]),
+            Component.text(
+              'UI components dispatch typed event objects via add(Event). '
+              'Registered event handlers process events, coordinate concurrency through transformers, and invoke emit().',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 3. When to Use CubitSignal
+      section(id: 'when-to-use-cubit', classes: 'docs-section', [
+        h2([Component.text('When to Use CubitSignal')]),
+        p([
+          Component.text(
+            'CubitSignal is the recommended choice for the vast majority of application state management tasks. '
+            'It provides minimal boilerplate, instant readability, and straightforward unit testing.',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([Component.text('Simple UI State: ')]),
+            Component.text(
+              'Toggle switches, modals, theme pickers, tabs, and bottom navigation indices.',
+            ),
+          ]),
+          li([
+            strong([Component.text('Form Handling & Validation: ')]),
+            Component.text(
+              'Capturing input fields, validation rules, and submitting form payloads.',
+            ),
+          ]),
+          li([
+            strong([Component.text('Single-Action Async Operations: ')]),
+            Component.text(
+              'Fetching data from a REST endpoint where event transformations are not required.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 4. When to Use BlocSignal
+      section(id: 'when-to-use-bloc', classes: 'docs-section', [
+        h2([Component.text('When to Use BlocSignal')]),
+        p([
+          Component.text(
+            'BlocSignal excels when complex asynchronous coordination, event queuing, or comprehensive audit logs are required.',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([Component.text('Event Concurrency Control: ')]),
+            Component.text(
+              'When you need to drop duplicate button clicks (droppable), sequence incoming requests (sequential), or restart search queries (restartable).',
+            ),
+          ]),
+          li([
+            strong([Component.text('Strict Event Audit Trails: ')]),
+            Component.text(
+              'When compliance, analytics, or debugging requirements demand logging every discrete user intent before state computation begins.',
+            ),
+          ]),
+          li([
+            strong([Component.text('Complex Multi-Event Workflows: ')]),
+            Component.text(
+              'Multi-step checkout wizards, real-time gaming loops, and biometric authentication pipelines.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 5. Decision Matrix
+      section(id: 'decision-matrix', classes: 'docs-section', [
+        h2([Component.text('Decision Matrix')]),
+        div(classes: 'docs-table-wrapper', [
+          table(classes: 'docs-table', [
+            thead([
+              tr([
+                th([Component.text('Feature / Requirement')]),
+                th([Component.text('CubitSignal')]),
+                th([Component.text('BlocSignal')]),
+              ]),
+            ]),
+            tbody([
+              tr([
+                td([
+                  strong([Component.text('Boilerplate Overhead')]),
+                ]),
+                td([Component.text('Minimal (Methods only)')]),
+                td([Component.text('Moderate (Events + Handlers)')]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('Execution Style')]),
+                ]),
+                td([Component.text('Direct method call')]),
+                td([Component.text('Dispatched event stream')]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('Concurrency Transformers')]),
+                ]),
+                td([Component.text('Manual async guards')]),
+                td([
+                  Component.text(
+                    'Built-in (droppable, sequential, restartable)',
+                  ),
+                ]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('Event Audit Logging')]),
+                ]),
+                td([Component.text('Change transitions only')]),
+                td([Component.text('Full onEvent + onTransition logging')]),
+              ]),
+              tr([
+                td([
+                  strong([Component.text('Learning Curve')]),
+                ]),
+                td([Component.text('Low & intuitive')]),
+                td([Component.text('Medium')]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+
+      // 6. Side-by-Side Example
+      section(id: 'side-by-side-example', classes: 'docs-section', [
+        h2([Component.text('Side-by-Side Example')]),
+        p([
+          Component.text(
+            'Here is the same authentication state container implemented as both a CubitSignal and a BlocSignal:',
+          ),
+        ]),
+        h3([Component.text('1. Implemented with CubitSignal')]),
+        const DocsCodeBlock(
+          filename: 'auth_cubit.dart',
+          dart313Code: '''
+sealed class AuthState {
+  const AuthState();
+}
+
+final class AuthInitial extends AuthState {
+  const AuthInitial();
+}
+
+final class AuthAuthenticated extends AuthState {
+  const AuthAuthenticated(this.username);
+  final String username;
+}
+
+class AuthCubit(AuthRepository repository)
+    extends CubitSignal<AuthState>(initialState: const AuthInitial()) {
+  Future<void> login(String username, String password) async {
+    final success = await repository.authenticate(username, password);
+    if (success) {
+      emit(AuthAuthenticated(username));
+    }
+  }
+
+  void logout() => emit(const AuthInitial());
+}''',
+          dart35Code: '''
+sealed class AuthState {
+  const AuthState();
+}
+
+final class AuthInitial extends AuthState {
+  const AuthInitial();
+}
+
+final class AuthAuthenticated extends AuthState {
+  const AuthAuthenticated(this.username);
+  final String username;
+}
+
+class AuthCubit extends CubitSignal<AuthState> {
+  AuthCubit(this._repository) : super(initialState: const AuthInitial());
+
+  final AuthRepository _repository;
+
+  Future<void> login(String username, String password) async {
+    final success = await _repository.authenticate(username, password);
+    if (success) {
+      emit(AuthAuthenticated(username));
+    }
+  }
+
+  void logout() => emit(const AuthInitial());
+}''',
+        ),
+        h3([Component.text('2. Implemented with BlocSignal')]),
+        const DocsCodeBlock(
+          filename: 'auth_bloc.dart',
+          dart313Code: '''
+sealed class AuthEvent {}
+final class AuthLoginRequested(this.username, this.password) extends AuthEvent {
+  final String username;
+  final String password;
+}
+final class AuthLogoutRequested extends AuthEvent {}
+
+class AuthBloc(AuthRepository repository)
+    extends BlocSignal<AuthEvent, AuthState>(initialState: const AuthInitial()) {
+  init {
+    on<AuthLoginRequested>((event, emit) async {
+      final success = await repository.authenticate(event.username, event.password);
+      if (success) {
+        emit(AuthAuthenticated(event.username));
+      }
+    }, transformer: droppable());
+
+    on<AuthLogoutRequested>((event, emit) {
+      emit(const AuthInitial());
+    });
+  }
+}''',
+          dart35Code: '''
+sealed class AuthEvent {}
+final class AuthLoginRequested extends AuthEvent {
+  const AuthLoginRequested(this.username, this.password);
+  final String username;
+  final String password;
+}
+final class AuthLogoutRequested extends AuthEvent {
+  const AuthLogoutRequested();
+}
+
+class AuthBloc extends BlocSignal<AuthEvent, AuthState> {
+  AuthBloc(this._repository) : super(initialState: const AuthInitial()) {
+    on<AuthLoginRequested>((event, emit) async {
+      final success = await _repository.authenticate(event.username, event.password);
+      if (success) {
+        emit(AuthAuthenticated(event.username));
+      }
+    }, transformer: droppable());
+
+    on<AuthLogoutRequested>((event, emit) {
+      emit(const AuthInitial());
+    });
+  }
+
+  final AuthRepository _repository;
+}''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_event_transformers.dart
+++ b/website/lib/src/components/docs/pages/docs_event_transformers.dart
@@ -1,0 +1,205 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering streamless event concurrency transformers in BlocSignal.
+class const DocsEventTransformersPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'Streamless Concurrency Architecture',
+      anchor: 'streamless-architecture',
+    ),
+    TocHeading(title: 'droppable()', anchor: 'droppable-transformer'),
+    TocHeading(title: 'sequential()', anchor: 'sequential-transformer'),
+    TocHeading(title: 'restartable()', anchor: 'restartable-transformer'),
+    TocHeading(
+      title: 'Custom Transformer Recipes',
+      anchor: 'custom-transformers',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🧠 Core Concepts')]),
+        h1([Component.text('Event Transformers')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Control asynchronous event execution with zero Rx Stream overhead using pure Dart higher-order functions and Mutex coordination.',
+          ),
+        ]),
+      ]),
+
+      // 1. Streamless Concurrency Architecture
+      section(id: 'streamless-architecture', classes: 'docs-section', [
+        h2([Component.text('Streamless Concurrency Architecture')]),
+        p([
+          Component.text(
+            'Unlike classic BLoC which depends on package:bloc_concurrency and Rx Streams, BlocSignal event transformers '
+            'are implemented as pure Dart higher-order functions: (event, handler, emit) => FutureOr<void>. '
+            'This completely avoids Stream subscription allocations and microtask queue delays.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Zero Stream Allocations',
+          children: [
+            p([
+              Component.text(
+                'By coordinating Futures directly rather than piping through Rx operators, transformer overhead is reduced to zero during high-frequency event bursts.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 2. droppable()
+      section(id: 'droppable-transformer', classes: 'docs-section', [
+        h2([Component.text('droppable()')]),
+        p([
+          Component.text(
+            'Ignores and drops any incoming events while the current event handler is actively processing an asynchronous Future. '
+            'Ideal for submit buttons, login actions, and checkout forms to prevent duplicate requests.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'droppable_example.dart',
+          dart313Code: '''
+on<SubmitFormPressed>((event, emit) async {
+  emit(const FormSubmitting());
+  await api.postPayload(event.data);
+  emit(const FormSuccess());
+}, transformer: droppable());
+''',
+          dart35Code: '''
+on<SubmitFormPressed>((event, emit) async {
+  emit(const FormSubmitting());
+  await _api.postPayload(event.data);
+  emit(const FormSuccess());
+}, transformer: droppable());
+''',
+        ),
+      ]),
+
+      // 3. sequential()
+      section(id: 'sequential-transformer', classes: 'docs-section', [
+        h2([Component.text('sequential()')]),
+        p([
+          Component.text(
+            'Queues and processes incoming events strictly in the order they were dispatched using an internal Mutex lock. '
+            'Guarantees FIFO order without dropping events.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'sequential_example.dart',
+          dart313Code: '''
+on<SyncDatabaseRecord>((event, emit) async {
+  await database.syncRecord(event.record);
+  emit(DatabaseSynced(event.record.id));
+}, transformer: sequential());
+''',
+          dart35Code: '''
+on<SyncDatabaseRecord>((event, emit) async {
+  await _database.syncRecord(event.record);
+  emit(DatabaseSynced(event.record.id));
+}, transformer: sequential());
+''',
+        ),
+      ]),
+
+      // 4. restartable()
+      section(id: 'restartable-transformer', classes: 'docs-section', [
+        h2([Component.text('restartable()')]),
+        p([
+          Component.text(
+            'Abandons prior in-flight emissions when a newer event of the same type arrives. '
+            'Ideal for search typeaheads and autocomplete fields where only the latest query result matters.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'restartable_example.dart',
+          dart313Code: '''
+on<SearchQueryChanged>((event, emit) async {
+  emit(const SearchLoading());
+  final results = await searchService.query(event.text);
+  emit(SearchResults(results));
+}, transformer: restartable());
+''',
+          dart35Code: '''
+on<SearchQueryChanged>((event, emit) async {
+  emit(const SearchLoading());
+  final results = await _searchService.query(event.text);
+  emit(SearchResults(results));
+}, transformer: restartable());
+''',
+        ),
+      ]),
+
+      // 5. Custom Transformer Recipes
+      section(id: 'custom-transformers', classes: 'docs-section', [
+        h2([Component.text('Custom Transformer Recipes')]),
+        p([
+          Component.text(
+            'You can easily author custom transformers to satisfy bespoke concurrency requirements. '
+            'Here is a custom debounce transformer written in pure Dart:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'debounce_transformer.dart',
+          dart313Code: '''
+import 'dart:async';
+import 'package:bloc_signals/bloc_signals.dart';
+
+EventTransformer<E, S> debounce<E, S>(Duration duration) {
+  Timer? timer;
+  return (event, handler, emit) {
+    final completer = Completer<void>();
+    timer?.cancel();
+    timer = Timer(duration, () async {
+      try {
+        await handler(event, emit);
+        completer.complete();
+      } catch (error, stack) {
+        completer.completeError(error, stack);
+      }
+    });
+    return completer.future;
+  };
+}
+
+// Usage in Bloc constructor:
+// on<SearchInputChanged>(..., transformer: debounce(const Duration(milliseconds: 300)));
+''',
+          dart35Code: '''
+import 'dart:async';
+import 'package:bloc_signals/bloc_signals.dart';
+
+EventTransformer<E, S> debounce<E, S>(Duration duration) {
+  Timer? timer;
+  return (event, handler, emit) {
+    final completer = Completer<void>();
+    timer?.cancel();
+    timer = Timer(duration, () async {
+      try {
+        await handler(event, emit);
+        completer.complete();
+      } catch (error, stack) {
+        completer.completeError(error, stack);
+      }
+    });
+    return completer.future;
+  };
+}
+
+// Usage in Bloc constructor:
+// on<SearchInputChanged>(..., transformer: debounce(const Duration(milliseconds: 300)));
+''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_events_and_handlers.dart
+++ b/website/lib/src/components/docs/pages/docs_events_and_handlers.dart
@@ -1,0 +1,208 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering event dispatching, on<E> handler registration, and error handling in BlocSignal.
+class const DocsEventsAndHandlersPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'Event Registration with on<E>',
+      anchor: 'event-registration',
+    ),
+    TocHeading(
+      title: 'Single-Registration Rule',
+      anchor: 'single-registration-rule',
+    ),
+    TocHeading(
+      title: 'Concurrent Async Coordination',
+      anchor: 'async-coordination',
+    ),
+    TocHeading(
+      title: 'Error Handling & Fault Routing',
+      anchor: 'error-handling',
+    ),
+    TocHeading(
+      title: 'Dynamic Zone Event Tracing',
+      anchor: 'zone-event-tracing',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🧠 Core Concepts')]),
+        h1([Component.text('Events & Handlers')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Master event-driven state pipelines in BlocSignal: handler registration, asynchronous coordination, error routing, and zone-based event tracing.',
+          ),
+        ]),
+      ]),
+
+      // 1. Event Registration with on<E>
+      section(id: 'event-registration', classes: 'docs-section', [
+        h2([Component.text('Event Registration with on<E>')]),
+        p([
+          Component.text(
+            'In BlocSignal, event handlers are registered inside constructor bodies using the on<E>((event, emit) => ...) registry. '
+            'Handlers receive the strongly-typed event payload and an emit function to transition state.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'counter_bloc.dart',
+          dart313Code: '''
+sealed class CounterEvent {}
+final class IncrementPressed extends CounterEvent {}
+final class DecrementPressed extends CounterEvent {}
+
+class CounterBloc extends BlocSignal<CounterEvent, int> {
+  CounterBloc() : super(initialState: 0) {
+    on<IncrementPressed>((event, emit) {
+      emit(stateValue + 1);
+    });
+
+    on<DecrementPressed>((event, emit) {
+      emit(stateValue - 1);
+    });
+  }
+}''',
+          dart35Code: '''
+sealed class CounterEvent {}
+final class IncrementPressed extends CounterEvent {
+  const IncrementPressed();
+}
+final class DecrementPressed extends CounterEvent {
+  const DecrementPressed();
+}
+
+class CounterBloc extends BlocSignal<CounterEvent, int> {
+  CounterBloc() : super(initialState: 0) {
+    on<IncrementPressed>((event, emit) {
+      emit(stateValue + 1);
+    });
+
+    on<DecrementPressed>((event, emit) {
+      emit(stateValue - 1);
+    });
+  }
+}''',
+        ),
+      ]),
+
+      // 2. Single-Registration Rule
+      section(id: 'single-registration-rule', classes: 'docs-section', [
+        h2([Component.text('Single-Registration Rule')]),
+        p([
+          Component.text(
+            'Each event type E can be registered at most once in a given BlocSignal. '
+            'Attempting to register on<E>() for the exact same event type twice will immediately throw a StateError during initialization.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.warning,
+          title: 'Duplicate Registration Detection',
+          children: [
+            p([
+              Component.text(
+                'Registering on<MyEvent> multiple times is disallowed to eliminate ambiguous execution order. '
+                'Use polymorphic subclasses or consolidated handler functions instead.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 3. Concurrent Async Coordination
+      section(id: 'async-coordination', classes: 'docs-section', [
+        h2([Component.text('Concurrent Async Coordination')]),
+        p([
+          Component.text(
+            'Event handlers in BlocSignal support FutureOr<void>. When multiple asynchronous events are dispatched in rapid succession, '
+            'handlers execute concurrently by default. You can control execution strategy by applying concurrency transformers.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'async_event_handling.dart',
+          dart313Code: '''
+class SearchBloc(SearchService service)
+    extends BlocSignal<SearchEvent, SearchState>(initialState: const SearchInitial()) {
+  init {
+    on<SearchQuerySubmitted>((event, emit) async {
+      emit(const SearchLoading());
+      try {
+        final results = await service.search(event.query);
+        emit(SearchSuccess(results));
+      } catch (e, stack) {
+        emit(SearchError(e.toString()));
+      }
+    }, transformer: restartable());
+  }
+}''',
+          dart35Code: '''
+class SearchBloc extends BlocSignal<SearchEvent, SearchState> {
+  SearchBloc(this._service) : super(initialState: const SearchInitial()) {
+    on<SearchQuerySubmitted>((event, emit) async {
+      emit(const SearchLoading());
+      try {
+        final results = await _service.search(event.query);
+        emit(SearchSuccess(results));
+      } catch (e, stack) {
+        emit(SearchError(e.toString()));
+      }
+    }, transformer: restartable());
+  }
+
+  final SearchService _service;
+}''',
+        ),
+      ]),
+
+      // 4. Error Handling & Fault Routing
+      section(id: 'error-handling', classes: 'docs-section', [
+        h2([Component.text('Error Handling & Fault Routing')]),
+        p([
+          Component.text(
+            'BlocSignal enforces strict fault isolation between operational exceptions and programmer errors:',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([
+              Component.text(
+                'Operational Exceptions (Exception, FormatException, etc.): ',
+              ),
+            ]),
+            Component.text(
+              'Caught automatically and routed to onError(error, stackTrace) and registered BlocSignalObserver instances without crashing the application.',
+            ),
+          ]),
+          li([
+            strong([
+              Component.text(
+                'Programmer Errors (Error, RangeError, TypeError): ',
+              ),
+            ]),
+            Component.text(
+              'Rethrown immediately to fail fast in development and highlight code defects.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 5. Dynamic Zone Event Tracing
+      section(id: 'zone-event-tracing', classes: 'docs-section', [
+        h2([Component.text('Dynamic Zone Event Tracing')]),
+        p([
+          Component.text(
+            'Whenever emit(newState) is called inside an on<E> handler, BlocSignal captures the causing event using Dart dynamic Zones. '
+            'This means downstream observers receive a complete Transition(currentState, event, nextState) without requiring developers to pass the event explicitly to emit().',
+          ),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_lifecycle_and_observers.dart
+++ b/website/lib/src/components/docs/pages/docs_lifecycle_and_observers.dart
@@ -1,0 +1,276 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering BlocSignalObserver, lifecycle hooks, Change, Transition, and telemetry.
+class const DocsLifecycleAndObserversPage({super.key})
+    extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'BlocSignalObserver Contract',
+      anchor: 'observer-contract',
+    ),
+    TocHeading(
+      title: 'Lifecycle Hook Reference',
+      anchor: 'lifecycle-hook-reference',
+    ),
+    TocHeading(title: 'Change vs. Transition', anchor: 'change-vs-transition'),
+    TocHeading(
+      title: 'OpenTelemetry & DevTools',
+      anchor: 'opentelemetry-devtools',
+    ),
+    TocHeading(
+      title: 'Memory Leak Prevention in Observers',
+      anchor: 'memory-leak-prevention',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🧠 Core Concepts')]),
+        h1([Component.text('Lifecycle & Observers')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Monitor, trace, and instrument state containers across your application using BlocSignalObserver, OpenTelemetry spans, and DevTools hooks.',
+          ),
+        ]),
+      ]),
+
+      // 1. BlocSignalObserver Contract
+      section(id: 'observer-contract', classes: 'docs-section', [
+        h2([Component.text('BlocSignalObserver Contract')]),
+        p([
+          Component.text(
+            'BlocSignalObserver provides a global inspection interface to observe container creation, event dispatching, '
+            'state changes, transitions, errors, and disposal across the entire application lifecycle.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'app_observer.dart',
+          dart313Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class AppBlocObserver extends BlocSignalObserver {
+  @override
+  void onCreate(BlocSignalBase bloc) {
+    super.onCreate(bloc);
+    print('Container Created: \${bloc.runtimeType}');
+  }
+
+  @override
+  void onEvent(BlocSignal bloc, Object? event) {
+    super.onEvent(bloc, event);
+    print('\${bloc.runtimeType} Event: \$event');
+  }
+
+  @override
+  void onChange(BlocSignalBase bloc, Change change) {
+    super.onChange(bloc, change);
+    print('\${bloc.runtimeType} Change: \${change.currentState} -> \${change.nextState}');
+  }
+
+  @override
+  void onTransition(BlocSignal bloc, Transition transition) {
+    super.onTransition(bloc, transition);
+    print('\${bloc.runtimeType} Transition: \${transition.event} => \${transition.nextState}');
+  }
+
+  @override
+  void onError(BlocSignalBase bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    print('Error in \${bloc.runtimeType}: \$error');
+  }
+
+  @override
+  void onClose(BlocSignalBase bloc) {
+    super.onClose(bloc);
+    print('Container Closed: \${bloc.runtimeType}');
+  }
+}
+
+// In main.dart:
+// BlocSignalObserver.observer = AppBlocObserver();
+''',
+          dart35Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class AppBlocObserver extends BlocSignalObserver {
+  @override
+  void onCreate(BlocSignalBase bloc) {
+    super.onCreate(bloc);
+    print('Container Created: \${bloc.runtimeType}');
+  }
+
+  @override
+  void onEvent(BlocSignal bloc, Object? event) {
+    super.onEvent(bloc, event);
+    print('\${bloc.runtimeType} Event: \$event');
+  }
+
+  @override
+  void onChange(BlocSignalBase bloc, Change change) {
+    super.onChange(bloc, change);
+    print('\${bloc.runtimeType} Change: \${change.currentState} -> \${change.nextState}');
+  }
+
+  @override
+  void onTransition(BlocSignal bloc, Transition transition) {
+    super.onTransition(bloc, transition);
+    print('\${bloc.runtimeType} Transition: \${transition.event} => \${transition.nextState}');
+  }
+
+  @override
+  void onError(BlocSignalBase bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    print('Error in \${bloc.runtimeType}: \$error');
+  }
+
+  @override
+  void onClose(BlocSignalBase bloc) {
+    super.onClose(bloc);
+    print('Container Closed: \${bloc.runtimeType}');
+  }
+}
+
+// In main.dart:
+// BlocSignalObserver.observer = AppBlocObserver();
+''',
+        ),
+      ]),
+
+      // 2. Lifecycle Hook Reference
+      section(id: 'lifecycle-hook-reference', classes: 'docs-section', [
+        h2([Component.text('Lifecycle Hook Reference')]),
+        div(classes: 'docs-table-wrapper', [
+          table(classes: 'docs-table', [
+            thead([
+              tr([
+                th([Component.text('Hook')]),
+                th([Component.text('Target')]),
+                th([Component.text('Trigger Moment')]),
+              ]),
+            ]),
+            tbody([
+              tr([
+                td([Component.text('onCreate')]),
+                td([Component.text('Cubit & Bloc')]),
+                td([
+                  Component.text(
+                    'Immediately after container constructor execution.',
+                  ),
+                ]),
+              ]),
+              tr([
+                td([Component.text('onEvent')]),
+                td([Component.text('Bloc only')]),
+                td([
+                  Component.text(
+                    'When add(event) is called before handler dispatch.',
+                  ),
+                ]),
+              ]),
+              tr([
+                td([Component.text('onChange')]),
+                td([Component.text('Cubit & Bloc')]),
+                td([
+                  Component.text('When emit() produces a new non-equal state.'),
+                ]),
+              ]),
+              tr([
+                td([Component.text('onTransition')]),
+                td([Component.text('Bloc only')]),
+                td([
+                  Component.text(
+                    'When emit() produces a new state associated with a causal event.',
+                  ),
+                ]),
+              ]),
+              tr([
+                td([Component.text('onError')]),
+                td([Component.text('Cubit & Bloc')]),
+                td([
+                  Component.text(
+                    'When an operational exception is captured during event processing.',
+                  ),
+                ]),
+              ]),
+              tr([
+                td([Component.text('onClose')]),
+                td([Component.text('Cubit & Bloc')]),
+                td([
+                  Component.text(
+                    'When close() is invoked and signal effects are disposed.',
+                  ),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+
+      // 3. Change vs. Transition
+      section(id: 'change-vs-transition', classes: 'docs-section', [
+        h2([Component.text('Change vs. Transition')]),
+        p([
+          Component.text(
+            'Both Change<State> and Transition<Event, State> represent state mutations, but provide different levels of context:',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([
+              Component.text('Change<State>(currentState, nextState): '),
+            ]),
+            Component.text(
+              'Fires for all state containers (both Cubits and Blocs). Contains before and after states.',
+            ),
+          ]),
+          li([
+            strong([
+              Component.text(
+                'Transition<Event, State>(currentState, event, nextState): ',
+              ),
+            ]),
+            Component.text(
+              'Fires exclusively for BlocSignal. Enriches the Change with the causal event that triggered the mutation.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 4. OpenTelemetry & DevTools
+      section(id: 'opentelemetry-devtools', classes: 'docs-section', [
+        h2([Component.text('OpenTelemetry & DevTools Integration')]),
+        p([
+          Component.text(
+            'The satellite package bloc_signals_otel provides OtelBlocSignalObserver, instrumenting events and transitions '
+            'into distributed OpenTelemetry trace spans. In addition, DevToolsBlocSignalObserver posts diagnostic events via dart:developer for Flutter DevTools.',
+          ),
+        ]),
+      ]),
+
+      // 5. Memory Leak Prevention in Observers
+      section(id: 'memory-leak-prevention', classes: 'docs-section', [
+        h2([Component.text('Memory Leak Prevention in Observers')]),
+        const DocsCallout(
+          type: CalloutType.important,
+          title: 'Span & Key Eviction Rules',
+          children: [
+            p([
+              Component.text(
+                'Because onTransition may not fire for every event (for example, when an error occurs or state is de-duplicated), '
+                'active span maps in telemetry observers must be capped (default 100 entries) with oldest-key eviction. '
+                'Furthermore, onClose() MUST purge lingering spans to prevent retained memory leaks upon container disposal.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_overview.dart
+++ b/website/lib/src/components/docs/pages/docs_overview.dart
@@ -252,7 +252,9 @@ void main() {
           ]),
           div(classes: 'docs-arch-arrow', [Component.text('➔')]),
           div(classes: 'docs-arch-step', [
-            span(classes: 'docs-arch-badge', [Component.text('4. UI & Observers')]),
+            span(classes: 'docs-arch-badge', [
+              Component.text('4. UI & Observers'),
+            ]),
             span(classes: 'docs-arch-desc', [
               Component.text('Widgets and telemetry receive instant updates.'),
             ]),

--- a/website/lib/src/components/docs/pages/docs_signals_reactivity.dart
+++ b/website/lib/src/components/docs/pages/docs_signals_reactivity.dart
@@ -1,0 +1,180 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering signals graph reactivity, stateValue vs state, computed derivations, and reactions.
+class const DocsSignalsReactivityPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'stateValue vs. state', anchor: 'statevalue-vs-state'),
+    TocHeading(title: 'Signals Graph Architecture', anchor: 'signals-graph'),
+    TocHeading(
+      title: 'Deriving State with computed()',
+      anchor: 'computed-derivations',
+    ),
+    TocHeading(
+      title: 'Managing Side Effects with effect()',
+      anchor: 'side-effects',
+    ),
+    TocHeading(
+      title: '0ms Synchronous Frame Propagation',
+      anchor: 'synchronous-propagation',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🧠 Core Concepts')]),
+        h1([Component.text('Signals Graph Reactivity')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Understand how BlocSignal leverages Rody Davis signals v7 primitives for fine-grained dependency tracking, automatic de-duplication, and 0ms synchronous updates.',
+          ),
+        ]),
+      ]),
+
+      // 1. stateValue vs. state
+      section(id: 'statevalue-vs-state', classes: 'docs-section', [
+        h2([Component.text('stateValue vs. state')]),
+        p([
+          Component.text(
+            'Every BlocSignalBase exposes two core state getters with distinct purposes:',
+          ),
+        ]),
+        ul(classes: 'docs-list', [
+          li([
+            strong([Component.text('stateValue (StateType): ')]),
+            Component.text(
+              'Reads the raw, current state synchronously. It does NOT register a signal dependency when read inside a computed or effect callback. '
+              'Use this for imperative checks, conditionals, and inside event handlers.',
+            ),
+          ]),
+          li([
+            strong([Component.text('state (ReadonlySignal<StateType>): ')]),
+            Component.text(
+              'Exposes the underlying reactive signal. Calling state() or state.value inside a computed signal or Flutter SignalBuilder automatically '
+              'subscribes to state updates and triggers fine-grained recalculations.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 2. Signals Graph Architecture
+      section(id: 'signals-graph', classes: 'docs-section', [
+        h2([Component.text('Signals Graph Architecture')]),
+        p([
+          Component.text(
+            'Under the hood, BlocSignal state containers create a Signal<StateType> node in the global reactive graph. '
+            'Whenever emit(newState) is called, the graph evaluates equality. If the state has changed, dependent nodes '
+            '(computed signals, effect listeners, and active Flutter Element subscribers) are marked dirty and evaluated synchronously.',
+          ),
+        ]),
+      ]),
+
+      // 3. Deriving State with computed()
+      section(id: 'computed-derivations', classes: 'docs-section', [
+        h2([Component.text('Deriving State with computed()')]),
+        p([
+          Component.text(
+            'You can derive combined state across multiple independent Cubits and Blocs without boilerplate orchestration blocs using computed():',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'computed_cart_example.dart',
+          dart313Code: '''
+final cartCubit = CartCubit();
+final userCubit = UserCubit();
+
+// Derived computed signal:
+final checkoutSummary = computed(() {
+  final items = cartCubit.state.value;
+  final user = userCubit.state.value;
+  final subtotal = items.fold<double>(0, (sum, item) => sum + item.price);
+  final discount = user.isVip ? 0.20 : 0.0;
+  return subtotal * (1 - discount);
+});
+
+// Automatically re-evaluates ONLY when cart or user state changes!
+''',
+          dart35Code: '''
+final cartCubit = CartCubit();
+final userCubit = UserCubit();
+
+// Derived computed signal:
+final checkoutSummary = computed(() {
+  final items = cartCubit.state.value;
+  final user = userCubit.state.value;
+  final subtotal = items.fold<double>(0, (sum, item) => sum + item.price);
+  final discount = user.isVip ? 0.20 : 0.0;
+  return subtotal * (1 - discount);
+});
+
+// Automatically re-evaluates ONLY when cart or user state changes!
+''',
+        ),
+      ]),
+
+      // 4. Managing Side Effects with effect()
+      section(id: 'side-effects', classes: 'docs-section', [
+        h2([Component.text('Managing Side Effects with effect()')]),
+        p([
+          Component.text(
+            'Use effect() or createEffect() to execute side effects (logging, persistent storage writes, analytics triggers) '
+            'in response to signal graph mutations. The callback runs immediately upon initialization and re-runs whenever tracked signals mutate.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'effect_logging_example.dart',
+          dart313Code: '''
+final disposeEffect = effect(() {
+  final currentCount = counterBloc.state.value;
+  print('Counter signal updated: \$currentCount');
+});
+
+// Call disposeEffect() to cancel the subscription when no longer needed.
+''',
+          dart35Code: '''
+final disposeEffect = effect(() {
+  final currentCount = counterBloc.state.value;
+  print('Counter signal updated: \$currentCount');
+});
+
+// Call disposeEffect() to cancel the subscription when no longer needed.
+''',
+        ),
+      ]),
+
+      // 5. 0ms Synchronous Frame Propagation
+      section(id: 'synchronous-propagation', classes: 'docs-section', [
+        h2([Component.text('0ms Synchronous Frame Propagation')]),
+        p([
+          Component.text(
+            'Traditional stream-based state management libraries queue state emissions onto asynchronous microtask queues. '
+            'This introduces at least 1-2 microtask ticks before UI widgets receive the new state.',
+          ),
+        ]),
+        p([
+          Component.text(
+            'BlocSignal executes state transitions synchronously. When emit(newState) is called, downstream computations '
+            'and widget builders are notified in the exact same execution frame, eliminating frame flickers and race conditions in complex UI workflows.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Immediate Test Verifications',
+          children: [
+            p([
+              Component.text(
+                'Because state propagation is 0ms synchronous, unit tests do not require artificial pumpAndSettle() or async sleep delays to assert immediate state changes.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_state_modeling.dart
+++ b/website/lib/src/components/docs/pages/docs_state_modeling.dart
@@ -1,0 +1,275 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering state modeling, immutability, records, and equality in BlocSignal.
+class const DocsStateModelingPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'Immutability Fundamentals',
+      anchor: 'immutability-fundamentals',
+    ),
+    TocHeading(title: 'Sealed Class Unions', anchor: 'sealed-class-unions'),
+    TocHeading(title: 'Dart Records for State', anchor: 'dart-records'),
+    TocHeading(
+      title: 'Fast Immutable Collections',
+      anchor: 'immutable-collections',
+    ),
+    TocHeading(
+      title: 'Equality & De-duplication',
+      anchor: 'equality-deduplication',
+    ),
+    TocHeading(
+      title: 'Custom SignalOptions Comparators',
+      anchor: 'custom-comparators',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🧠 Core Concepts')]),
+        h1([Component.text('State Modeling & Immutability')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Master state architecture patterns in BlocSignal: sealed class unions, Dart records, immutable collections, and custom equality comparators.',
+          ),
+        ]),
+      ]),
+
+      // 1. Immutability Fundamentals
+      section(id: 'immutability-fundamentals', classes: 'docs-section', [
+        h2([Component.text('Immutability Fundamentals')]),
+        p([
+          Component.text(
+            'State in BlocSignal must always be immutable. Because signals perform automatic de-duplication using equality checks (==), '
+            'in-place mutation of mutable objects (such as calling list.add() on a standard List) will not trigger signal recalculations or widget rebuilds.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.important,
+          title: 'Never Mutate State In-Place',
+          children: [
+            p([
+              Component.text(
+                'Always emit a brand new instance or a copyWith copy. In-place mutations break reactive dependency tracking and violate the unidirectional data flow contract.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 2. Sealed Class Unions
+      section(id: 'sealed-class-unions', classes: 'docs-section', [
+        h2([Component.text('Sealed Class Unions')]),
+        p([
+          Component.text(
+            'Dart 3 sealed classes provide type-safe, exhaustive pattern matching across all possible UI states. '
+            'This completely eliminates impossible state representations (for example, showing a loading spinner while simultaneously displaying an error alert).',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'user_profile_state.dart',
+          dart313Code: '''
+sealed class ProfileState {
+  const ProfileState();
+}
+
+final class ProfileLoading extends ProfileState {
+  const ProfileLoading();
+}
+
+final class ProfileLoaded(this.user, this.posts) extends ProfileState {
+  final User user;
+  final List<Post> posts;
+}
+
+final class ProfileError(this.message) extends ProfileState {
+  final String message;
+}
+
+// In your UI component:
+Widget buildProfile(BuildContext context, ProfileState state) {
+  return switch (state) {
+    ProfileLoading() => const CircularProgressIndicator(),
+    ProfileLoaded(:final user, :final posts) => ProfileView(user: user, posts: posts),
+    ProfileError(:final message) => ErrorBanner(message: message),
+  };
+}''',
+          dart35Code: '''
+sealed class ProfileState {
+  const ProfileState();
+}
+
+final class ProfileLoading extends ProfileState {
+  const ProfileLoading();
+}
+
+final class ProfileLoaded extends ProfileState {
+  const ProfileLoaded(this.user, this.posts);
+  final User user;
+  final List<Post> posts;
+}
+
+final class ProfileError extends ProfileState {
+  const ProfileError(this.message);
+  final String message;
+}
+
+// In your UI component:
+Widget buildProfile(BuildContext context, ProfileState state) {
+  return switch (state) {
+    ProfileLoading() => const CircularProgressIndicator(),
+    ProfileLoaded(:final user, :final posts) => ProfileView(user: user, posts: posts),
+    ProfileError(:final message) => ErrorBanner(message: message),
+  };
+}''',
+        ),
+      ]),
+
+      // 3. Dart Records for State
+      section(id: 'dart-records', classes: 'docs-section', [
+        h2([Component.text('Dart Records for State')]),
+        p([
+          Component.text(
+            'For simple, multi-field states, Dart Records provide built-in value equality and structural typing without creating standalone classes:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'pagination_cubit.dart',
+          dart313Code: '''
+typedef PaginationState = ({int page, int pageSize, bool hasMore});
+
+class PaginationCubit extends CubitSignal<PaginationState> {
+  PaginationCubit()
+      : super(initialState: (page: 1, pageSize: 20, hasMore: true));
+
+  void nextPage() {
+    emit((
+      page: stateValue.page + 1,
+      pageSize: stateValue.pageSize,
+      hasMore: stateValue.hasMore,
+    ));
+  }
+}''',
+          dart35Code: '''
+typedef PaginationState = ({int page, int pageSize, bool hasMore});
+
+class PaginationCubit extends CubitSignal<PaginationState> {
+  PaginationCubit()
+      : super(initialState: (page: 1, pageSize: 20, hasMore: true));
+
+  void nextPage() {
+    emit((
+      page: stateValue.page + 1,
+      pageSize: stateValue.pageSize,
+      hasMore: stateValue.hasMore,
+    ));
+  }
+}''',
+        ),
+      ]),
+
+      // 4. Fast Immutable Collections
+      section(id: 'immutable-collections', classes: 'docs-section', [
+        h2([Component.text('Fast Immutable Collections (FIC)')]),
+        p([
+          Component.text(
+            'Standard Dart List and Map instances compare by identity reference rather than contents. '
+            'Using Fast Immutable Collections (package:fast_immutable_collections) guarantees true structural equality and O(1) mutations.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'todo_cubit.dart',
+          dart313Code: '''
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+
+class TodoCubit extends CubitSignal<IList<String>> {
+  TodoCubit() : super(initialState: const <String>[].lock);
+
+  void addTodo(String item) {
+    emit(stateValue.add(item));
+  }
+
+  void removeTodo(int index) {
+    emit(stateValue.removeAt(index));
+  }
+}''',
+          dart35Code: '''
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
+
+class TodoCubit extends CubitSignal<IList<String>> {
+  TodoCubit() : super(initialState: const <String>[].lock);
+
+  void addTodo(String item) {
+    emit(stateValue.add(item));
+  }
+
+  void removeTodo(int index) {
+    emit(stateValue.removeAt(index));
+  }
+}''',
+        ),
+      ]),
+
+      // 5. Equality & De-duplication
+      section(id: 'equality-deduplication', classes: 'docs-section', [
+        h2([Component.text('Equality & De-duplication')]),
+        p([
+          Component.text(
+            'Whenever emit(newState) is called, BlocSignal compares the incoming state with the current state. '
+            'If the states evaluate as equal (previous == next), the emission is dropped automatically. '
+            'No Change is emitted, observers are not notified, and downstream widgets do not perform redundant rebuilds.',
+          ),
+        ]),
+      ]),
+
+      // 6. Custom SignalOptions Comparators
+      section(id: 'custom-comparators', classes: 'docs-section', [
+        h2([Component.text('Custom SignalOptions Comparators')]),
+        p([
+          Component.text(
+            'You can customize equality evaluation per-container by passing a SignalOptions instance or an equals: comparator closure:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          filename: 'custom_comparator_cubit.dart',
+          dart313Code: '''
+class CaseInsensitiveCubit extends CubitSignal<String> {
+  CaseInsensitiveCubit()
+      : super(
+          initialState: '',
+          equals: (a, b) => a.toLowerCase() == b.toLowerCase(),
+        );
+
+  void updateText(String text) => emit(text);
+}
+
+// In this cubit:
+// cubit.updateText('Flutter');
+// cubit.updateText('flutter'); // Dropped as duplicate! No rebuild triggered.
+''',
+          dart35Code: '''
+class CaseInsensitiveCubit extends CubitSignal<String> {
+  CaseInsensitiveCubit()
+      : super(
+          initialState: '',
+          equals: (a, b) => a.toLowerCase() == b.toLowerCase(),
+        );
+
+  void updateText(String text) => emit(text);
+}
+
+// In this cubit:
+// cubit.updateText('Flutter');
+// cubit.updateText('flutter'); // Dropped as duplicate! No rebuild triggered.
+''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/cubits/docs_cubit.dart
+++ b/website/lib/src/cubits/docs_cubit.dart
@@ -49,22 +49,35 @@ class DocsCubit({String? initialSectionId}) extends CubitSignal<DocsState> {
       final path = web.window.location.pathname;
       final hash = web.window.location.hash;
 
-      // Check if path is e.g. /docs/installation
-      if (path.startsWith('/docs/')) {
-        final slug = path.replaceFirst('/docs/', '').trim();
-        if (slug.isNotEmpty) return slug;
+      final pathSlug = _cleanSlug(path);
+      if (pathSlug.isNotEmpty && pathSlug != 'docs') {
+        return DocsRegistry.resolveSection(pathSlug).id;
       }
 
-      // Check if hash is e.g. #docs/installation or #installation
-      final cleanHash = hash
-          .replaceFirst('#', '')
-          .replaceFirst('docs/', '')
-          .trim();
-      if (cleanHash.isNotEmpty) {
-        return cleanHash;
+      final hashSlug = _cleanSlug(hash.replaceFirst('#', ''));
+      if (hashSlug.isNotEmpty && hashSlug != 'docs') {
+        return DocsRegistry.resolveSection(hashSlug).id;
       }
     } catch (_) {}
     return 'overview';
+  }
+
+  static String _cleanSlug(String raw) {
+    var s = raw.trim();
+    if (s.startsWith('/')) s = s.substring(1);
+    if (s.endsWith('/')) s = s.substring(0, s.length - 1);
+    if (s.endsWith('/index.html')) {
+      s = s.substring(0, s.length - '/index.html'.length);
+    } else if (s.endsWith('index.html')) {
+      s = s.substring(0, s.length - 'index.html'.length);
+    }
+    if (s.startsWith('docs/')) {
+      s = s.substring('docs/'.length);
+    } else if (s == 'docs') {
+      s = '';
+    }
+    if (s.endsWith('/')) s = s.substring(0, s.length - 1);
+    return s.trim();
   }
 
   void _syncFromBrowser() {
@@ -77,14 +90,14 @@ class DocsCubit({String? initialSectionId}) extends CubitSignal<DocsState> {
 
   /// Selects a new active documentation section.
   void selectSection(String sectionId, {bool pushHistory = true}) {
-    if (stateValue.activeSectionId == sectionId) {
+    final targetSection = DocsRegistry.resolveSection(sectionId);
+
+    if (stateValue.activeSectionId == targetSection.id) {
       if (stateValue.isMobileDrawerOpen) {
         closeMobileDrawer();
       }
       return;
     }
-
-    final targetSection = DocsRegistry.resolveSection(sectionId);
 
     if (pushHistory) {
       try {
@@ -98,13 +111,13 @@ class DocsCubit({String? initialSectionId}) extends CubitSignal<DocsState> {
 
     emit(
       stateValue.copyWith(
-        activeSectionId: sectionId,
+        activeSectionId: targetSection.id,
         expandedCategories: updatedCategories,
         isMobileDrawerOpen: false,
       ),
     );
 
-    _trackDocsPageView(sectionId);
+    _trackDocsPageView(targetSection.id);
 
     // Scroll to top of article
     try {

--- a/website/lib/src/models/docs_registry.dart
+++ b/website/lib/src/models/docs_registry.dart
@@ -1,9 +1,15 @@
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
+import '../components/docs/pages/docs_cubit_vs_bloc.dart';
+import '../components/docs/pages/docs_event_transformers.dart';
+import '../components/docs/pages/docs_events_and_handlers.dart';
 import '../components/docs/pages/docs_installation.dart';
+import '../components/docs/pages/docs_lifecycle_and_observers.dart';
 import '../components/docs/pages/docs_overview.dart';
 import '../components/docs/pages/docs_quickstart.dart';
+import '../components/docs/pages/docs_signals_reactivity.dart';
+import '../components/docs/pages/docs_state_modeling.dart';
 import 'docs_models.dart';
 
 /// Central registry of all documentation topics and categories across all phases.
@@ -40,7 +46,7 @@ class const DocsRegistry() {
         ),
       ],
     ),
-    DocCategory(
+    const DocCategory(
       title: 'Core Concepts',
       icon: '🧠',
       sections: [
@@ -50,12 +56,7 @@ class const DocsRegistry() {
           path: '/docs/cubit-vs-bloc',
           category: 'Core Concepts',
           description: 'Choosing between direct method invocation and event-driven architectures.',
-          badge: 'Phase 2',
-          builder: () => _PlaceholderDoc(
-            title: 'CubitSignal vs. BlocSignal',
-            phase: 'Phase 2',
-            description: 'In-depth architectural comparison, philosophy, and decision matrix between CubitSignal and BlocSignal.',
-          ),
+          builder: DocsCubitVsBlocPage.new,
         ),
         DocSectionItem(
           id: 'state-modeling',
@@ -63,12 +64,7 @@ class const DocsRegistry() {
           path: '/docs/state-modeling',
           category: 'Core Concepts',
           description: 'Immutable data models, Dart Records, Fast Immutable Collections (FIC), and custom equality comparators.',
-          badge: 'Phase 2',
-          builder: () => _PlaceholderDoc(
-            title: 'State Modeling & Immutability',
-            phase: 'Phase 2',
-            description: 'Best practices for state modeling, immutability, Record states, and SignalOptions custom equals.',
-          ),
+          builder: DocsStateModelingPage.new,
         ),
         DocSectionItem(
           id: 'events-and-handlers',
@@ -76,12 +72,7 @@ class const DocsRegistry() {
           path: '/docs/events-and-handlers',
           category: 'Core Concepts',
           description: 'Registering typed event handlers with on<E>(), concurrency coordination, and error tracking.',
-          badge: 'Phase 2',
-          builder: () => _PlaceholderDoc(
-            title: 'Events & Handlers',
-            phase: 'Phase 2',
-            description: 'How on<E> handlers work, synchronous event dispatching, and Future.wait concurrency.',
-          ),
+          builder: DocsEventsAndHandlersPage.new,
         ),
         DocSectionItem(
           id: 'event-transformers',
@@ -89,12 +80,7 @@ class const DocsRegistry() {
           path: '/docs/event-transformers',
           category: 'Core Concepts',
           description: 'Streamless event transformers (droppable, sequential, restartable) and custom debounce/mutex locks.',
-          badge: 'Phase 2',
-          builder: () => _PlaceholderDoc(
-            title: 'Event Transformers',
-            phase: 'Phase 2',
-            description: 'Streamless higher-order function concurrency transformers and Mutex locks.',
-          ),
+          builder: DocsEventTransformersPage.new,
         ),
         DocSectionItem(
           id: 'lifecycle-and-observers',
@@ -102,12 +88,7 @@ class const DocsRegistry() {
           path: '/docs/lifecycle-and-observers',
           category: 'Core Concepts',
           description: 'BlocSignalObserver, Change, Transition, and OpenTelemetry identity span tracking.',
-          badge: 'Phase 2',
-          builder: () => _PlaceholderDoc(
-            title: 'Lifecycle & Observers',
-            phase: 'Phase 2',
-            description: 'Global and local observer lifecycles, Change/Transition logging, and DevTools hooks.',
-          ),
+          builder: DocsLifecycleAndObserversPage.new,
         ),
         DocSectionItem(
           id: 'signals-reactivity',
@@ -115,12 +96,7 @@ class const DocsRegistry() {
           path: '/docs/signals-reactivity',
           category: 'Core Concepts',
           description: 'Understanding stateValue vs state, computed() derivations, and managed effect() reactions.',
-          badge: 'Phase 2',
-          builder: () => _PlaceholderDoc(
-            title: 'Signals Graph Reactivity',
-            phase: 'Phase 2',
-            description: 'How ReadonlySignal powers automatic de-duplication, fine-grained reactivity, and 0ms updates.',
-          ),
+          builder: DocsSignalsReactivityPage.new,
         ),
       ],
     ),
@@ -358,9 +334,28 @@ class const DocsRegistry() {
 
   /// Resolves a section by its ID or returns the default overview.
   static DocSectionItem resolveSection(String id) {
+    var cleanId = id.trim();
+    if (cleanId.startsWith('/')) cleanId = cleanId.substring(1);
+    if (cleanId.endsWith('/')) cleanId = cleanId.substring(0, cleanId.length - 1);
+    if (cleanId.endsWith('/index.html')) {
+      cleanId = cleanId.substring(0, cleanId.length - '/index.html'.length);
+    } else if (cleanId.endsWith('index.html')) {
+      cleanId = cleanId.substring(0, cleanId.length - 'index.html'.length);
+    }
+    if (cleanId.startsWith('docs/')) {
+      cleanId = cleanId.substring('docs/'.length);
+    }
+
     for (final category in categories) {
       for (final section in category.sections) {
-        if (section.id == id) return section;
+        if (section.id == id ||
+            section.id == cleanId ||
+            section.path == id ||
+            section.path == '/$id' ||
+            section.path == '/docs/$cleanId' ||
+            section.path == '/$cleanId') {
+          return section;
+        }
       }
     }
     return categories.first.sections.first;

--- a/website/test/docs_cubit_test.dart
+++ b/website/test/docs_cubit_test.dart
@@ -28,13 +28,16 @@ void main() {
       );
     });
 
-    test('selectSection updates activeSectionId and expands target category', () {
-      cubit.selectSection('testing-guide', pushHistory: false);
+    test(
+      'selectSection updates activeSectionId and expands target category',
+      () {
+        cubit.selectSection('testing-guide', pushHistory: false);
 
-      expect(cubit.stateValue.activeSectionId, equals('testing-guide'));
-      expect(cubit.stateValue.expandedCategories, contains('Testing'));
-      expect(cubit.stateValue.isMobileDrawerOpen, isFalse);
-    });
+        expect(cubit.stateValue.activeSectionId, equals('testing-guide'));
+        expect(cubit.stateValue.expandedCategories, contains('Testing'));
+        expect(cubit.stateValue.isMobileDrawerOpen, isFalse);
+      },
+    );
 
     test('selectSection ignores selecting the already active section', () {
       final initialState = cubit.stateValue;

--- a/website/test/docs_registry_test.dart
+++ b/website/test/docs_registry_test.dart
@@ -34,6 +34,44 @@ void main() {
       final quickstart = DocsRegistry.resolveSection('quickstart');
       expect(quickstart.id, equals('quickstart'));
       expect(quickstart.path, equals('/docs/quickstart'));
+
+      final cubitVsBloc = DocsRegistry.resolveSection('cubit-vs-bloc');
+      expect(cubitVsBloc.id, equals('cubit-vs-bloc'));
+      expect(cubitVsBloc.category, equals('Core Concepts'));
+
+      final stateModeling = DocsRegistry.resolveSection('state-modeling');
+      expect(stateModeling.id, equals('state-modeling'));
+      expect(stateModeling.category, equals('Core Concepts'));
+
+      final events = DocsRegistry.resolveSection('events-and-handlers');
+      expect(events.id, equals('events-and-handlers'));
+
+      final transformers = DocsRegistry.resolveSection('event-transformers');
+      expect(transformers.id, equals('event-transformers'));
+
+      final lifecycle = DocsRegistry.resolveSection('lifecycle-and-observers');
+      expect(lifecycle.id, equals('lifecycle-and-observers'));
+
+      final reactivity = DocsRegistry.resolveSection('signals-reactivity');
+      expect(reactivity.id, equals('signals-reactivity'));
+
+      // Variations with trailing slashes, index.html, and full paths
+      expect(
+        DocsRegistry.resolveSection('installation/').id,
+        equals('installation'),
+      );
+      expect(
+        DocsRegistry.resolveSection('/docs/installation/').id,
+        equals('installation'),
+      );
+      expect(
+        DocsRegistry.resolveSection('/docs/quickstart/index.html').id,
+        equals('quickstart'),
+      );
+      expect(
+        DocsRegistry.resolveSection('/docs/cubit-vs-bloc').id,
+        equals('cubit-vs-bloc'),
+      );
     });
 
     test('resolveSection falls back to first section on unknown id', () {
@@ -43,17 +81,23 @@ void main() {
 
     test('getAdjacentSections returns correct prev and next sections', () {
       // First section has no previous
-      final (firstPrev, firstNext) = DocsRegistry.getAdjacentSections('overview');
+      final (firstPrev, firstNext) = DocsRegistry.getAdjacentSections(
+        'overview',
+      );
       expect(firstPrev, isNull);
       expect(firstNext?.id, equals('installation'));
 
       // Middle section has both prev and next
-      final (midPrev, midNext) = DocsRegistry.getAdjacentSections('installation');
+      final (midPrev, midNext) = DocsRegistry.getAdjacentSections(
+        'installation',
+      );
       expect(midPrev?.id, equals('overview'));
       expect(midNext?.id, equals('quickstart'));
 
       // Unknown section returns (null, null)
-      final (nonePrev, noneNext) = DocsRegistry.getAdjacentSections('nonexistent');
+      final (nonePrev, noneNext) = DocsRegistry.getAdjacentSections(
+        'nonexistent',
+      );
       expect(nonePrev, isNull);
       expect(noneNext, isNull);
     });
@@ -91,7 +135,10 @@ void main() {
 
     test('fromLocation resolves other routes correctly', () {
       expect(AppRoute.fromLocation(path: '/'), equals(AppRoute.home));
-      expect(AppRoute.fromLocation(path: '/showcase'), equals(AppRoute.showcase));
+      expect(
+        AppRoute.fromLocation(path: '/showcase'),
+        equals(AppRoute.showcase),
+      );
       expect(
         AppRoute.fromLocation(path: '/ported-examples'),
         equals(AppRoute.portedExamples),


### PR DESCRIPTION
Resolves #168 (Phase 2 of parent meta-issue #165).

### 🎯 Objective & Scope
Authors comprehensive, standalone reference documentation for all pure Dart `bloc_signals` core concepts, event execution models, concurrency transformers, lifecycle hooks, and signals graph reactivity.

### 📋 Deliverables
1. **Authored 6 Core Concepts Chapters**:
   - `DocsCubitVsBlocPage` (`/docs/cubit-vs-bloc`): Direct method invocation vs. decoupled event-driven architecture, decision matrix, side-by-side Auth examples.
   - `DocsStateModelingPage` (`/docs/state-modeling`): Immutability principles, Dart 3 sealed class pattern matching, Dart Records, Fast Immutable Collections (FIC), and custom `SignalOptions(equals:)` comparators.
   - `DocsEventsAndHandlersPage` (`/docs/events-and-handlers`): Handler registration with `on<E>`, single-registration invariant, `Future.wait` async coordination, error routing, and Zone event tracing.
   - `DocsEventTransformersPage` (`/docs/event-transformers`): Streamless concurrency architecture (`droppable`, `sequential`, `restartable`), Mutex locks, custom debounce/filter recipes.
   - `DocsLifecycleAndObserversPage` (`/docs/lifecycle-and-observers`): `BlocSignalObserver` hook reference, `Change` vs. `Transition`, OpenTelemetry tracing, memory leak prevention.
   - `DocsSignalsReactivityPage` (`/docs/signals-reactivity`): `stateValue` vs. `state`, `computed()` derivations, `effect()` reactions, and 0ms synchronous updates.
2. **Resilient Routing & Navigation Fix**:
   - Slug normalization in `DocsRegistry.resolveSection` and `DocsCubit._resolveInitialSectionFromBrowser` to support trailing slashes, index.html fallbacks, and deep links cleanly.
   - Added `preventDefault()` to sidebar links and pagination buttons for seamless 0ms SPA transitions.
3. **Dual-Tab Code Ergonomics**:
   - Every code snippet offers interactive switching between modern Dart 3.13+ (primary constructors, parameter shorthands) and baseline Dart 3.5 syntax.

### 🧪 Verification
- `dart analyze --fatal-infos` -> **0 issues found**
- `dart test` in `website/` -> **14/14 tests passing**
- `dart run tool/run_workspace_tests.dart` -> **100% tests passing across all 12 monorepo targets**
- `dart run website/tool/build_static.dart` -> **Static JS bundle compiled and 29 route fallbacks generated**
- `dart format .` -> **Clean**