### PR TITLE
docs(website): fix Dart 3.13 primary constructor code samples (#191)

### DIFF
--- a/doc/articles/dart-313-primary-constructors-blocsignal-boilerplate-free-reactive-architecture-5fll.md
+++ b/doc/articles/dart-313-primary-constructors-blocsignal-boilerplate-free-reactive-architecture-5fll.md
@@ -93,7 +93,8 @@ class UserCubit(
   final UserRepository repository,
   final AnalyticsService analytics, {
   final UserState initial = const UserInitial(),
-}) extends CubitSignal<UserState>(initialState: initial) {
+}) extends CubitSignal<UserState> {
+  this : super(initialState: initial);
 
   Future<void> loadUser(String id) async {
     emit(const UserLoading());
@@ -121,10 +122,9 @@ One of the most powerful features in Dart 3.13 is the **`this` constructor body 
 class SearchBloc(
   final SearchRepository repository, {
   final SearchState initial = const SearchInitial(),
-}) extends BlocSignal<SearchEvent, SearchState>(initialState: initial) {
-
-  // Dart 3.13 primary constructor body
-  this {
+}) extends BlocSignal<SearchEvent, SearchState> {
+  // Dart 3.13 primary constructor body with super-initializer
+  this : super(initialState: initial) {
     on<SearchQueryChanged>(
       (event, emit) async {
         if (event.query.trim().isEmpty) return emit(const SearchEmpty());
@@ -149,9 +149,8 @@ The header cleanly declares the class contract, and the `this` block sets up the
 
 ```dart
 class CartSummaryCubit(final CartBloc cartBloc)
-    extends CubitSignal<CartSummary>(initialState: const CartSummary.zero()) {
-
-  this {
+    extends CubitSignal<CartSummary> {
+  this : super(initialState: const CartSummary.zero()) {
     // Automatically reacts to cartBloc.state signals synchronously:
     createEffect(() {
       final items = cartBloc.state.value.items;
@@ -169,13 +168,15 @@ class CartSummaryCubit(final CartBloc cartBloc)
 Dart 3.13 also introduces constructor shorthands, allowing you to define secondary named constructors using `new name()` without repeating the class name:
 
 ```dart
-class CounterCubit(var int count) extends CubitSignal<int>(initialState: count) {
+class CounterCubit(int count) extends CubitSignal<int> {
+  this : super(initialState: count);
+
   // Named constructor shorthands:
   new zero() : this(0);
   new seeded(int initial) : this(initial);
 
-  void increment() => emit(state + 1);
-  void decrement() => emit(state - 1);
+  void increment() => emit(stateValue + 1);
+  void decrement() => emit(stateValue - 1);
 }
 ```
 

--- a/doc/articles/why-blocsignal-doesnt-need-provider-and-why-classic-bloc-always-did-1j3g.md
+++ b/doc/articles/why-blocsignal-doesnt-need-provider-and-why-classic-bloc-always-did-1j3g.md
@@ -238,15 +238,16 @@ class Counter extends _$Counter {
 #### In Dart 3.5 (Baseline Syntax):
 ```dart
 class CounterCubit extends CubitSignal<int> {
-  CounterCubit([int initial = 0]) : super(initial);
-  void increment() => emit(state.value + 1); // ⚡ Synchronous, zero code-gen
+  CounterCubit([int initial = 0]) : super(initialState: initial);
+  void increment() => emit(stateValue + 1); // ⚡ Synchronous, zero code-gen
 }
 ```
 
 #### In Dart 3.13 (Modern Primary Constructor):
 ```dart
-class CounterCubit([int initial = 0]) extends CubitSignal<int>(initial) {
-  void increment() => emit(state.value + 1);
+class CounterCubit([int initial = 0]) extends CubitSignal<int> {
+  this : super(initialState: initial);
+  void increment() => emit(stateValue + 1);
 }
 ```
 

--- a/plugins/bloc-signals/skills/bloc-signals/decision_matrix.md
+++ b/plugins/bloc-signals/skills/bloc-signals/decision_matrix.md
@@ -109,8 +109,8 @@ final counter = 0.$;
 void increment() => counter.value++;
 
 // 2. CubitSignal with direct method
-class CounterCubit extends CubitSignal<int> {
-  CounterCubit() : super(initialState: 0);
+class CounterCubit() extends CubitSignal<int> {
+  this : super(initialState: 0);
 
   void increment() => emit(stateValue + 1);
 }
@@ -119,8 +119,8 @@ class CounterCubit extends CubitSignal<int> {
 sealed class const CounterEvent();
 final class const IncrementRequested() extends CounterEvent;
 
-class CounterBloc extends BlocSignal<CounterEvent, int> {
-  CounterBloc() : super(initialState: 0) {
+class CounterBloc() extends BlocSignal<CounterEvent, int> {
+  this : super(initialState: 0) {
     on<IncrementRequested>((event, emit) => emit(stateValue + 1));
   }
 }

--- a/website/lib/src/components/docs/pages/docs_cubit_vs_bloc.dart
+++ b/website/lib/src/components/docs/pages/docs_cubit_vs_bloc.dart
@@ -230,7 +230,9 @@ final class AuthInitial extends AuthState;
 final class AuthAuthenticated(final String username) extends AuthState;
 
 class AuthCubit(final AuthRepository repository)
-    extends CubitSignal<AuthState>(initialState: const AuthInitial()) {
+    extends CubitSignal<AuthState> {
+  this : super(initialState: const AuthInitial());
+
   Future<void> login(String username, String password) async {
     final success = await repository.authenticate(username, password);
     if (success) {
@@ -279,8 +281,8 @@ final class AuthLoginRequested(final String username, final String password)
 final class AuthLogoutRequested extends AuthEvent;
 
 class AuthBloc(final AuthRepository repository)
-    extends BlocSignal<AuthEvent, AuthState>(initialState: const AuthInitial()) {
-  this {
+    extends BlocSignal<AuthEvent, AuthState> {
+  this : super(initialState: const AuthInitial()) {
     on<AuthLoginRequested>((event, emit) async {
       final success = await repository.authenticate(event.username, event.password);
       if (success) {

--- a/website/lib/src/components/docs/pages/docs_decision_matrix.dart
+++ b/website/lib/src/components/docs/pages/docs_decision_matrix.dart
@@ -467,8 +467,9 @@ final counter = 0.$;
 void increment() => counter.value++;
 
 // 2. CubitSignal with modern syntax
-class CounterCubit extends CubitSignal<int> {
-  CounterCubit() : super(initialState: 0);
+class CounterCubit() extends CubitSignal<int> {
+  this : super(initialState: 0);
+
   void increment() => emit(stateValue + 1);
 }
 
@@ -476,8 +477,8 @@ class CounterCubit extends CubitSignal<int> {
 sealed class const CounterEvent();
 final class const IncrementRequested() extends CounterEvent;
 
-class CounterBloc extends BlocSignal<CounterEvent, int> {
-  CounterBloc() : super(initialState: 0) {
+class CounterBloc() extends BlocSignal<CounterEvent, int> {
+  this : super(initialState: 0) {
     on<IncrementRequested>((event, emit) => emit(stateValue + 1));
   }
 }''',

--- a/website/lib/src/components/docs/pages/docs_events_and_handlers.dart
+++ b/website/lib/src/components/docs/pages/docs_events_and_handlers.dart
@@ -69,8 +69,8 @@ sealed class CounterEvent;
 final class IncrementPressed extends CounterEvent;
 final class DecrementPressed extends CounterEvent;
 
-class CounterBloc() extends BlocSignal<CounterEvent, int>(initialState: 0) {
-  this {
+class CounterBloc() extends BlocSignal<CounterEvent, int> {
+  this : super(initialState: 0) {
     on<IncrementPressed>((event, emit) => emit(stateValue + 1));
     on<DecrementPressed>((event, emit) => emit(stateValue - 1));
   }
@@ -140,10 +140,8 @@ class CounterBloc extends BlocSignal<CounterEvent, int> {
           filename: 'async_event_handling.dart',
           dart313Code: '''
 class SearchBloc(final SearchService service)
-    extends BlocSignal<SearchEvent, SearchState>(
-      initialState: const SearchInitial(),
-    ) {
-  this {
+    extends BlocSignal<SearchEvent, SearchState> {
+  this : super(initialState: const SearchInitial()) {
     on<SearchQuerySubmitted>((event, emit) async {
       emit(const SearchLoading());
       try {

--- a/website/lib/src/components/docs/pages/docs_overview.dart
+++ b/website/lib/src/components/docs/pages/docs_overview.dart
@@ -99,7 +99,9 @@ class const DocsOverviewPage({super.key}) extends StatelessComponent {
           dart313Code: '''
 import 'package:bloc_signals/bloc_signals.dart';
 
-class CounterCubit() extends CubitSignal<int>(initialState: 0) {
+class CounterCubit() extends CubitSignal<int> {
+  this : super(initialState: 0);
+
   void increment() => emit(stateValue + 1);
 }
 

--- a/website/lib/src/components/docs/pages/docs_pkg_hydrate.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_hydrate.dart
@@ -122,7 +122,7 @@ import 'package:bloc_signals_hydrate/bloc_signals_hydrate.dart';
 enum AppTheme { light, dark, system }
 
 class ThemeCubit() extends HydratedCubitSignal<AppTheme> {
-  this() : super(initialState: AppTheme.system);
+  this : super(initialState: AppTheme.system);
 
   void toggleTheme() {
     emit(stateValue == AppTheme.dark ? AppTheme.light : AppTheme.dark);

--- a/website/lib/src/components/docs/pages/docs_pkg_replay.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_replay.dart
@@ -86,7 +86,7 @@ class CanvasState {
 }
 
 class DrawingCubit() extends ReplayCubit<CanvasState> {
-  this() : super(initialState: const CanvasState(paths: []));
+  this : super(initialState: const CanvasState(paths: []));
 
   void addPath(String path) {
     emit(CanvasState(paths: [...stateValue.paths, path]));

--- a/website/lib/src/components/docs/pages/docs_quickstart.dart
+++ b/website/lib/src/components/docs/pages/docs_quickstart.dart
@@ -69,7 +69,9 @@ class const DocsQuickstartPage({super.key}) extends StatelessComponent {
           dart313Code: '''
 import 'package:bloc_signals/bloc_signals.dart';
 
-class CounterCubit() extends CubitSignal<int>(initialState: 0) {
+class CounterCubit() extends CubitSignal<int> {
+  this : super(initialState: 0);
+
   void increment() => emit(stateValue + 1);
   void decrement() => emit(stateValue - 1);
 }
@@ -106,8 +108,8 @@ sealed class CounterEvent;
 final class Increment extends CounterEvent;
 final class Decrement extends CounterEvent;
 
-class CounterBloc() extends BlocSignal<CounterEvent, int>(initialState: 0) {
-  this {
+class CounterBloc() extends BlocSignal<CounterEvent, int> {
+  this : super(initialState: 0) {
     on<Increment>((event, emit) => emit(stateValue + 1));
     on<Decrement>((event, emit) => emit(stateValue - 1));
   }

--- a/website/lib/src/components/docs/pages/docs_state_modeling.dart
+++ b/website/lib/src/components/docs/pages/docs_state_modeling.dart
@@ -140,10 +140,9 @@ Widget buildProfile(BuildContext context, ProfileState state) {
           dart313Code: '''
 typedef PaginationState = ({int page, int pageSize, bool hasMore});
 
-class PaginationCubit()
-    extends CubitSignal<PaginationState>(
-      initialState: (page: 1, pageSize: 20, hasMore: true),
-    ) {
+class PaginationCubit() extends CubitSignal<PaginationState> {
+  this : super(initialState: (page: 1, pageSize: 20, hasMore: true));
+
   void nextPage() {
     emit((
       page: stateValue.page + 1,
@@ -184,8 +183,9 @@ class PaginationCubit extends CubitSignal<PaginationState> {
           dart313Code: '''
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 
-class TodoCubit()
-    extends CubitSignal<IList<String>>(initialState: const <String>[].lock) {
+class TodoCubit() extends CubitSignal<IList<String>> {
+  this : super(initialState: const <String>[].lock);
+
   void addTodo(String item) => emit(stateValue.add(item));
   void removeTodo(int index) => emit(stateValue.removeAt(index));
 }''',
@@ -229,11 +229,12 @@ class TodoCubit extends CubitSignal<IList<String>> {
         const DocsCodeBlock(
           filename: 'custom_comparator_cubit.dart',
           dart313Code: '''
-class CaseInsensitiveCubit()
-    extends CubitSignal<String>(
-      initialState: '',
-      equals: (a, b) => a.toLowerCase() == b.toLowerCase(),
-    ) {
+class CaseInsensitiveCubit() extends CubitSignal<String> {
+  this : super(
+    initialState: '',
+    equals: (a, b) => a.toLowerCase() == b.toLowerCase(),
+  );
+
   void updateText(String text) => emit(text);
 }
 

--- a/website/test/docs_code_snippets_syntax_test.dart
+++ b/website/test/docs_code_snippets_syntax_test.dart
@@ -1,0 +1,116 @@
+import 'package:blocsignal_website/src/components/docs/docs_code_block.dart';
+import 'package:blocsignal_website/src/models/docs_registry.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:test/test.dart';
+
+void _collectCodeBlocks(Component component, List<DocsCodeBlock> blocks) {
+  if (component is DocsCodeBlock) {
+    blocks.add(component);
+    return;
+  }
+  if (component is StatelessComponent) {
+    final element = component.createElement();
+    // ignore: invalid_use_of_protected_member
+    final built = component.build(element);
+    _collectCodeBlocks(built, blocks);
+  } else if (component is DomComponent) {
+    final children = component.children;
+    if (children != null) {
+      for (final child in children) {
+        _collectCodeBlocks(child, blocks);
+      }
+    }
+  }
+}
+
+void main() {
+  group('Docs Code Snippets Syntax Verification', () {
+    test('no documentation page contains invalid extends SuperClass(...) syntax in snippets', () {
+      final blocks = <DocsCodeBlock>[];
+      for (final category in DocsRegistry.categories) {
+        for (final section in category.sections) {
+          final pageComponent = section.builder();
+          _collectCodeBlocks(pageComponent, blocks);
+        }
+      }
+
+      expect(
+        blocks,
+        isNotEmpty,
+        reason: 'Expected to find DocsCodeBlock instances across docs',
+      );
+
+      final invalidExtendsRegex = RegExp(
+        r'extends\s+[A-Za-z0-9_]+(?:\s*<[^>]+>)?\s*\(',
+      );
+
+      final violations = <String>[];
+
+      for (final block in blocks) {
+        final title = block.displayTitle ?? 'Untitled';
+        for (final (label, snippet) in [
+          ('dart313Code', block.dart313Code),
+          ('dart35Code', block.dart35Code),
+          ('code', block.code),
+        ]) {
+          if (snippet == null) continue;
+          final lines = snippet.split('\n');
+          for (var i = 0; i < lines.length; i++) {
+            final line = lines[i];
+            if (invalidExtendsRegex.hasMatch(line)) {
+              violations.add('$title [$label line ${i + 1}]: $line');
+            }
+          }
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Found invalid extends SuperClass(...) constructor invocation in docs snippets:\n'
+            '${violations.join('\n')}',
+      );
+    });
+
+    test('no documentation page contains invalid this() : super(...) syntax in snippets', () {
+      final blocks = <DocsCodeBlock>[];
+      for (final category in DocsRegistry.categories) {
+        for (final section in category.sections) {
+          final pageComponent = section.builder();
+          _collectCodeBlocks(pageComponent, blocks);
+        }
+      }
+
+      final invalidThisCtorRegex = RegExp(r'this\(\)\s*:');
+
+      final violations = <String>[];
+
+      for (final block in blocks) {
+        final title = block.displayTitle ?? 'Untitled';
+        for (final (label, snippet) in [
+          ('dart313Code', block.dart313Code),
+          ('dart35Code', block.dart35Code),
+          ('code', block.code),
+        ]) {
+          if (snippet == null) continue;
+          final lines = snippet.split('\n');
+          for (var i = 0; i < lines.length; i++) {
+            final line = lines[i];
+            if (invalidThisCtorRegex.hasMatch(line)) {
+              violations.add('$title [$label line ${i + 1}]: $line');
+            }
+          }
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Found invalid this() : super(...) syntax in docs snippets:\n'
+            '${violations.join('\n')}',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #191.

Corrects invalid Dart 3.13 primary constructor code samples across documentation pages, skill guides, and technical articles where superclass constructors were erroneously invoked in the `extends` clause (for example `class CounterCubit() extends CubitSignal<int>(initialState: 0)`) rather than using valid Dart 3.13 syntax (`this : super(initialState: 0)` in-body constructor initialization or `super.initialState`).

## Changes
- **Website Documentation (`website/lib/src/components/docs/pages/`)**: Updated `docs_overview.dart`, `docs_quickstart.dart`, `docs_events_and_handlers.dart`, `docs_cubit_vs_bloc.dart`, `docs_state_modeling.dart`, `docs_pkg_hydrate.dart`, `docs_pkg_replay.dart`, and `docs_decision_matrix.dart` to use valid Dart 3.13 syntax.
- **Skill Guide (`plugins/bloc-signals/skills/bloc-signals/decision_matrix.md`)**: Updated modern Dart 3.13 code snippet.
- **Article Archives (`doc/articles/`)**: Updated `dart-313-primary-constructors-...md` and `why-blocsignal-doesnt-need-provider-...md`.
- **Automated Regression Test (`website/test/docs_code_snippets_syntax_test.dart`)**: Added an automated scanner test asserting that no documentation code blocks contain `extends Type(...)` or `this() : super(...)`.

---

## 🔍 Pre-Commit Self-Critical Review (The 6 Pillars)

### 🏛️ Pillar 1: Intent
- **Problem**: Documentation and tutorial code samples for Dart 3.13 erroneously invoked superclass generative constructors inside the `extends` clause (for example `class CounterCubit() extends CubitSignal<int>(initialState: 0)`) or used invalid constructor body syntax (`this() : super(...)`).
- **Resolution**: Every instance across `website/lib/src/components/docs/pages/`, `plugins/bloc-signals/skills/bloc-signals/decision_matrix.md`, and technical article markdown archives (`doc/articles/`) was surgically updated to valid Dart 3.13 primary constructor syntax (`class CounterCubit() extends CubitSignal<int> { this : super(initialState: 0); ... }`).
- **Scope Limit**: Edits are restricted strictly to documentation code blocks and an automated verification test. No runtime package APIs or published contracts were touched. No piggybacking changes were included.

### 🧪 Pillar 2: Verification
- **Test Replication**: Created an automated Jaspr component tree scanner in `website/test/docs_code_snippets_syntax_test.dart`.
- **Failure Replicated**: Before the fixes, the automated test detected all 11 invalid syntax occurrences across all doc pages and failed assertions.
- **Passing Suite**:
  - `website/test/docs_code_snippets_syntax_test.dart` passes cleanly.
  - All 21 tests in `website` pass.
  - Workspace static analysis (`dart analyze --fatal-infos`) reports 0 issues.
  - `dart run tool/run_workspace_tests.dart` passes with 100% test coverage across the monorepo.
  - `dart run tool/validate_agent_plugin.dart` successfully validates plugin and skill bundles.
  - Static site build (`dart run website/tool/build_static.dart`) succeeds and compiles all 29 routes.

### 📐 Pillar 3: Architecture
- **Language Alignment**: Strictly adheres to the Dart 3.13 language specification for primary constructors, in-body initializer lists (`this : super(...)`), and parameter shorthands.
- **Dual Presentation Standard**: Preserves the dual-syntax presentation standard (`dart35Code` baseline vs. `dart313Code` modern) across all website documentation pages.
- **Phrasing Standards**: Maintained phrasing standards without Latin abbreviations ("for example" and "that is").

### 💥 Pillar 4: Blast Radius
- **Risk Level**: Minimal / Zero runtime blast radius.
- **Package Safety**: Published core packages (`bloc_signals*`) are completely untouched and maintain their `sdk: ^3.5.0` baseline.
- **Website Safety**: All 29 static routes build cleanly without JS compilation errors or runtime exceptions.

### 🛡️ Pillar 5: Reviewer Defense
- **Question**: *Why use `this : super(initialState: 0)` in class bodies instead of `class CounterCubit({super.initialState = 0})` everywhere?*
- **Defense**: In Bloc and Cubit architectures, feature classes like `CounterCubit` or `SearchBloc` encapsulate their initial state rather than requiring callers to supply `initialState:`. Using `this : super(initialState: ...)` in the class body allows the primary constructor to take only necessary feature parameters (such as repositories or services) while cleanly passing fixed default initial states to the framework base class.
- **Question**: *Are the published DEV.to articles updated automatically?*
- **Defense**: The local archive (`doc/articles/`) is updated in this commit. Once the online DEV.to posts are updated on dev.to, `tool/sync_all_articles.dart` will re-verify complete byte-for-byte fidelity with the live blog posts.

### 🩹 Pillar 6: Scar Tissue & Crash Defenses
- **Dart 3.13 Extends Trap**: Dart's `extends` clause accepts only a type name. In-body super initialization must be written as `this : super(...)` or `this : super(...) { ... }`, never `extends Type(...)` or `this() : super(...)`.
- **Permanent Regression Shield**: Added `website/test/docs_code_snippets_syntax_test.dart` to the permanent CI test suite, ensuring any future documentation additions with invalid syntax will break the build before landing.
