### PR TITLE
docs(website): complete Docs Hub Phase 4 (#170)

### DIFF
--- a/website/lib/src/components/docs/docs_code_block.dart
+++ b/website/lib/src/components/docs/docs_code_block.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 
+import 'package:bloc_signals_jaspr/bloc_signals_jaspr.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
+
+import '../../cubits/docs_cubit.dart';
 
 /// A code block component with syntax header, copy button, and optional side-by-side tabs.
 class const DocsCodeBlock({
@@ -23,19 +26,19 @@ class const DocsCodeBlock({
 class _DocsCodeBlockState() extends State<DocsCodeBlock> {
   bool _copied = false;
   Timer? _copyTimer;
-  String _activeTab = '3.13'; // '3.13' or '3.5'
+  String? _overrideTab;
 
-  String get _currentCode {
+  String _currentCode(String effectiveVersion) {
     if (component.code != null) return component.code!;
-    if (_activeTab == '3.13' && component.dart313Code != null) {
+    if (effectiveVersion == '3.13' && component.dart313Code != null) {
       return component.dart313Code!;
     }
     return component.dart35Code ?? component.dart313Code ?? '';
   }
 
-  void _copyToClipboard() {
+  void _copyToClipboard(String codeToCopy) {
     try {
-      web.window.navigator.clipboard.writeText(_currentCode);
+      web.window.navigator.clipboard.writeText(codeToCopy);
       setState(() {
         _copied = true;
       });
@@ -61,6 +64,13 @@ class _DocsCodeBlockState() extends State<DocsCodeBlock> {
     final hasDualVersions =
         component.dart35Code != null && component.dart313Code != null;
 
+    String globalVersion = '3.13';
+    try {
+      globalVersion = context.read<DocsCubit>().stateValue.selectedDartVersion;
+    } catch (_) {}
+    final activeTab = _overrideTab ?? globalVersion;
+    final activeCode = _currentCode(activeTab);
+
     return div(classes: 'docs-code-container', [
       div(classes: 'docs-code-header', [
         div(classes: 'docs-code-title-group', [
@@ -80,20 +90,20 @@ class _DocsCodeBlockState() extends State<DocsCodeBlock> {
             div(classes: 'docs-version-tabs', [
               button(
                 classes:
-                    'docs-version-tab ${_activeTab == "3.13" ? "active" : ""}',
+                    'docs-version-tab ${activeTab == "3.13" ? "active" : ""}',
                 onClick: () {
                   setState(() {
-                    _activeTab = '3.13';
+                    _overrideTab = '3.13';
                   });
                 },
                 [Component.text('Dart 3.13+ (Modern)')],
               ),
               button(
                 classes:
-                    'docs-version-tab ${_activeTab == "3.5" ? "active" : ""}',
+                    'docs-version-tab ${activeTab == "3.5" ? "active" : ""}',
                 onClick: () {
                   setState(() {
-                    _activeTab = '3.5';
+                    _overrideTab = '3.5';
                   });
                 },
                 [Component.text('Dart 3.5 (Baseline)')],
@@ -102,7 +112,7 @@ class _DocsCodeBlockState() extends State<DocsCodeBlock> {
           ],
           button(
             classes: 'docs-copy-btn ${_copied ? "copied" : ""}',
-            onClick: _copyToClipboard,
+            onClick: () => _copyToClipboard(activeCode),
             attributes: {'aria-label': 'Copy code to clipboard'},
             [
               span(classes: 'docs-copy-icon', [
@@ -117,7 +127,7 @@ class _DocsCodeBlockState() extends State<DocsCodeBlock> {
       ]),
       pre(classes: 'docs-code-body', [
         code(classes: 'language-${component.language}', [
-          Component.text(_currentCode),
+          Component.text(activeCode),
         ]),
       ]),
     ]);

--- a/website/lib/src/components/docs/docs_content.dart
+++ b/website/lib/src/components/docs/docs_content.dart
@@ -14,8 +14,19 @@ import 'pages/docs_flutter_providers.dart';
 import 'pages/docs_flutter_widgets.dart';
 import 'pages/docs_installation.dart';
 import 'pages/docs_lifecycle_and_observers.dart';
+import 'pages/docs_migration_bloc.dart';
+import 'pages/docs_migration_riverpod.dart';
 import 'pages/docs_overview.dart';
+import 'pages/docs_pkg_devtools.dart';
+import 'pages/docs_pkg_hydrate.dart';
+import 'pages/docs_pkg_otel.dart';
+import 'pages/docs_pkg_replay.dart';
+import 'pages/docs_pkg_riverpod.dart';
 import 'pages/docs_quickstart.dart';
+import 'pages/docs_recipe_caching.dart';
+import 'pages/docs_recipe_controllers.dart';
+import 'pages/docs_recipe_form_validation.dart';
+import 'pages/docs_recipe_one_shot.dart';
 import 'pages/docs_signals_reactivity.dart';
 import 'pages/docs_state_modeling.dart';
 import 'pages/docs_testing_guide.dart';
@@ -34,70 +45,71 @@ class const DocsContent({super.key}) extends StatelessComponent {
         );
         final cubit = context.read<DocsCubit>();
 
-        // Extract TOC headings based on active section
-        final headings = _getHeadingsForSection(state.activeSectionId);
-        final sourcePath = _getSourcePathForSection(state.activeSectionId);
+        final headings = _getHeadingsForSection(currentSection.id);
+        final sourcePath = _getSourcePathForSection(currentSection.id);
 
         return div(classes: 'docs-content-layout', [
-          // Mobile Docs Navigation Bar
-          div(classes: 'docs-mobile-bar', [
-            button(
-              classes: 'docs-mobile-menu-btn',
-              onClick: () => cubit.toggleMobileDrawer(),
-              attributes: {'aria-label': 'Open documentation menu'},
-              [
-                span(classes: 'docs-mobile-menu-icon', [Component.text('☰')]),
-                span(classes: 'docs-mobile-menu-text', [
-                  Component.text('Menu'),
+          div(classes: 'docs-main-wrapper', [
+            // Mobile Docs Navigation Bar
+            div(classes: 'docs-mobile-bar', [
+              button(
+                classes: 'docs-mobile-menu-btn',
+                onClick: () => cubit.toggleMobileDrawer(),
+                attributes: {'aria-label': 'Open documentation menu'},
+                [
+                  span(classes: 'docs-mobile-menu-icon', [Component.text('☰')]),
+                  span(classes: 'docs-mobile-menu-text', [
+                    Component.text('Menu'),
+                  ]),
+                ],
+              ),
+              div(classes: 'docs-mobile-breadcrumbs', [
+                span(classes: 'docs-crumb-category', [
+                  Component.text(currentSection.category),
                 ]),
-              ],
-            ),
-            div(classes: 'docs-mobile-breadcrumbs', [
-              span(classes: 'docs-crumb-category', [
-                Component.text(currentSection.category),
-              ]),
-              span(classes: 'docs-crumb-separator', [Component.text(' / ')]),
-              span(classes: 'docs-crumb-title', [
-                Component.text(currentSection.title),
+                span(classes: 'docs-crumb-separator', [Component.text(' / ')]),
+                span(classes: 'docs-crumb-title', [
+                  Component.text(currentSection.title),
+                ]),
               ]),
             ]),
-          ]),
 
-          // Main Article Container
-          main_(classes: 'docs-main-container', [
-            currentSection.builder(),
+            // Main Documentation Article
+            main_(classes: 'docs-main-container', [
+              currentSection.builder(),
 
-            // Footer Pagination (Previous / Next Article)
-            div(classes: 'docs-pagination', [
-              if (prevSection != null)
-                button(
-                  classes: 'docs-pager-btn prev',
-                  onClick: () => cubit.selectSection(prevSection.id),
-                  [
-                    span(classes: 'docs-pager-direction', [
-                      Component.text('← Previous'),
-                    ]),
-                    span(classes: 'docs-pager-title', [
-                      Component.text(prevSection.title),
-                    ]),
-                  ],
-                )
-              else
-                div(classes: 'docs-pager-spacer', []),
+              // Footer Pagination (Previous / Next Article)
+              div(classes: 'docs-pagination', [
+                if (prevSection != null)
+                  button(
+                    classes: 'docs-pager-btn prev',
+                    onClick: () => cubit.selectSection(prevSection.id),
+                    [
+                      span(classes: 'docs-pager-direction', [
+                        Component.text('← Previous'),
+                      ]),
+                      span(classes: 'docs-pager-title', [
+                        Component.text(prevSection.title),
+                      ]),
+                    ],
+                  )
+                else
+                  div(classes: 'docs-pager-spacer', []),
 
-              if (nextSection != null)
-                button(
-                  classes: 'docs-pager-btn next',
-                  onClick: () => cubit.selectSection(nextSection.id),
-                  [
-                    span(classes: 'docs-pager-direction', [
-                      Component.text('Next →'),
-                    ]),
-                    span(classes: 'docs-pager-title', [
-                      Component.text(nextSection.title),
-                    ]),
-                  ],
-                ),
+                if (nextSection != null)
+                  button(
+                    classes: 'docs-pager-btn next',
+                    onClick: () => cubit.selectSection(nextSection.id),
+                    [
+                      span(classes: 'docs-pager-direction', [
+                        Component.text('Next →'),
+                      ]),
+                      span(classes: 'docs-pager-title', [
+                        Component.text(nextSection.title),
+                      ]),
+                    ],
+                  ),
+              ]),
             ]),
           ]),
 
@@ -138,6 +150,28 @@ class const DocsContent({super.key}) extends StatelessComponent {
         return DocsFlutterContextPage.headings;
       case 'testing-guide':
         return DocsTestingGuidePage.headings;
+      case 'pkg-hydrate':
+        return DocsPkgHydratePage.headings;
+      case 'pkg-replay':
+        return DocsPkgReplayPage.headings;
+      case 'pkg-riverpod':
+        return DocsPkgRiverpodPage.headings;
+      case 'pkg-otel':
+        return DocsPkgOtelPage.headings;
+      case 'pkg-devtools':
+        return DocsPkgDevtoolsPage.headings;
+      case 'recipe-one-shot':
+        return DocsRecipeOneShotPage.headings;
+      case 'recipe-form-validation':
+        return DocsRecipeFormValidationPage.headings;
+      case 'recipe-controllers':
+        return DocsRecipeControllersPage.headings;
+      case 'recipe-caching':
+        return DocsRecipeCachingPage.headings;
+      case 'migration-bloc':
+        return DocsMigrationBlocPage.headings;
+      case 'migration-riverpod':
+        return DocsMigrationRiverpodPage.headings;
       default:
         return const [];
     }
@@ -171,6 +205,28 @@ class const DocsContent({super.key}) extends StatelessComponent {
         return 'website/lib/src/components/docs/pages/docs_flutter_context.dart';
       case 'testing-guide':
         return 'website/lib/src/components/docs/pages/docs_testing_guide.dart';
+      case 'pkg-hydrate':
+        return 'website/lib/src/components/docs/pages/docs_pkg_hydrate.dart';
+      case 'pkg-replay':
+        return 'website/lib/src/components/docs/pages/docs_pkg_replay.dart';
+      case 'pkg-riverpod':
+        return 'website/lib/src/components/docs/pages/docs_pkg_riverpod.dart';
+      case 'pkg-otel':
+        return 'website/lib/src/components/docs/pages/docs_pkg_otel.dart';
+      case 'pkg-devtools':
+        return 'website/lib/src/components/docs/pages/docs_pkg_devtools.dart';
+      case 'recipe-one-shot':
+        return 'website/lib/src/components/docs/pages/docs_recipe_one_shot.dart';
+      case 'recipe-form-validation':
+        return 'website/lib/src/components/docs/pages/docs_recipe_form_validation.dart';
+      case 'recipe-controllers':
+        return 'website/lib/src/components/docs/pages/docs_recipe_controllers.dart';
+      case 'recipe-caching':
+        return 'website/lib/src/components/docs/pages/docs_recipe_caching.dart';
+      case 'migration-bloc':
+        return 'website/lib/src/components/docs/pages/docs_migration_bloc.dart';
+      case 'migration-riverpod':
+        return 'website/lib/src/components/docs/pages/docs_migration_riverpod.dart';
       default:
         return 'website/lib/src/models/docs_registry.dart';
     }

--- a/website/lib/src/components/docs/docs_sidebar.dart
+++ b/website/lib/src/components/docs/docs_sidebar.dart
@@ -58,6 +58,27 @@ class const DocsSidebar({super.key}) extends StatelessComponent {
               ),
           ]),
 
+          // Global Syntax Preference Toggle
+          div(classes: 'docs-syntax-selector', [
+            span(classes: 'docs-syntax-label', [
+              Component.text('Dart Syntax:'),
+            ]),
+            div(classes: 'docs-version-tabs', [
+              button(
+                classes:
+                    'docs-version-tab ${state.selectedDartVersion == "3.13" ? "active" : ""}',
+                onClick: () => cubit.setDartVersion('3.13'),
+                [Component.text('3.13+ Modern')],
+              ),
+              button(
+                classes:
+                    'docs-version-tab ${state.selectedDartVersion == "3.5" ? "active" : ""}',
+                onClick: () => cubit.setDartVersion('3.5'),
+                [Component.text('3.5 Baseline')],
+              ),
+            ]),
+          ]),
+
           // Category Navigation Tree
           nav(classes: 'docs-nav-tree', [
             if (displayedCategories.isEmpty) ...[

--- a/website/lib/src/components/docs/pages/docs_migration_bloc.dart
+++ b/website/lib/src/components/docs/pages/docs_migration_bloc.dart
@@ -1,0 +1,235 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering migration from package:bloc and flutter_bloc.
+class const DocsMigrationBlocPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'Overview & Key Differences',
+      anchor: 'overview-differences',
+    ),
+    TocHeading(
+      title: 'Concept Translation Matrix',
+      anchor: 'translation-matrix',
+    ),
+    TocHeading(title: 'Cubit Migration', anchor: 'cubit-migration'),
+    TocHeading(title: 'Bloc & Event Migration', anchor: 'bloc-migration'),
+    TocHeading(title: 'Flutter UI Migration', anchor: 'ui-migration'),
+    TocHeading(title: 'Unit Test Migration', anchor: 'testing-migration'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🔄 Migration Guides')]),
+        h1([Component.text('Migrating from package:bloc & flutter_bloc')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Step-by-step guide and side-by-side conversion patterns for transitioning from classic BLoC / flutter_bloc to BlocSignal.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Key Differences
+      section(id: 'overview-differences', classes: 'docs-section', [
+        h2([Component.text('Overview & Key Differences')]),
+        p([
+          Component.text(
+            'BlocSignal preserves the familiar mental model of BLoC (Events, States, Transitions, Cubits, Blocs, Observers, Providers, Builders) '
+            'while replacing asynchronous microtask Stream pipelines with synchronous Preact Signals v7 primitives.',
+          ),
+        ]),
+        ul([
+          li([
+            strong([Component.text('0ms Synchronous Propagation')]),
+            Component.text(
+              ': emit() recalculates downstream signal graphs and updates UI immediately in the current frame without microtask delay.',
+            ),
+          ]),
+          li([
+            strong([Component.text('Streamless Concurrency')]),
+            Component.text(
+              ': Event transformers (droppable, restartable, sequential) operate via pure Dart functions and mutexes with zero stream allocation.',
+            ),
+          ]),
+          li([
+            strong([Component.text('Automatic Signal Interop')]),
+            Component.text(
+              ': State is exposed as ReadonlySignal<S>, allowing direct composition with computed() and effect().',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 2. Concept Translation Matrix
+      section(id: 'translation-matrix', classes: 'docs-section', [
+        h2([Component.text('Concept Translation Matrix')]),
+        table(classes: 'docs-table', [
+          thead([
+            tr([
+              th([Component.text('classic package:bloc / flutter_bloc')]),
+              th([Component.text('bloc_signals / bloc_signals_flutter')]),
+            ]),
+          ]),
+          tbody([
+            tr([
+              td([Component.text('Cubit<State>')]),
+              td([Component.text('CubitSignal<State>')]),
+            ]),
+            tr([
+              td([Component.text('Bloc<Event, State>')]),
+              td([Component.text('BlocSignal<Event, State>')]),
+            ]),
+            tr([
+              td([Component.text('BlocProvider<B>')]),
+              td([Component.text('BlocSignalProvider<B>')]),
+            ]),
+            tr([
+              td([Component.text('BlocBuilder<B, S>')]),
+              td([Component.text('BlocSignalBuilder<B, S>')]),
+            ]),
+            tr([
+              td([Component.text('BlocListener<B, S>')]),
+              td([Component.text('BlocSignalListener<B, S>')]),
+            ]),
+            tr([
+              td([Component.text('BlocConsumer<B, S>')]),
+              td([Component.text('BlocSignalConsumer<B, S>')]),
+            ]),
+            tr([
+              td([Component.text('BlocSelector<B, S, T>')]),
+              td([Component.text('BlocSignalSelector<B, S, T>')]),
+            ]),
+            tr([
+              td([Component.text('blocTest<B, S>(seed: ...)')]),
+              td([
+                Component.text(
+                  'blocSignalTest<B, S>(build: () => B(initialState: ...))',
+                ),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+
+      // 3. Cubit Migration
+      section(id: 'cubit-migration', classes: 'docs-section', [
+        h2([Component.text('Cubit Migration')]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Cubit',
+          language: 'dart',
+          code: '''
+// --- BEFORE: package:bloc ---
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class CounterCubit extends Cubit<int> {
+  CounterCubit() : super(0);
+  void increment() => emit(state + 1);
+}
+
+// --- AFTER: bloc_signals ---
+import 'package:bloc_signals/bloc_signals.dart';
+
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+  void increment() => emit(stateValue + 1);
+}''',
+        ),
+      ]),
+
+      // 4. Bloc & Event Migration
+      section(id: 'bloc-migration', classes: 'docs-section', [
+        h2([Component.text('Bloc & Event Migration')]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Bloc with Transformers',
+          language: 'dart',
+          code: '''
+// --- BEFORE: package:bloc ---
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SearchBloc extends Bloc<SearchEvent, SearchState> {
+  SearchBloc() : super(SearchInitial()) {
+    on<QuerySubmitted>(
+      (event, emit) async => _onSearch(event, emit),
+      transformer: restartable(),
+    );
+  }
+}
+
+// --- AFTER: bloc_signals ---
+import 'package:bloc_signals/bloc_signals.dart';
+
+class SearchBloc extends BlocSignal<SearchEvent, SearchState> {
+  SearchBloc() : super(initialState: SearchInitial()) {
+    on<QuerySubmitted>(
+      (event, emit) async => _onSearch(event, emit),
+      transformer: restartable(), // Zero-stream pure function transformer!
+    );
+  }
+}''',
+        ),
+      ]),
+
+      // 5. Flutter UI Migration
+      section(id: 'ui-migration', classes: 'docs-section', [
+        h2([Component.text('Flutter UI Migration')]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Flutter Widgets',
+          language: 'dart',
+          code: '''
+// --- BEFORE: flutter_bloc ---
+BlocProvider(
+  create: (context) => CounterCubit(),
+  child: BlocBuilder<CounterCubit, int>(
+    builder: (context, count) => Text('\$count'),
+  ),
+);
+
+// --- AFTER: bloc_signals_flutter ---
+BlocSignalProvider(
+  create: (context) => CounterCubit(),
+  child: BlocSignalBuilder<CounterCubit, int>(
+    builder: (context, count) => Text('\$count'),
+  ),
+);''',
+        ),
+      ]),
+
+      // 6. Unit Test Migration
+      section(id: 'testing-migration', classes: 'docs-section', [
+        h2([Component.text('Unit Test Migration')]),
+        p([
+          Component.text(
+            'In bloc_signals_test, state seeding is performed directly in the build constructor closure rather than through a separate seed parameter:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Unit Tests',
+          language: 'dart',
+          code: '''
+// --- BEFORE: bloc_test ---
+blocTest<CounterCubit, int>(
+  'emits [11] when increment is called with seed 10',
+  build: () => CounterCubit(),
+  seed: () => 10,
+  act: (cubit) => cubit.increment(),
+  expect: () => [11],
+);
+
+// --- AFTER: bloc_signals_test ---
+blocSignalTest<CounterCubit, int>(
+  'emits [11] when increment is called with initial state 10',
+  build: () => CounterCubit(initialState: 10),
+  act: (cubit) => cubit.increment(),
+  expect: () => [11],
+);''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_migration_riverpod.dart
+++ b/website/lib/src/components/docs/pages/docs_migration_riverpod.dart
@@ -1,0 +1,201 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering migration from flutter_riverpod.
+class const DocsMigrationRiverpodPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Mental Model Shift', anchor: 'mental-model'),
+    TocHeading(
+      title: 'Concept Translation Matrix',
+      anchor: 'translation-matrix',
+    ),
+    TocHeading(
+      title: 'StateNotifier to CubitSignal',
+      anchor: 'notifier-to-cubit',
+    ),
+    TocHeading(title: 'Widget Refactoring', anchor: 'widget-refactoring'),
+    TocHeading(title: 'Derived State with computed()', anchor: 'derived-state'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('🔄 Migration Guides')]),
+        h1([Component.text('Migrating from Riverpod')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Understand the architectural shift from global provider graphs to scoped reactive containers, with side-by-side widget and state translation patterns.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Mental Model Shift
+      section(id: 'mental-model', classes: 'docs-section', [
+        h2([Component.text('Overview & Mental Model Shift')]),
+        p([
+          Component.text(
+            'Riverpod organizes state as a global declarative dependency graph accessed via WidgetRef. '
+            'BlocSignal organizes state into scoped, self-contained containers provided through the Flutter Element tree '
+            'using standard BuildContext lookups and 0ms synchronous Preact signals.',
+          ),
+        ]),
+      ]),
+
+      // 2. Concept Translation Matrix
+      section(id: 'translation-matrix', classes: 'docs-section', [
+        h2([Component.text('Concept Translation Matrix')]),
+        table(classes: 'docs-table', [
+          thead([
+            tr([
+              th([Component.text('Riverpod 2 / 3')]),
+              th([Component.text('BlocSignal / Flutter')]),
+            ]),
+          ]),
+          tbody([
+            tr([
+              td([Component.text('StateNotifier<State> / Notifier<State>')]),
+              td([Component.text('CubitSignal<State>')]),
+            ]),
+            tr([
+              td([Component.text('ProviderScope')]),
+              td([
+                Component.text('BlocSignalProvider / MultiBlocSignalProvider'),
+              ]),
+            ]),
+            tr([
+              td([Component.text('ref.watch(provider)')]),
+              td([Component.text('context.watch<B>() or BlocSignalBuilder')]),
+            ]),
+            tr([
+              td([Component.text('ref.read(provider.notifier)')]),
+              td([Component.text('context.read<B>()')]),
+            ]),
+            tr([
+              td([Component.text('ref.listen(provider, ...)')]),
+              td([Component.text('BlocSignalListener')]),
+            ]),
+            tr([
+              td([Component.text('ref.watch(provider.select(...))')]),
+              td([
+                Component.text(
+                  'context.select<B, S, R>() or BlocSignalSelector',
+                ),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]),
+
+      // 3. StateNotifier to CubitSignal
+      section(id: 'notifier-to-cubit', classes: 'docs-section', [
+        h2([Component.text('StateNotifier / Notifier to CubitSignal')]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Notifier vs Cubit',
+          language: 'dart',
+          code: '''
+// --- BEFORE: Riverpod Notifier ---
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class CounterNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
+final counterProvider = NotifierProvider<CounterNotifier, int>(
+  CounterNotifier.new,
+);
+
+// --- AFTER: CubitSignal ---
+import 'package:bloc_signals/bloc_signals.dart';
+
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+
+  void increment() => emit(stateValue + 1);
+}''',
+        ),
+      ]),
+
+      // 4. Widget Refactoring
+      section(id: 'widget-refactoring', classes: 'docs-section', [
+        h2([Component.text('Widget Refactoring')]),
+        p([
+          Component.text(
+            'Replace ConsumerWidget and ConsumerStatefulWidget with standard StatelessWidget and StatefulWidget, '
+            'accessing state directly through BuildContext extensions:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Widget Consumption',
+          language: 'dart',
+          code: '''
+// --- BEFORE: Riverpod ConsumerWidget ---
+class CounterScreen extends ConsumerWidget {
+  const CounterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final count = ref.watch(counterProvider);
+    return Scaffold(
+      body: Center(child: Text('\$count')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => ref.read(counterProvider.notifier).increment(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+// --- AFTER: BlocSignal with context.watch and context.read ---
+class CounterScreen extends StatelessWidget {
+  const CounterScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final count = context.watch<CounterCubit>().stateValue;
+    return Scaffold(
+      body: Center(child: Text('\$count')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.read<CounterCubit>().increment(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}''',
+        ),
+      ]),
+
+      // 5. Derived State with computed()
+      section(id: 'derived-state', classes: 'docs-section', [
+        h2([Component.text('Derived State with computed()')]),
+        p([
+          Component.text(
+            'In Riverpod, derived state is declared using dependent functional providers. '
+            'In BlocSignal, derived state is declared inside or alongside Cubits using computed() signals:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'Side-by-Side: Derived Computations',
+          language: 'dart',
+          code: '''
+// --- BEFORE: Riverpod Functional Provider ---
+final isEvenProvider = Provider<bool>((ref) {
+  final count = ref.watch(counterProvider);
+  return count.isEven;
+});
+
+// --- AFTER: BlocSignal computed() Signal ---
+extension CounterDerived on CounterCubit {
+  ReadonlySignal<bool> get isEven => computed(() => state.value.isEven);
+}''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_pkg_devtools.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_devtools.dart
@@ -1,0 +1,137 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering Flutter DevTools integration with bloc_signals_devtools.
+class const DocsPkgDevtoolsPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Setup', anchor: 'overview-setup'),
+    TocHeading(
+      title: 'DevToolsBlocSignalObserver',
+      anchor: 'devtools-observer',
+    ),
+    TocHeading(title: 'Instance Tree Inspector', anchor: 'instance-tree'),
+    TocHeading(title: 'Live State Diff Viewer', anchor: 'state-diffs'),
+    TocHeading(title: 'Memory Leak Detector', anchor: 'leak-detector'),
+    TocHeading(
+      title: 'Timeline Tracing & Profiling',
+      anchor: 'timeline-tracing',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('📦 Satellite Packages')]),
+        h1([Component.text('bloc_signals_devtools')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Interactive Flutter DevTools extension and VM service telemetry for inspecting active state containers, transitions, and memory lifecycle.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Setup
+      section(id: 'overview-setup', classes: 'docs-section', [
+        h2([Component.text('Overview & Setup')]),
+        p([
+          Component.text(
+            'The bloc_signals_devtools package provides a dedicated tab inside Flutter DevTools. '
+            'It connects directly to the Dart VM Service to display real-time diagnostics, state trees, and event timelines.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'flutter pub add bloc_signals_devtools bloc_signals --dev',
+        ),
+      ]),
+
+      // 2. DevToolsBlocSignalObserver
+      section(id: 'devtools-observer', classes: 'docs-section', [
+        h2([Component.text('DevToolsBlocSignalObserver')]),
+        p([
+          Component.text(
+            'Enable DevTools telemetry by attaching DevToolsBlocSignalObserver in debug mode:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/main.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:flutter/foundation.dart';
+
+void main() {
+  if (kDebugMode) {
+    // Posts telemetry events to the Dart VM Service via dart:developer
+    BlocSignalObserver.observer = DevToolsBlocSignalObserver();
+  }
+
+  runApp(const MyApp());
+}''',
+        ),
+      ]),
+
+      // 3. Instance Tree Inspector
+      section(id: 'instance-tree', classes: 'docs-section', [
+        h2([Component.text('Instance Tree Inspector')]),
+        p([
+          Component.text(
+            'View all currently active CubitSignal and BlocSignal instances grouped by class type. '
+            'Inspect their current state values, creation timestamps, and lifecycle status in real time.',
+          ),
+        ]),
+      ]),
+
+      // 4. Live State Diff Viewer
+      section(id: 'state-diffs', classes: 'docs-section', [
+        h2([Component.text('Live State Diff Viewer')]),
+        p([
+          Component.text(
+            'Every time an event triggers a transition, the DevTools tab highlights exact JSON field differences '
+            'between previous and current state values with color-coded diffs.',
+          ),
+        ]),
+      ]),
+
+      // 5. Memory Leak Detector
+      section(id: 'leak-detector', classes: 'docs-section', [
+        h2([Component.text('Memory Leak Detector Badge')]),
+        p([
+          Component.text(
+            'The leak detector automatically flags containers that receive events after close() has been called, '
+            'or instances that remain un-garbage-collected after their parent widget has unmounted.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.important,
+          title: 'Production Zero-Overhead',
+          children: [
+            p([
+              Component.text(
+                'DevToolsBlocSignalObserver relies on dart:developer postEvent calls which are automatically stripped '
+                'in release builds, guaranteeing zero runtime overhead in production.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 6. Timeline Tracing & Profiling
+      section(id: 'timeline-tracing', classes: 'docs-section', [
+        h2([Component.text('Timeline Tracing & Profiling')]),
+        p([
+          Component.text(
+            'State transitions and event handler durations are registered as Timeline events. '
+            'You can correlate state mutations directly with Flutter UI frame rendering in the DevTools Performance profiler.',
+          ),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_pkg_hydrate.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_hydrate.dart
@@ -1,0 +1,319 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering state persistence with bloc_signals_hydrate.
+class const DocsPkgHydratePage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Installation', anchor: 'overview-install'),
+    TocHeading(title: 'HydratedCubitSignal', anchor: 'hydrated-cubit'),
+    TocHeading(title: 'HydratedBlocSignal', anchor: 'hydrated-bloc'),
+    TocHeading(
+      title: 'Zero-Override Primitives',
+      anchor: 'primitive-hydration',
+    ),
+    TocHeading(title: 'Custom JSON Serialization', anchor: 'custom-json'),
+    TocHeading(
+      title: 'Storage Adapters & Security',
+      anchor: 'storage-adapters',
+    ),
+    TocHeading(title: 'Clearing & Resetting State', anchor: 'clearing-state'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('📦 Satellite Packages')]),
+        h1([Component.text('bloc_signals_hydrate')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Automatic, zero-flicker state persistence and hydration for CubitSignal and BlocSignal across app restarts and browser reloads.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Installation
+      section(id: 'overview-install', classes: 'docs-section', [
+        h2([Component.text('Overview & Installation')]),
+        p([
+          Component.text(
+            'The bloc_signals_hydrate package integrates persistent storage engines into BlocSignal containers. '
+            'Unlike asynchronous hydration schemes that trigger loading spinners or layout shifts on launch, '
+            'bloc_signals_hydrate restores state synchronously during constructor execution, guaranteeing that '
+            'widgets render hydrated state on the very first frame.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'flutter pub add bloc_signals_hydrate bloc_signals',
+        ),
+        p([
+          Component.text(
+            'Initialize the global storage delegate in your application entry point before running runApp:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/main.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:flutter/widgets.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Initialize SharedPreferences or custom storage engine
+  HydratedStorage.storage = await SharedPreferencesHydratedStorage.create();
+
+  runApp(const MyApp());
+}''',
+        ),
+      ]),
+
+      // 2. HydratedCubitSignal
+      section(id: 'hydrated-cubit', classes: 'docs-section', [
+        h2([Component.text('HydratedCubitSignal')]),
+        p([
+          Component.text(
+            'Extend HydratedCubitSignal instead of CubitSignal to gain automatic persistence. '
+            'Every time emit() produces a new distinct state, the updated value is serialized and written to storage automatically.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/theme_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+
+enum AppTheme { light, dark, system }
+
+class ThemeCubit extends HydratedCubitSignal<AppTheme> {
+  ThemeCubit() : super(initialState: AppTheme.system);
+
+  void toggleTheme() {
+    emit(stateValue == AppTheme.dark ? AppTheme.light : AppTheme.dark);
+  }
+
+  @override
+  AppTheme fromJson(Object? json) {
+    if (json is String) {
+      return AppTheme.values.firstWhere(
+        (t) => t.name == json,
+        orElse: () => AppTheme.system,
+      );
+    }
+    return AppTheme.system;
+  }
+
+  @override
+  Object? toJson(AppTheme state) => state.name;
+}''',
+          dart313Code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+
+enum AppTheme { light, dark, system }
+
+class ThemeCubit() extends HydratedCubitSignal<AppTheme> {
+  this() : super(initialState: AppTheme.system);
+
+  void toggleTheme() {
+    emit(stateValue == AppTheme.dark ? AppTheme.light : AppTheme.dark);
+  }
+
+  @override
+  AppTheme fromJson(Object? json) {
+    if (json is String) {
+      return AppTheme.values.firstWhere(
+        (t) => t.name == json,
+        orElse: () => AppTheme.system,
+      );
+    }
+    return AppTheme.system;
+  }
+
+  @override
+  Object? toJson(AppTheme state) => state.name;
+}''',
+        ),
+      ]),
+
+      // 3. HydratedBlocSignal
+      section(id: 'hydrated-bloc', classes: 'docs-section', [
+        h2([Component.text('HydratedBlocSignal')]),
+        p([
+          Component.text(
+            'For event-driven state containers, extend HydratedBlocSignal. '
+            'State transitions triggered by incoming events persist automatically.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/counter_bloc.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+
+sealed class CounterEvent {}
+final class Increment extends CounterEvent {}
+final class Decrement extends CounterEvent {}
+
+class CounterBloc extends HydratedBlocSignal<CounterEvent, int> {
+  CounterBloc() : super(initialState: 0) {
+    on<Increment>((event, emit) => emit(stateValue + 1));
+    on<Decrement>((event, emit) => emit(stateValue - 1));
+  }
+
+  @override
+  int fromJson(Object? json) => (json as num?)?.toInt() ?? 0;
+
+  @override
+  Object? toJson(int state) => state;
+}''',
+        ),
+      ]),
+
+      // 4. Zero-Override Primitives
+      section(id: 'primitive-hydration', classes: 'docs-section', [
+        h2([Component.text('Zero-Override Primitive & Collection Hydration')]),
+        p([
+          Component.text(
+            'Because bloc_signals_hydrate accepts dynamic and Object? in serialization methods rather than requiring Map<String, dynamic>, '
+            'standard Dart primitive types (int, double, String, bool) and collections (List<String>) hydrate directly without boilerplate:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/view_count_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+
+/// Primitives hydrate directly without creating custom Map wrappers.
+class ViewCountCubit extends HydratedCubitSignal<int> {
+  ViewCountCubit() : super(initialState: 0);
+
+  void recordVisit() => emit(stateValue + 1);
+
+  @override
+  int fromJson(Object? json) => (json as num?)?.toInt() ?? 0;
+
+  @override
+  Object? toJson(int state) => state;
+}''',
+        ),
+      ]),
+
+      // 5. Custom JSON Serialization
+      section(id: 'custom-json', classes: 'docs-section', [
+        h2([Component.text('Custom JSON Serialization')]),
+        p([
+          Component.text(
+            'For complex data classes and records, map states to and from standard JSON-encodable maps and lists:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/user_profile_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+
+class UserProfile {
+  const UserProfile({required this.id, required this.name, required this.email});
+  final String id;
+  final String name;
+  final String email;
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
+    id: json['id'] as String,
+    name: json['name'] as String,
+    email: json['email'] as String,
+  );
+
+  Map<String, dynamic> toJson() => {'id': id, 'name': name, 'email': email};
+}
+
+class UserProfileCubit extends HydratedCubitSignal<UserProfile?> {
+  UserProfileCubit() : super(initialState: null);
+
+  void updateProfile(UserProfile profile) => emit(profile);
+
+  @override
+  UserProfile? fromJson(Object? json) {
+    if (json is Map<String, dynamic>) {
+      return UserProfile.fromJson(json);
+    }
+    return null;
+  }
+
+  @override
+  Object? toJson(UserProfile? state) => state?.toJson();
+}''',
+        ),
+      ]),
+
+      // 6. Storage Adapters & Security
+      section(id: 'storage-adapters', classes: 'docs-section', [
+        h2([Component.text('Storage Adapters & Security')]),
+        p([
+          Component.text(
+            'bloc_signals_hydrate provides modular storage adapters for various security and platform requirements:',
+          ),
+        ]),
+        ul([
+          li([
+            strong([Component.text('SharedPreferencesHydratedStorage')]),
+            Component.text(
+              ': Standard, lightweight local key-value persistence for mobile and web.',
+            ),
+          ]),
+          li([
+            strong([Component.text('SecureHydratedStorage')]),
+            Component.text(
+              ': AES-encrypted storage powered by platform keychain and keystore services for sensitive auth tokens and credentials.',
+            ),
+          ]),
+          li([
+            strong([Component.text('InMemoryHydratedStorage')]),
+            Component.text(
+              ': Ephemeral in-memory storage designed for lightning-fast hermetic unit testing.',
+            ),
+          ]),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Testing Tip',
+          children: [
+            p([
+              Component.text(
+                'In unit tests, set HydratedStorage.storage = InMemoryHydratedStorage() in setUp() and clear it in tearDown() to ensure full isolation between test cases.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 7. Clearing & Resetting State
+      section(id: 'clearing-state', classes: 'docs-section', [
+        h2([Component.text('Clearing & Resetting State')]),
+        p([
+          Component.text(
+            'To clear persisted state on user logout or session reset, invoke clear(). '
+            'This removes the persisted data from disk and resets the in-memory state to initialState without re-persisting the initial state back to storage.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/auth_cubit.dart',
+          language: 'dart',
+          code: '''
+void onUserLogout() async {
+  // Clears storage key and restores initialState synchronously
+  await userProfileCubit.clear();
+}''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_pkg_otel.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_otel.dart
@@ -1,0 +1,149 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering OpenTelemetry distributed tracing with bloc_signals_otel.
+class const DocsPkgOtelPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Installation', anchor: 'overview-install'),
+    TocHeading(title: 'OtelBlocSignalObserver', anchor: 'otel-observer'),
+    TocHeading(title: 'Span Lifecycle & Hierarchy', anchor: 'span-lifecycle'),
+    TocHeading(
+      title: 'Span Correlation on Errors',
+      anchor: 'error-correlation',
+    ),
+    TocHeading(title: 'Memory Leak Prevention', anchor: 'leak-prevention'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('📦 Satellite Packages')]),
+        h1([Component.text('bloc_signals_otel')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Enterprise OpenTelemetry distributed tracing and observability for BlocSignal and CubitSignal pipelines.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Installation
+      section(id: 'overview-install', classes: 'docs-section', [
+        h2([Component.text('Overview & Installation')]),
+        p([
+          Component.text(
+            'The bloc_signals_otel package transforms your state layer into an observable telemetry source. '
+            'It instruments container creation, event dispatches, state transitions, and asynchronous operational exceptions '
+            'into standard OpenTelemetry Spans ready for export to Jaeger, Grafana Tempo, Datadog, or Cloud Trace.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'dart pub add bloc_signals_otel bloc_signals opentelemetry',
+        ),
+      ]),
+
+      // 2. OtelBlocSignalObserver
+      section(id: 'otel-observer', classes: 'docs-section', [
+        h2([Component.text('OtelBlocSignalObserver Setup')]),
+        p([
+          Component.text(
+            'Attach the observer to the global BlocSignalObserver delegate during app bootstrap:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/main.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_otel/bloc_signals_otel.dart';
+import 'package:opentelemetry/opentelemetry.dart';
+
+void main() {
+  final tracer = globalTracerProvider.getTracer('my_app_tracer');
+
+  // Register the OpenTelemetry observer
+  BlocSignalObserver.observer = OtelBlocSignalObserver(
+    tracer: tracer,
+    maxActiveSpans: 100, // Bound active span maps against memory leaks
+  );
+
+  runApp();
+}''',
+        ),
+      ]),
+
+      // 3. Span Lifecycle & Hierarchy
+      section(id: 'span-lifecycle', classes: 'docs-section', [
+        h2([Component.text('Span Lifecycle & Hierarchy')]),
+        p([
+          Component.text(
+            'The observer generates standard OpenTelemetry spans across the state lifecycle:',
+          ),
+        ]),
+        ul([
+          li([
+            strong([Component.text('Container Span (onCreate → onClose)')]),
+            Component.text(
+              ': Represents the full active lifespan of the Cubit or Bloc instance.',
+            ),
+          ]),
+          li([
+            strong([Component.text('Event Span (onEvent → onTransition)')]),
+            Component.text(
+              ': Measures the exact time taken to process an event and compute the next state.',
+            ),
+          ]),
+          li([
+            strong([
+              Component.text('Transition Span (onChange / onTransition)'),
+            ]),
+            Component.text(
+              ': Records the previous state, next state, and transition latency.',
+            ),
+          ]),
+        ]),
+      ]),
+
+      // 4. Span Correlation on Errors
+      section(id: 'error-correlation', classes: 'docs-section', [
+        h2([Component.text('Span Correlation on Errors')]),
+        p([
+          Component.text(
+            'When an asynchronous operational exception occurs during event handling, OtelBlocSignalObserver '
+            'uses identity hash matching to attach the error and stack trace directly to the currently active event span, '
+            'rather than emitting disconnected, orphaned error traces.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Direct Error Tracing',
+          children: [
+            p([
+              Component.text(
+                'This guarantees that distributed trace viewers display the failing event and the causing exception within the exact same flamegraph hierarchy.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 5. Memory Leak Prevention
+      section(id: 'leak-prevention', classes: 'docs-section', [
+        h2([Component.text('Memory Leak Prevention')]),
+        p([
+          Component.text(
+            'In high-throughput systems, some events may be de-duplicated or dropped (for example via droppable() transformers). '
+            'To prevent un-ended spans from accumulating in memory indefinitely, OtelBlocSignalObserver caps internal span maps '
+            '(default 100 entries) with automatic LRU eviction and enforces flush on onClose().',
+          ),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_pkg_replay.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_replay.dart
@@ -1,0 +1,242 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering undo/redo state history with bloc_signals_replay.
+class const DocsPkgReplayPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Installation', anchor: 'overview-install'),
+    TocHeading(title: 'ReplayCubit', anchor: 'replay-cubit'),
+    TocHeading(title: 'ReplayBloc', anchor: 'replay-bloc'),
+    TocHeading(title: 'History Limits & Bounds', anchor: 'history-limits'),
+    TocHeading(
+      title: 'Filtering with shouldReplay',
+      anchor: 'filtering-history',
+    ),
+    TocHeading(title: 'Mixins & Composition', anchor: 'mixins-composition'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('📦 Satellite Packages')]),
+        h1([Component.text('bloc_signals_replay')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'High-performance undo and redo state history tracking for CubitSignal and BlocSignal with customizable capacity and transition filtering.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Installation
+      section(id: 'overview-install', classes: 'docs-section', [
+        h2([Component.text('Overview & Installation')]),
+        p([
+          Component.text(
+            'The bloc_signals_replay package equips state containers with time-travel capabilities. '
+            'It records state history stacks without copying heavyweight objects, exposing synchronous '
+            'canUndo and canRedo signals that bind seamlessly to Flutter buttons and key shortcuts.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'flutter pub add bloc_signals_replay bloc_signals',
+        ),
+      ]),
+
+      // 2. ReplayCubit
+      section(id: 'replay-cubit', classes: 'docs-section', [
+        h2([Component.text('ReplayCubit')]),
+        p([
+          Component.text(
+            'Extend ReplayCubit<State> to automatically record emitted states in an undo history stack:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/drawing_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_replay/bloc_signals_replay.dart';
+
+class CanvasState {
+  const CanvasState({required this.paths});
+  final List<String> paths;
+}
+
+class DrawingCubit extends ReplayCubit<CanvasState> {
+  DrawingCubit() : super(initialState: const CanvasState(paths: []));
+
+  void addPath(String path) {
+    emit(CanvasState(paths: [...stateValue.paths, path]));
+  }
+}''',
+          dart313Code: '''
+import 'package:bloc_signals_replay/bloc_signals_replay.dart';
+
+class CanvasState {
+  const CanvasState({required this.paths});
+  final List<String> paths;
+}
+
+class DrawingCubit() extends ReplayCubit<CanvasState> {
+  this() : super(initialState: const CanvasState(paths: []));
+
+  void addPath(String path) {
+    emit(CanvasState(paths: [...stateValue.paths, path]));
+  }
+}''',
+        ),
+        p([
+          Component.text(
+            'In your UI, bind undo and redo buttons directly to canUndo and canRedo signals:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/canvas_toolbar.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+
+class CanvasToolbar extends StatelessWidget {
+  const CanvasToolbar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.watch<DrawingCubit>();
+
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.undo),
+          onPressed: cubit.canUndo ? cubit.undo : null,
+        ),
+        IconButton(
+          icon: const Icon(Icons.redo),
+          onPressed: cubit.canRedo ? cubit.redo : null,
+        ),
+      ],
+    );
+  }
+}''',
+        ),
+      ]),
+
+      // 3. ReplayBloc
+      section(id: 'replay-bloc', classes: 'docs-section', [
+        h2([Component.text('ReplayBloc')]),
+        p([
+          Component.text(
+            'For event-driven architectures, extend ReplayBloc<Event, State>. '
+            'ReplayBloc routes undo and redo commands through synthetic ReplayEvents, ensuring that '
+            'BlocSignalObservers observe complete lifecycle transitions during time-travel operations.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/editor_bloc.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_replay/bloc_signals_replay.dart';
+
+sealed class EditorEvent {}
+final class TextInserted extends EditorEvent {
+  TextInserted(this.text);
+  final String text;
+}
+
+class EditorBloc extends ReplayBloc<EditorEvent, String> {
+  EditorBloc() : super(initialState: '') {
+    on<TextInserted>((event, emit) => emit('\$stateValue\${event.text}'));
+  }
+}''',
+        ),
+      ]),
+
+      // 4. History Limits & Bounds
+      section(id: 'history-limits', classes: 'docs-section', [
+        h2([Component.text('History Limits & Memory Bounds')]),
+        p([
+          Component.text(
+            'To prevent unbounded memory consumption in long-running sessions, pass maxHistoryLength to the super constructor. '
+            'When the stack exceeds this capacity, the oldest history entries are automatically discarded.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/limited_history_cubit.dart',
+          language: 'dart',
+          code: '''
+class LimitedHistoryCubit extends ReplayCubit<int> {
+  // Retains at most 20 historical states in the undo queue
+  LimitedHistoryCubit() : super(initialState: 0, maxHistoryLength: 20);
+}''',
+        ),
+      ]),
+
+      // 5. Filtering with shouldReplay
+      section(id: 'filtering-history', classes: 'docs-section', [
+        h2([Component.text('Filtering with shouldReplay')]),
+        p([
+          Component.text(
+            'Override shouldReplay to selectively record only meaningful user actions while ignoring transient intermediate states (like loading flags or hovered items):',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/filtered_replay_cubit.dart',
+          language: 'dart',
+          code: '''
+class FormFieldState {
+  const FormFieldState({required this.value, required this.isFocused});
+  final String value;
+  final bool isFocused;
+}
+
+class FormFieldCubit extends ReplayCubit<FormFieldState> {
+  FormFieldCubit() : super(
+    initialState: const FormFieldState(value: '', isFocused: false),
+  );
+
+  @override
+  bool shouldReplay(FormFieldState state) {
+    // Only record state history when the text value changes, ignoring focus shifts
+    return state.value.isNotEmpty;
+  }
+}''',
+        ),
+      ]),
+
+      // 6. Mixins & Composition
+      section(id: 'mixins-composition', classes: 'docs-section', [
+        h2([Component.text('Mixins & Composition')]),
+        p([
+          Component.text(
+            'If your state container already extends a custom base class or another satellite container '
+            '(such as HydratedCubitSignal), compose replay functionality using ReplayCubitMixin or ReplayBlocMixin:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/hydrated_replay_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
+import 'package:bloc_signals_replay/bloc_signals_replay.dart';
+
+/// Combines persistent disk storage with in-memory undo/redo history.
+class PersistentEditorCubit extends HydratedCubitSignal<String>
+    with ReplayCubitMixin<String> {
+  PersistentEditorCubit() : super(initialState: '');
+
+  @override
+  String fromJson(Object? json) => json as String? ?? '';
+
+  @override
+  Object? toJson(String state) => state;
+}''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_pkg_riverpod.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_riverpod.dart
@@ -1,0 +1,157 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering bidirectional Riverpod interop with bloc_signals_riverpod.
+class const DocsPkgRiverpodPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Installation', anchor: 'overview-install'),
+    TocHeading(title: 'Riverpod to BlocSignal', anchor: 'riverpod-to-bloc'),
+    TocHeading(title: 'BlocSignal to Riverpod', anchor: 'bloc-to-riverpod'),
+    TocHeading(
+      title: 'Auto-Disposal & Lifecycle',
+      anchor: 'lifecycle-disposal',
+    ),
+    TocHeading(
+      title: 'Riverpod 2 & 3 Compatibility',
+      anchor: 'version-compatibility',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [Component.text('📦 Satellite Packages')]),
+        h1([Component.text('bloc_signals_riverpod')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Seamless, bidirectional interoperability bridges connecting Riverpod providers and BlocSignal reactive state containers.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Installation
+      section(id: 'overview-install', classes: 'docs-section', [
+        h2([Component.text('Overview & Installation')]),
+        p([
+          Component.text(
+            'The bloc_signals_riverpod package allows codebases transitioning between Riverpod and BlocSignal '
+            'to share state seamlessly. You can consume Riverpod providers inside BlocSignals, or expose BlocSignals '
+            'as standard Riverpod providers with zero boilerplate.',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'terminal',
+          language: 'bash',
+          code: 'flutter pub add bloc_signals_riverpod bloc_signals flutter_riverpod',
+        ),
+      ]),
+
+      // 2. Riverpod to BlocSignal
+      section(id: 'riverpod-to-bloc', classes: 'docs-section', [
+        h2([Component.text('Riverpod to BlocSignal (.toBlocSignal)')]),
+        p([
+          Component.text(
+            'Convert any Riverpod ProviderListenable into a BlocSignalBase state container using the .toBlocSignal(ref) extension. '
+            'State updates from the Riverpod container propagate into the BlocSignal synchronously:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/riverpod_bridge.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:bloc_signals_riverpod/bloc_signals_riverpod.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final authUserProvider = StateProvider<String?>((ref) => 'Randal');
+
+class UserHeaderWidget extends ConsumerWidget {
+  const UserHeaderWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Adapt the Riverpod provider to a BlocSignal instance bound to this widget's lifecycle
+    final userBloc = authUserProvider.toBlocSignal(ref);
+
+    return BlocSignalBuilder<BlocSignalBase<String?>, String?>(
+      bloc: userBloc,
+      builder: (context, user) => Text('Welcome, \${user ?? "Guest"}'),
+    );
+  }
+}''',
+        ),
+      ]),
+
+      // 3. BlocSignal to Riverpod
+      section(id: 'bloc-to-riverpod', classes: 'docs-section', [
+        h2([Component.text('BlocSignal to Riverpod (.toProvider)')]),
+        p([
+          Component.text(
+            'Expose an existing CubitSignal or BlocSignal as a Riverpod provider using the .toProvider() extension:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/counter_provider.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:bloc_signals_riverpod/bloc_signals_riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+  void increment() => emit(stateValue + 1);
+}
+
+// Create a Riverpod provider backed by CounterCubit
+final counterProvider = Provider<int>((ref) {
+  final cubit = CounterCubit();
+  ref.onDispose(cubit.close);
+  return ref.watchBlocSignal(cubit);
+});''',
+        ),
+      ]),
+
+      // 4. Auto-Disposal & Lifecycle
+      section(id: 'lifecycle-disposal', classes: 'docs-section', [
+        h2([Component.text('Auto-Disposal & Lifecycle Binding')]),
+        p([
+          Component.text(
+            'When you call .toBlocSignal(ref) and pass a Ref or WidgetRef, bloc_signals_riverpod automatically registers '
+            'ref.onDispose(bloc.close). This guarantees that when the surrounding Riverpod provider or consumer widget is destroyed, '
+            'the adapted BlocSignal is disposed of cleanly without retaining memory.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.important,
+          title: 'Preventing Listener Duplication',
+          children: [
+            p([
+              Component.text(
+                'Never subscribe to signals inside standard auto-invalidating Provider((ref) => ...) closures if ref.invalidateSelf() is called. '
+                'Instead, use Riverpod 2/3 Notifiers where the container lifecycle is stable.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 5. Riverpod 2 & 3 Compatibility
+      section(id: 'version-compatibility', classes: 'docs-section', [
+        h2([Component.text('Riverpod 2 & 3 Cross-Version Compatibility')]),
+        p([
+          Component.text(
+            'The adapter leverages package:riverpod/src/internals.dart to maintain unified binary and source compatibility '
+            'across both Riverpod 2.x and Riverpod 3.x installations. You can upgrade Riverpod versions without requiring adapter rewrites.',
+          ),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_recipe_caching.dart
+++ b/website/lib/src/components/docs/pages/docs_recipe_caching.dart
@@ -1,0 +1,199 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering API caching and TTL expiration patterns.
+class const DocsRecipeCachingPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'Overview & Stale-While-Revalidate',
+      anchor: 'overview-swr',
+    ),
+    TocHeading(title: 'Designing the Cache State Model', anchor: 'cache-model'),
+    TocHeading(title: 'The Caching Cubit Pattern', anchor: 'caching-cubit'),
+    TocHeading(
+      title: 'Derived Status with computed()',
+      anchor: 'derived-status',
+    ),
+    TocHeading(
+      title: 'Cache Invalidation & Manual Refresh',
+      anchor: 'manual-refresh',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [
+          Component.text('🛠️ Architecture Recipes'),
+        ]),
+        h1([Component.text('API Caching & TTL Expiration')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Implement high-performance Stale-While-Revalidate caching with automatic Time-to-Live (TTL) expiration and background network synchronization.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Stale-While-Revalidate
+      section(id: 'overview-swr', classes: 'docs-section', [
+        h2([Component.text('Overview & Stale-While-Revalidate')]),
+        p([
+          Component.text(
+            'Modern mobile and web applications deliver instant responsiveness by serving cached data immediately '
+            'while silently fetching fresh updates in the background. With BlocSignal, cached entries render with 0ms delay on initial build, '
+            'and signals notify the UI when fresh network data arrives.',
+          ),
+        ]),
+      ]),
+
+      // 2. Designing the Cache State Model
+      section(id: 'cache-model', classes: 'docs-section', [
+        h2([Component.text('Designing the Cache State Model')]),
+        const DocsCodeBlock(
+          title: 'lib/cache_state.dart',
+          language: 'dart',
+          code: '''
+class CacheEntry<T> {
+  const CacheEntry({
+    required this.data,
+    required this.fetchedAt,
+    this.isRefreshing = false,
+  });
+
+  final T data;
+  final DateTime fetchedAt;
+  final bool isRefreshing;
+
+  bool isExpired(Duration ttl) =>
+      DateTime.now().difference(fetchedAt) > ttl;
+
+  CacheEntry<T> copyWith({
+    T? data,
+    DateTime? fetchedAt,
+    bool? isRefreshing,
+  }) => CacheEntry<T>(
+    data: data ?? this.data,
+    fetchedAt: fetchedAt ?? this.fetchedAt,
+    isRefreshing: isRefreshing ?? this.isRefreshing,
+  );
+}''',
+        ),
+      ]),
+
+      // 3. The Caching Cubit Pattern
+      section(id: 'caching-cubit', classes: 'docs-section', [
+        h2([Component.text('The Caching Cubit Pattern')]),
+        const DocsCodeBlock(
+          title: 'lib/news_feed_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class NewsFeedCubit extends CubitSignal<CacheEntry<List<String>>?> {
+  NewsFeedCubit({required this.repository}) : super(initialState: null);
+
+  final NewsRepository repository;
+  static const Duration cacheTtl = Duration(minutes: 5);
+
+  Future<void> loadFeed({bool forceRefresh = false}) async {
+    final current = stateValue;
+
+    // 1. Serve fresh cache if still valid and not forcing refresh
+    if (!forceRefresh && current != null && !current.isExpired(cacheTtl)) {
+      return;
+    }
+
+    // 2. Mark background refresh while keeping existing cached data on screen
+    if (current != null) {
+      emit(current.copyWith(isRefreshing: true));
+    }
+
+    // 3. Fetch fresh data from network
+    try {
+      final items = await repository.fetchTopNews();
+      emit(CacheEntry(
+        data: items,
+        fetchedAt: DateTime.now(),
+        isRefreshing: false,
+      ));
+    } catch (error) {
+      // Revert refreshing indicator while preserving existing data
+      if (current != null) {
+        emit(current.copyWith(isRefreshing: false));
+      }
+    }
+  }
+}''',
+        ),
+      ]),
+
+      // 4. Derived Status with computed()
+      section(id: 'derived-status', classes: 'docs-section', [
+        h2([Component.text('Derived Status with computed()')]),
+        p([
+          Component.text(
+            'Expose derived signals for UI components to inspect cache freshness without re-running expiration math inside build methods:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/news_feed_helpers.dart',
+          language: 'dart',
+          code: '''
+extension NewsFeedDerived on NewsFeedCubit {
+  /// Derived boolean signal indicating if current cached data is stale
+  ReadonlySignal<bool> get isStale => computed(() {
+    final current = state.value;
+    if (current == null) return true;
+    return current.isExpired(NewsFeedCubit.cacheTtl);
+  });
+}''',
+        ),
+      ]),
+
+      // 5. Cache Invalidation & Manual Refresh
+      section(id: 'manual-refresh', classes: 'docs-section', [
+        h2([Component.text('Cache Invalidation & Pull-to-Refresh')]),
+        p([
+          Component.text(
+            'Connect loadFeed(forceRefresh: true) directly to Flutter RefreshIndicator for smooth pull-to-refresh interactions:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/news_feed_view.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+
+class NewsFeedView extends StatelessWidget {
+  const NewsFeedView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.watch<NewsFeedCubit>();
+    final cache = cubit.stateValue;
+
+    if (cache == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return RefreshIndicator(
+      onRefresh: () => cubit.loadFeed(forceRefresh: true),
+      child: ListView.builder(
+        itemCount: cache.data.length,
+        itemBuilder: (context, index) => ListTile(
+          title: Text(cache.data[index]),
+        ),
+      ),
+    );
+  }
+}''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_recipe_controllers.dart
+++ b/website/lib/src/components/docs/pages/docs_recipe_controllers.dart
@@ -1,0 +1,170 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering coordinating TextEditingControllers with BlocSignal.
+class const DocsRecipeControllersPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(
+      title: 'The Challenge: Mutable vs Immutable',
+      anchor: 'the-challenge',
+    ),
+    TocHeading(title: 'The Build-Phase Pitfall', anchor: 'build-pitfall'),
+    TocHeading(title: 'Safe Synchronization Pattern', anchor: 'sync-pattern'),
+    TocHeading(
+      title: 'Preserving Cursor Selection',
+      anchor: 'cursor-preservation',
+    ),
+    TocHeading(
+      title: 'Complete Stateful Implementation',
+      anchor: 'complete-example',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [
+          Component.text('🛠️ Architecture Recipes'),
+        ]),
+        h1([Component.text('Coordinating TextEditingControllers')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Safely synchronize Flutter mutable TextEditingControllers with immutable Cubit and Bloc state without cursor jump glitches or infinite rebuild loops.',
+          ),
+        ]),
+      ]),
+
+      // 1. The Challenge
+      section(id: 'the-challenge', classes: 'docs-section', [
+        h2([Component.text('The Challenge: Mutable vs Immutable')]),
+        p([
+          Component.text(
+            'Flutter TextEditingController is a mutable Listenable that manages text value and cursor selection offset. '
+            'In contrast, BlocSignal relies on immutable state transitions. Coordinating both directions—user typing in the UI '
+            'and external state updates from network or storage—requires care.',
+          ),
+        ]),
+      ]),
+
+      // 2. The Build-Phase Pitfall
+      section(id: 'build-pitfall', classes: 'docs-section', [
+        h2([Component.text('The Build-Phase Pitfall')]),
+        const DocsCallout(
+          type: CalloutType.warning,
+          title: 'Never Update Controllers Inside build()',
+          children: [
+            p([
+              Component.text(
+                'Assigning controller.text = state.value inside a build() method triggers listener notifications while the framework '
+                'is actively building the widget tree, causing "setState() or markNeedsBuild() called during build" errors or resetting the cursor to position 0.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+
+      // 3. Safe Synchronization Pattern
+      section(id: 'sync-pattern', classes: 'docs-section', [
+        h2([Component.text('Safe Synchronization Pattern')]),
+        p([
+          Component.text(
+            'Use BlocSignalListener to synchronize external state updates to the controller only when the state value diverges from the current controller text:',
+          ),
+        ]),
+      ]),
+
+      // 4. Preserving Cursor Selection
+      section(id: 'cursor-preservation', classes: 'docs-section', [
+        h2([Component.text('Preserving Cursor Selection')]),
+        p([
+          Component.text(
+            'When setting controller text programmatically, update controller.value rather than controller.text '
+            'so you can retain or adjust TextSelection:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/text_sync_helper.dart',
+          language: 'dart',
+          code: '''
+void syncControllerSafely(TextEditingController controller, String newText) {
+  if (controller.text == newText) return;
+
+  final oldSelection = controller.selection;
+  final newOffset = oldSelection.baseOffset.clamp(0, newText.length);
+
+  controller.value = TextEditingValue(
+    text: newText,
+    selection: TextSelection.collapsed(offset: newOffset),
+  );
+}''',
+        ),
+      ]),
+
+      // 5. Complete Stateful Implementation
+      section(id: 'complete-example', classes: 'docs-section', [
+        h2([Component.text('Complete Stateful Implementation')]),
+        const DocsCodeBlock(
+          title: 'lib/search_bar_widget.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+
+class SearchInputWidget extends StatefulWidget {
+  const SearchInputWidget({super.key});
+
+  @override
+  State<SearchInputWidget> createState() => _SearchInputWidgetState();
+}
+
+class _SearchInputWidgetState extends State<SearchInputWidget> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize controller with initial cubit value
+    final initialQuery = context.read<SearchCubit>().stateValue.query;
+    _controller = TextEditingController(text: initialQuery);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSignalListener<SearchCubit, SearchState>(
+      listenWhen: (prev, current) => prev.query != current.query,
+      listener: (context, state) {
+        // Sync external query resets (e.g. from a clear filters button)
+        if (_controller.text != state.query) {
+          _controller.value = TextEditingValue(
+            text: state.query,
+            selection: TextSelection.collapsed(offset: state.query.length),
+          );
+        }
+      },
+      child: TextField(
+        controller: _controller,
+        onChanged: (text) => context.read<SearchCubit>().queryChanged(text),
+        decoration: const InputDecoration(
+          hintText: 'Search packages...',
+          prefixIcon: Icon(Icons.search),
+        ),
+      ),
+    );
+  }
+}''',
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_recipe_form_validation.dart
+++ b/website/lib/src/components/docs/pages/docs_recipe_form_validation.dart
@@ -1,0 +1,200 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering form validation using computed signals.
+class const DocsRecipeFormValidationPage({super.key})
+    extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'Overview & Reactive Forms', anchor: 'overview-forms'),
+    TocHeading(title: 'Designing the Form Cubit', anchor: 'form-cubit'),
+    TocHeading(
+      title: 'Derived Validation with computed()',
+      anchor: 'computed-validation',
+    ),
+    TocHeading(title: 'Flutter UI Integration', anchor: 'ui-integration'),
+    TocHeading(
+      title: 'Performance & Debouncing',
+      anchor: 'performance-debouncing',
+    ),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [
+          Component.text('🛠️ Architecture Recipes'),
+        ]),
+        h1([Component.text('Form Validation with Reactive Signals')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Build ultra-responsive, zero-boilerplate forms by separating raw user inputs from derived validation rules using computed() signals.',
+          ),
+        ]),
+      ]),
+
+      // 1. Overview & Reactive Forms
+      section(id: 'overview-forms', classes: 'docs-section', [
+        h2([Component.text('Overview & Reactive Forms')]),
+        p([
+          Component.text(
+            'Traditional form validation in Flutter often mixes raw text values, error strings, and submission flags '
+            'inside large state objects with complex copyWith() logic. With BlocSignal and computed() signals, '
+            'validation rules are defined as pure functions of input signals, automatically recalculating with 0ms latency '
+            'and memoizing results.',
+          ),
+        ]),
+      ]),
+
+      // 2. Designing the Form Cubit
+      section(id: 'form-cubit', classes: 'docs-section', [
+        h2([Component.text('Designing the Form Cubit')]),
+        const DocsCodeBlock(
+          title: 'lib/login_form_cubit.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class LoginFormState {
+  const LoginFormState({
+    this.email = '',
+    this.password = '',
+    this.isSubmitting = false,
+  });
+
+  final String email;
+  final String password;
+  final bool isSubmitting;
+
+  LoginFormState copyWith({
+    String? email,
+    String? password,
+    bool? isSubmitting,
+  }) => LoginFormState(
+    email: email ?? this.email,
+    password: password ?? this.password,
+    isSubmitting: isSubmitting ?? this.isSubmitting,
+  );
+}
+
+class LoginFormCubit extends CubitSignal<LoginFormState> {
+  LoginFormCubit() : super(initialState: const LoginFormState()) {
+    // Derived email validation error
+    emailError = computed(() {
+      final email = state.value.email;
+      if (email.isEmpty) return null;
+      if (!email.contains('@') || !email.contains('.')) {
+        return 'Please enter a valid email address';
+      }
+      return null;
+    });
+
+    // Derived password validation error
+    passwordError = computed(() {
+      final password = state.value.password;
+      if (password.isEmpty) return null;
+      if (password.length < 8) {
+        return 'Password must be at least 8 characters';
+      }
+      return null;
+    });
+
+    // Combined form validity signal
+    isValid = computed(() {
+      final s = state.value;
+      return s.email.isNotEmpty &&
+          s.password.isNotEmpty &&
+          emailError.value == null &&
+          passwordError.value == null;
+    });
+  }
+
+  late final ReadonlySignal<String?> emailError;
+  late final ReadonlySignal<String?> passwordError;
+  late final ReadonlySignal<bool> isValid;
+
+  void emailChanged(String email) => emit(stateValue.copyWith(email: email));
+  void passwordChanged(String password) => emit(stateValue.copyWith(password: password));
+}''',
+        ),
+      ]),
+
+      // 3. Derived Validation with computed()
+      section(id: 'computed-validation', classes: 'docs-section', [
+        h2([Component.text('Derived Validation with computed()')]),
+        p([
+          Component.text(
+            'Notice that emailError, passwordError, and isValid are not stored fields in LoginFormState. '
+            'They are derived signals created via computed(). They track state.value automatically and only notify '
+            'listeners when their evaluated validation result changes.',
+          ),
+        ]),
+      ]),
+
+      // 4. Flutter UI Integration
+      section(id: 'ui-integration', classes: 'docs-section', [
+        h2([Component.text('Flutter UI Integration')]),
+        const DocsCodeBlock(
+          title: 'lib/login_form_view.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+
+class LoginFormView extends StatelessWidget {
+  const LoginFormView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.watch<LoginFormCubit>();
+
+    return Column(
+      children: [
+        TextField(
+          onChanged: cubit.emailChanged,
+          decoration: InputDecoration(
+            labelText: 'Email',
+            errorText: cubit.emailError.value,
+          ),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          obscureText: true,
+          onChanged: cubit.passwordChanged,
+          decoration: InputDecoration(
+            labelText: 'Password',
+            errorText: cubit.passwordError.value,
+          ),
+        ),
+        const SizedBox(height: 24),
+        ElevatedButton(
+          onPressed: cubit.isValid.value ? () => _submit(context) : null,
+          child: const Text('Log In'),
+        ),
+      ],
+    );
+  }
+
+  void _submit(BuildContext context) {
+    // Handle submission logic
+  }
+}''',
+        ),
+      ]),
+
+      // 5. Performance & Debouncing
+      section(id: 'performance-debouncing', classes: 'docs-section', [
+        h2([Component.text('Performance & Debouncing')]),
+        p([
+          Component.text(
+            'Because computed signals automatically de-duplicate equal outputs, typing in the password field will never '
+            're-evaluate or rebuild the email error widget unless the email validation state actually changes.',
+          ),
+        ]),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/components/docs/pages/docs_recipe_one_shot.dart
+++ b/website/lib/src/components/docs/pages/docs_recipe_one_shot.dart
@@ -1,0 +1,150 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../docs_callout.dart';
+import '../docs_code_block.dart';
+import '../docs_toc.dart';
+
+/// Documentation page covering handling one-shot presentation side-effects.
+class const DocsRecipeOneShotPage({super.key}) extends StatelessComponent {
+  static const List<TocHeading> headings = [
+    TocHeading(title: 'The Problem: Ephemeral Events', anchor: 'the-problem'),
+    TocHeading(
+      title: 'Pattern 1: Sealed Result States',
+      anchor: 'sealed-result-states',
+    ),
+    TocHeading(
+      title: 'Pattern 2: Event Streams vs Listeners',
+      anchor: 'listeners-vs-streams',
+    ),
+    TocHeading(title: 'Complete Flutter Example', anchor: 'flutter-example'),
+    TocHeading(title: 'Anti-Patterns to Avoid', anchor: 'anti-patterns'),
+  ];
+
+  @override
+  Component build(BuildContext context) {
+    return article(classes: 'docs-article', [
+      header(classes: 'docs-article-header', [
+        div(classes: 'docs-badge', [
+          Component.text('🛠️ Architecture Recipes'),
+        ]),
+        h1([Component.text('One-Shot Presentation Side Effects')]),
+        p(classes: 'docs-lead', [
+          Component.text(
+            'Clean, declarative patterns for triggering one-off UI actions like Navigation, SnackBars, and Alert Dialogs without anti-pattern event reset flags.',
+          ),
+        ]),
+      ]),
+
+      // 1. The Problem
+      section(id: 'the-problem', classes: 'docs-section', [
+        h2([Component.text('The Problem: Ephemeral Events')]),
+        p([
+          Component.text(
+            'In declarative state management, representing one-time actions (like showing a SnackBar or navigating to a new screen) '
+            'can be tricky. If an error message is stored as a persistent property on your state object, navigating away and returning '
+            'or rotating the device could cause the SnackBar to trigger a second time.',
+          ),
+        ]),
+      ]),
+
+      // 2. Pattern 1: Sealed Result States
+      section(id: 'sealed-result-states', classes: 'docs-section', [
+        h2([
+          Component.text(
+            'Pattern 1: Sealed Result States with BlocSignalListener',
+          ),
+        ]),
+        p([
+          Component.text(
+            'The recommended approach in BlocSignal is to model terminal outcomes using sealed state classes and react to them with BlocSignalListener:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/auth_state.dart',
+          language: 'dart',
+          code: '''
+sealed class AuthState {}
+final class AuthInitial extends AuthState {}
+final class AuthSubmitting extends AuthState {}
+final class AuthSuccess extends AuthState {
+  AuthSuccess(this.user);
+  final User user;
+}
+final class AuthFailure extends AuthState {
+  AuthFailure(this.errorMessage);
+  final String errorMessage;
+}''',
+        ),
+      ]),
+
+      // 3. Pattern 2: Listeners vs Streams
+      section(id: 'listeners-vs-streams', classes: 'docs-section', [
+        h2([
+          Component.text('Pattern 2: Why BlocSignalListener Over Raw Streams'),
+        ]),
+        p([
+          Component.text(
+            'Unlike raw EventBus streams, BlocSignalListener participates in Flutter widget lifecycles. '
+            'It registers and unregisters listeners automatically when the widget mounts and unmounts, preventing memory leaks '
+            'and ensuring that dialogs are only shown when the widget is actively mounted in the element tree.',
+          ),
+        ]),
+      ]),
+
+      // 4. Complete Flutter Example
+      section(id: 'flutter-example', classes: 'docs-section', [
+        h2([Component.text('Complete Flutter Example')]),
+        const DocsCodeBlock(
+          title: 'lib/login_view.dart',
+          language: 'dart',
+          code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+
+class LoginView extends StatelessWidget {
+  const LoginView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSignalListener<AuthBloc, AuthState>(
+      listenWhen: (previous, current) =>
+          current is AuthSuccess || current is AuthFailure,
+      listener: (context, state) {
+        if (state is AuthSuccess) {
+          Navigator.of(context).pushReplacementNamed('/home');
+        } else if (state is AuthFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.errorMessage),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      },
+      child: const LoginForm(),
+    );
+  }
+}''',
+        ),
+      ]),
+
+      // 5. Anti-Patterns to Avoid
+      section(id: 'anti-patterns', classes: 'docs-section', [
+        h2([Component.text('Anti-Patterns to Avoid')]),
+        const DocsCallout(
+          type: CalloutType.warning,
+          title: 'Avoid Boolean Reset Flags',
+          children: [
+            p([
+              Component.text(
+                'Avoid adding fields like shouldShowSnackBar: true followed immediately by emit(state.copyWith(shouldShowSnackBar: false)). '
+                'This generates double transitions and race conditions. Instead, model outcomes as distinct sealed states handled in listenWhen.',
+              ),
+            ]),
+          ],
+        ),
+      ]),
+    ]);
+  }
+}

--- a/website/lib/src/models/docs_registry.dart
+++ b/website/lib/src/models/docs_registry.dart
@@ -1,6 +1,3 @@
-import 'package:jaspr/dom.dart';
-import 'package:jaspr/jaspr.dart';
-
 import '../components/docs/pages/docs_cubit_vs_bloc.dart';
 import '../components/docs/pages/docs_event_transformers.dart';
 import '../components/docs/pages/docs_events_and_handlers.dart';
@@ -9,8 +6,19 @@ import '../components/docs/pages/docs_flutter_providers.dart';
 import '../components/docs/pages/docs_flutter_widgets.dart';
 import '../components/docs/pages/docs_installation.dart';
 import '../components/docs/pages/docs_lifecycle_and_observers.dart';
+import '../components/docs/pages/docs_migration_bloc.dart';
+import '../components/docs/pages/docs_migration_riverpod.dart';
 import '../components/docs/pages/docs_overview.dart';
+import '../components/docs/pages/docs_pkg_devtools.dart';
+import '../components/docs/pages/docs_pkg_hydrate.dart';
+import '../components/docs/pages/docs_pkg_otel.dart';
+import '../components/docs/pages/docs_pkg_replay.dart';
+import '../components/docs/pages/docs_pkg_riverpod.dart';
 import '../components/docs/pages/docs_quickstart.dart';
+import '../components/docs/pages/docs_recipe_caching.dart';
+import '../components/docs/pages/docs_recipe_controllers.dart';
+import '../components/docs/pages/docs_recipe_form_validation.dart';
+import '../components/docs/pages/docs_recipe_one_shot.dart';
 import '../components/docs/pages/docs_signals_reactivity.dart';
 import '../components/docs/pages/docs_state_modeling.dart';
 import '../components/docs/pages/docs_testing_guide.dart';
@@ -80,10 +88,10 @@ class const DocsRegistry() {
         ),
         DocSectionItem(
           id: 'event-transformers',
-          title: 'Event Transformers',
+          title: 'Event Transformers & Concurrency',
           path: '/docs/event-transformers',
           category: 'Core Concepts',
-          description: 'Streamless event transformers (droppable, sequential, restartable) and custom debounce/mutex locks.',
+          description: 'droppable(), sequential(), restartable(), and custom streamless event Transformers.',
           builder: DocsEventTransformersPage.new,
         ),
         DocSectionItem(
@@ -91,7 +99,7 @@ class const DocsRegistry() {
           title: 'Lifecycle & Observers',
           path: '/docs/lifecycle-and-observers',
           category: 'Core Concepts',
-          description: 'BlocSignalObserver, Change, Transition, and OpenTelemetry identity span tracking.',
+          description: 'State container lifecycles, isClosed guarantees, and global observability with BlocSignalObserver.',
           builder: DocsLifecycleAndObserversPage.new,
         ),
         DocSectionItem(
@@ -99,21 +107,21 @@ class const DocsRegistry() {
           title: 'Signals Graph Reactivity',
           path: '/docs/signals-reactivity',
           category: 'Core Concepts',
-          description: 'Understanding stateValue vs state, computed() derivations, and managed effect() reactions.',
+          description: 'Preact signals v7 integration, 0ms synchronous propagation, computed signals, and effects.',
           builder: DocsSignalsReactivityPage.new,
         ),
       ],
     ),
-    DocCategory(
+    const DocCategory(
       title: 'Flutter Integration',
-      icon: '📱',
+      icon: '💙',
       sections: [
         DocSectionItem(
           id: 'flutter-providers',
-          title: 'BlocSignalProvider & Lookup',
+          title: 'Providers & Dependency Injection',
           path: '/docs/flutter-providers',
           category: 'Flutter Integration',
-          description: 'Dependency injection with BlocSignalProvider, MultiBlocSignalProvider, and O(1) lookups.',
+          description: 'BlocSignalProvider scoping, lazy loading, and O(1) InheritedElement resolution.',
           builder: DocsFlutterProvidersPage.new,
         ),
         DocSectionItem(
@@ -148,7 +156,7 @@ class const DocsRegistry() {
         ),
       ],
     ),
-    DocCategory(
+    const DocCategory(
       title: 'Satellite Packages',
       icon: '📦',
       sections: [
@@ -158,12 +166,7 @@ class const DocsRegistry() {
           path: '/docs/pkg-hydrate',
           category: 'Satellite Packages',
           description: 'Synchronous frame 1 state persistence across restarts.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'bloc_signals_hydrate',
-            phase: 'Phase 4',
-            description: 'State persistence with zero-boilerplate primitive and collection storage.',
-          ),
+          builder: DocsPkgHydratePage.new,
         ),
         DocSectionItem(
           id: 'pkg-replay',
@@ -171,13 +174,7 @@ class const DocsRegistry() {
           path: '/docs/pkg-replay',
           category: 'Satellite Packages',
           description: 'Undo and redo history management with ReplayCubit and ReplayBloc.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'bloc_signals_replay',
-            phase: 'Phase 4',
-            description:
-                'Time-travel and undo/redo stacks for state containers.',
-          ),
+          builder: DocsPkgReplayPage.new,
         ),
         DocSectionItem(
           id: 'pkg-riverpod',
@@ -186,13 +183,7 @@ class const DocsRegistry() {
           category: 'Satellite Packages',
           description:
               'Bidirectional Riverpod 2 & 3 interoperability adapters.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'bloc_signals_riverpod',
-            phase: 'Phase 4',
-            description:
-                'Bridging Riverpod providers into BlocSignal and vice-versa.',
-          ),
+          builder: DocsPkgRiverpodPage.new,
         ),
         DocSectionItem(
           id: 'pkg-otel',
@@ -201,12 +192,7 @@ class const DocsRegistry() {
           category: 'Satellite Packages',
           description:
               'OpenTelemetry distributed tracing and observability spans.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'bloc_signals_otel',
-            phase: 'Phase 4',
-            description: 'Distributed tracing and OpenTelemetry metrics for transitions and errors.',
-          ),
+          builder: DocsPkgOtelPage.new,
         ),
         DocSectionItem(
           id: 'pkg-devtools',
@@ -214,16 +200,11 @@ class const DocsRegistry() {
           path: '/docs/pkg-devtools',
           category: 'Satellite Packages',
           description: 'DevTools timeline inspection and leak detector badge.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'bloc_signals_devtools',
-            phase: 'Phase 4',
-            description: 'Custom DevTools extension for timeline debugging and state inspection.',
-          ),
+          builder: DocsPkgDevtoolsPage.new,
         ),
       ],
     ),
-    DocCategory(
+    const DocCategory(
       title: 'Architecture & Recipes',
       icon: '💡',
       sections: [
@@ -233,13 +214,7 @@ class const DocsRegistry() {
           path: '/docs/recipe-one-shot',
           category: 'Architecture & Recipes',
           description: 'Handling snackbars, dialogs, and navigation without polluting domain state.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'One-Shot UI Side Effects',
-            phase: 'Phase 4',
-            description:
-                'Recipes for transient side-effects without state corruption.',
-          ),
+          builder: DocsRecipeOneShotPage.new,
         ),
         DocSectionItem(
           id: 'recipe-form-validation',
@@ -247,12 +222,7 @@ class const DocsRegistry() {
           path: '/docs/recipe-form-validation',
           category: 'Architecture & Recipes',
           description: 'Primary input signals paired with computed() derived validation states.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'Form Validation',
-            phase: 'Phase 4',
-            description: 'Building performant, boilerplate-free forms with computed signals.',
-          ),
+          builder: DocsRecipeFormValidationPage.new,
         ),
         DocSectionItem(
           id: 'recipe-controllers',
@@ -260,12 +230,7 @@ class const DocsRegistry() {
           path: '/docs/recipe-controllers',
           category: 'Architecture & Recipes',
           description: 'Bidirectional syncing of TextEditingControllers without build-phase mutation loops.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'Coordinating Controllers',
-            phase: 'Phase 4',
-            description: 'How to coordinate Flutter controllers with reactive state containers safely.',
-          ),
+          builder: DocsRecipeControllersPage.new,
         ),
         DocSectionItem(
           id: 'recipe-caching',
@@ -273,16 +238,11 @@ class const DocsRegistry() {
           path: '/docs/recipe-caching',
           category: 'Architecture & Recipes',
           description: 'Managing asynchronous server data with automatic cache invalidation.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'API Caching & TTL Expiration',
-            phase: 'Phase 4',
-            description: 'Implementing resilient API caching with time-to-live expiration.',
-          ),
+          builder: DocsRecipeCachingPage.new,
         ),
       ],
     ),
-    DocCategory(
+    const DocCategory(
       title: 'Migration Guides',
       icon: '🔄',
       sections: [
@@ -292,12 +252,7 @@ class const DocsRegistry() {
           path: '/docs/migration-bloc',
           category: 'Migration Guides',
           description: 'Step-by-step migration guide from classic BLoC / flutter_bloc to BlocSignal.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'Migrating from package:bloc',
-            phase: 'Phase 4',
-            description: 'Comprehensive guide and code comparisons for migrating from Flutter BLoC.',
-          ),
+          builder: DocsMigrationBlocPage.new,
         ),
         DocSectionItem(
           id: 'migration-riverpod',
@@ -305,12 +260,7 @@ class const DocsRegistry() {
           path: '/docs/migration-riverpod',
           category: 'Migration Guides',
           description: 'Step-by-step migration guide from Riverpod providers to BlocSignal.',
-          badge: 'Phase 4',
-          builder: () => _PlaceholderDoc(
-            title: 'Migrating from Riverpod',
-            phase: 'Phase 4',
-            description: 'Comparing concepts and converting Riverpod state notifiers to BlocSignal.',
-          ),
+          builder: DocsMigrationRiverpodPage.new,
         ),
       ],
     ),
@@ -361,39 +311,5 @@ class const DocsRegistry() {
     final prev = index > 0 ? allSections[index - 1] : null;
     final next = index < allSections.length - 1 ? allSections[index + 1] : null;
     return (prev, next);
-  }
-}
-
-class const _PlaceholderDoc({
-  required final String title,
-  required final String phase,
-  required final String description,
-}) extends StatelessComponent {
-  @override
-  Component build(BuildContext context) {
-    return article(classes: 'docs-article', [
-      header(classes: 'docs-article-header', [
-        div(classes: 'docs-badge', [Component.text('⏳ In Progress ($phase)')]),
-        h1([Component.text(title)]),
-        p(classes: 'docs-lead', [Component.text(description)]),
-      ]),
-      section(classes: 'docs-section', [
-        div(classes: 'docs-placeholder-card', [
-          span(classes: 'docs-placeholder-icon', [Component.text('🚧')]),
-          h3([Component.text('Coming Soon in $phase')]),
-          p([
-            Component.text(
-              'This documentation chapter is currently being drafted as part of $phase of the BlocSignal Documentation Hub rollout. '
-              'In the meantime, refer to the Getting Started guides and the official README.',
-            ),
-          ]),
-          div(classes: 'docs-placeholder-actions', [
-            a(href: '/docs/quickstart', classes: 'btn-primary-sm', [
-              Component.text('Go to Quickstart Guide ➔'),
-            ]),
-          ]),
-        ]),
-      ]),
-    ]);
   }
 }

--- a/website/test/docs_registry_test.dart
+++ b/website/test/docs_registry_test.dart
@@ -71,6 +71,56 @@ void main() {
       expect(testingGuide.id, equals('testing-guide'));
       expect(testingGuide.category, equals('Testing'));
 
+      final pkgHydrate = DocsRegistry.resolveSection('pkg-hydrate');
+      expect(pkgHydrate.id, equals('pkg-hydrate'));
+      expect(pkgHydrate.category, equals('Satellite Packages'));
+
+      final pkgReplay = DocsRegistry.resolveSection('pkg-replay');
+      expect(pkgReplay.id, equals('pkg-replay'));
+      expect(pkgReplay.category, equals('Satellite Packages'));
+
+      final pkgRiverpod = DocsRegistry.resolveSection('pkg-riverpod');
+      expect(pkgRiverpod.id, equals('pkg-riverpod'));
+      expect(pkgRiverpod.category, equals('Satellite Packages'));
+
+      final pkgOtel = DocsRegistry.resolveSection('pkg-otel');
+      expect(pkgOtel.id, equals('pkg-otel'));
+      expect(pkgOtel.category, equals('Satellite Packages'));
+
+      final pkgDevtools = DocsRegistry.resolveSection('pkg-devtools');
+      expect(pkgDevtools.id, equals('pkg-devtools'));
+      expect(pkgDevtools.category, equals('Satellite Packages'));
+
+      final recipeOneShot = DocsRegistry.resolveSection('recipe-one-shot');
+      expect(recipeOneShot.id, equals('recipe-one-shot'));
+      expect(recipeOneShot.category, equals('Architecture & Recipes'));
+
+      final recipeFormValidation = DocsRegistry.resolveSection(
+        'recipe-form-validation',
+      );
+      expect(recipeFormValidation.id, equals('recipe-form-validation'));
+      expect(recipeFormValidation.category, equals('Architecture & Recipes'));
+
+      final recipeControllers = DocsRegistry.resolveSection(
+        'recipe-controllers',
+      );
+      expect(recipeControllers.id, equals('recipe-controllers'));
+      expect(recipeControllers.category, equals('Architecture & Recipes'));
+
+      final recipeCaching = DocsRegistry.resolveSection('recipe-caching');
+      expect(recipeCaching.id, equals('recipe-caching'));
+      expect(recipeCaching.category, equals('Architecture & Recipes'));
+
+      final migrationBloc = DocsRegistry.resolveSection('migration-bloc');
+      expect(migrationBloc.id, equals('migration-bloc'));
+      expect(migrationBloc.category, equals('Migration Guides'));
+
+      final migrationRiverpod = DocsRegistry.resolveSection(
+        'migration-riverpod',
+      );
+      expect(migrationRiverpod.id, equals('migration-riverpod'));
+      expect(migrationRiverpod.category, equals('Migration Guides'));
+
       // Variations with trailing slashes, index.html, and full paths
       expect(
         DocsRegistry.resolveSection('installation/').id,
@@ -87,6 +137,14 @@ void main() {
       expect(
         DocsRegistry.resolveSection('/docs/cubit-vs-bloc').id,
         equals('cubit-vs-bloc'),
+      );
+      expect(
+        DocsRegistry.resolveSection('/docs/pkg-hydrate').id,
+        equals('pkg-hydrate'),
+      );
+      expect(
+        DocsRegistry.resolveSection('/docs/migration-bloc').id,
+        equals('migration-bloc'),
       );
     });
 

--- a/website/web/styles.css
+++ b/website/web/styles.css
@@ -2711,6 +2711,22 @@ code, pre, .font-mono {
   color: var(--text-primary);
 }
 
+.docs-syntax-selector {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+}
+
+.docs-syntax-label {
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
 .docs-nav-tree {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Completes **Phase 4** (the final phase) of the BlocSignal Documentation Hub (`/docs`), delivering full coverage across satellite ecosystem packages, architectural recipes, and migration guides:

- **5 Satellite Packages**:
  - `bloc_signals_hydrate` (`/docs/pkg-hydrate`): Synchronous frame 1 hydration, primitive/collection storage, `SharedPreferencesHydratedStorage`, `SecureHydratedStorage`.
  - `bloc_signals_replay` (`/docs/pkg-replay`): `ReplayCubit` / `ReplayBloc`, undo/redo stacks, history limits, `canUndo`/`canRedo`.
  - `bloc_signals_riverpod` (`/docs/pkg-riverpod`): Bidirectional adapters (`.toBlocSignal(ref)`, `.toProvider()`), auto-disposal.
  - `bloc_signals_otel` (`/docs/pkg-otel`): Distributed OpenTelemetry tracing, span hierarchies, error correlation, LRU eviction.
  - `bloc_signals_devtools` (`/docs/pkg-devtools`): DevTools extension, timeline trace, state diff inspector, leak detector.
- **4 Architecture Recipes**:
  - One-Shot UI Side Effects (`/docs/recipe-one-shot`)
  - Form Validation with Reactive Signals (`/docs/recipe-form-validation`)
  - Coordinating TextEditingControllers (`/docs/recipe-controllers`)
  - API Caching & TTL Expiration (`/docs/recipe-caching`)
- **2 Migration Guides**:
  - Migrating from `package:bloc` & `flutter_bloc` (`/docs/migration-bloc`)
  - Migrating from `flutter_riverpod` (`/docs/migration-riverpod`)
- **Developer Ergonomics**:
  - Global Dart 3.13+ vs Dart 3.5 syntax toggle in left sidebar.
  - Synchronized `DocsCodeBlock` with local per-snippet override tabs.
  - Full 3-column responsive layout (`docs-shell` grid).

Closes #170