### PR TITLE
docs(website): fix form validation recipe and UI rebuild patterns (#194)

### DIFF
--- a/website/lib/src/components/docs/pages/docs_pkg_replay.dart
+++ b/website/lib/src/components/docs/pages/docs_pkg_replay.dart
@@ -100,27 +100,57 @@ class DrawingCubit() extends ReplayCubit<CanvasState> {
         ]),
         const DocsCodeBlock(
           title: 'lib/canvas_toolbar.dart',
-          language: 'dart',
-          code: '''
+          dart313Code: '''
 import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
 import 'package:flutter/material.dart';
+import 'drawing_cubit.dart';
 
 class CanvasToolbar extends StatelessWidget {
   const CanvasToolbar({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final cubit = context.watch<DrawingCubit>();
+    final cubit = context.read<DrawingCubit>();
+    final canUndo = context.select<DrawingCubit, bool>((c) => c.canUndo);
+    final canRedo = context.select<DrawingCubit, bool>((c) => c.canRedo);
 
     return Row(
       children: [
         IconButton(
           icon: const Icon(Icons.undo),
-          onPressed: cubit.canUndo ? cubit.undo : null,
+          onPressed: canUndo ? cubit.undo : null,
         ),
         IconButton(
           icon: const Icon(Icons.redo),
-          onPressed: cubit.canRedo ? cubit.redo : null,
+          onPressed: canRedo ? cubit.redo : null,
+        ),
+      ],
+    );
+  }
+}''',
+          dart35Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'drawing_cubit.dart';
+
+class CanvasToolbar extends StatelessWidget {
+  const CanvasToolbar({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<DrawingCubit>();
+    final canUndo = context.select<DrawingCubit, bool>((c) => c.canUndo);
+    final canRedo = context.select<DrawingCubit, bool>((c) => c.canRedo);
+
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.undo),
+          onPressed: canUndo ? cubit.undo : null,
+        ),
+        IconButton(
+          icon: const Icon(Icons.redo),
+          onPressed: canRedo ? cubit.redo : null,
         ),
       ],
     );

--- a/website/lib/src/components/docs/pages/docs_recipe_caching.dart
+++ b/website/lib/src/components/docs/pages/docs_recipe_caching.dart
@@ -164,31 +164,65 @@ extension NewsFeedDerived on NewsFeedCubit {
         ]),
         const DocsCodeBlock(
           title: 'lib/news_feed_view.dart',
-          language: 'dart',
-          code: '''
+          dart313Code: '''
 import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
 import 'package:flutter/material.dart';
+import 'news_feed_cubit.dart';
 
 class NewsFeedView extends StatelessWidget {
   const NewsFeedView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final cubit = context.watch<NewsFeedCubit>();
-    final cache = cubit.stateValue;
+    final cubit = context.read<NewsFeedCubit>();
 
-    if (cache == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
+    return BlocSignalBuilder<NewsFeedCubit, CachedData<List<String>>?>(
+      builder: (context, cache) {
+        if (cache == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
-    return RefreshIndicator(
-      onRefresh: () => cubit.loadFeed(forceRefresh: true),
-      child: ListView.builder(
-        itemCount: cache.data.length,
-        itemBuilder: (context, index) => ListTile(
-          title: Text(cache.data[index]),
-        ),
-      ),
+        return RefreshIndicator(
+          onRefresh: () => cubit.loadFeed(forceRefresh: true),
+          child: ListView.builder(
+            itemCount: cache.data.length,
+            itemBuilder: (context, index) => ListTile(
+              title: Text(cache.data[index]),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}''',
+          dart35Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'news_feed_cubit.dart';
+
+class NewsFeedView extends StatelessWidget {
+  const NewsFeedView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<NewsFeedCubit>();
+
+    return BlocSignalBuilder<NewsFeedCubit, CachedData<List<String>>?>(
+      builder: (context, cache) {
+        if (cache == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        return RefreshIndicator(
+          onRefresh: () => cubit.loadFeed(forceRefresh: true),
+          child: ListView.builder(
+            itemCount: cache.data.length,
+            itemBuilder: (context, index) => ListTile(
+              title: Text(cache.data[index]),
+            ),
+          ),
+        );
+      },
     );
   }
 }''',

--- a/website/lib/src/components/docs/pages/docs_recipe_form_validation.dart
+++ b/website/lib/src/components/docs/pages/docs_recipe_form_validation.dart
@@ -1,6 +1,8 @@
+import 'package:blocsignal_website/src/models/pub_api_registry.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
+import '../docs_callout.dart';
 import '../docs_code_block.dart';
 import '../docs_toc.dart';
 
@@ -15,6 +17,11 @@ class const DocsRecipeFormValidationPage({super.key})
       anchor: 'computed-validation',
     ),
     TocHeading(title: 'Flutter UI Integration', anchor: 'ui-integration'),
+    TocHeading(title: 'Scoped Provider Setup', anchor: 'provider-setup'),
+    TocHeading(
+      title: 'Fine-Grained Rebuilds with context.select',
+      anchor: 'fine-grained-select',
+    ),
     TocHeading(
       title: 'Performance & Debouncing',
       anchor: 'performance-debouncing',
@@ -54,8 +61,7 @@ class const DocsRecipeFormValidationPage({super.key})
         h2([Component.text('Designing the Form Cubit')]),
         const DocsCodeBlock(
           title: 'lib/login_form_cubit.dart',
-          language: 'dart',
-          code: '''
+          dart313Code: '''
 import 'package:bloc_signals/bloc_signals.dart';
 
 class LoginFormState {
@@ -84,7 +90,7 @@ class LoginFormCubit extends CubitSignal<LoginFormState> {
   LoginFormCubit() : super(initialState: const LoginFormState()) {
     // Derived email validation error
     emailError = computed(() {
-      final email = state.value.email;
+      final email = stateValue.email;
       if (email.isEmpty) return null;
       if (!email.contains('@') || !email.contains('.')) {
         return 'Please enter a valid email address';
@@ -94,7 +100,7 @@ class LoginFormCubit extends CubitSignal<LoginFormState> {
 
     // Derived password validation error
     passwordError = computed(() {
-      final password = state.value.password;
+      final password = stateValue.password;
       if (password.isEmpty) return null;
       if (password.length < 8) {
         return 'Password must be at least 8 characters';
@@ -104,7 +110,70 @@ class LoginFormCubit extends CubitSignal<LoginFormState> {
 
     // Combined form validity signal
     isValid = computed(() {
-      final s = state.value;
+      final s = stateValue;
+      return s.email.isNotEmpty &&
+          s.password.isNotEmpty &&
+          emailError.value == null &&
+          passwordError.value == null;
+    });
+  }
+
+  late final ReadonlySignal<String?> emailError;
+  late final ReadonlySignal<String?> passwordError;
+  late final ReadonlySignal<bool> isValid;
+
+  void emailChanged(String email) => emit(stateValue.copyWith(email: email));
+  void passwordChanged(String password) => emit(stateValue.copyWith(password: password));
+}''',
+          dart35Code: '''
+import 'package:bloc_signals/bloc_signals.dart';
+
+class LoginFormState {
+  const LoginFormState({
+    this.email = '',
+    this.password = '',
+    this.isSubmitting = false,
+  });
+
+  final String email;
+  final String password;
+  final bool isSubmitting;
+
+  LoginFormState copyWith({
+    String? email,
+    String? password,
+    bool? isSubmitting,
+  }) {
+    return LoginFormState(
+      email: email ?? this.email,
+      password: password ?? this.password,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+    );
+  }
+}
+
+class LoginFormCubit extends CubitSignal<LoginFormState> {
+  LoginFormCubit() : super(initialState: const LoginFormState()) {
+    emailError = computed(() {
+      final email = stateValue.email;
+      if (email.isEmpty) return null;
+      if (!email.contains('@') || !email.contains('.')) {
+        return 'Please enter a valid email address';
+      }
+      return null;
+    });
+
+    passwordError = computed(() {
+      final password = stateValue.password;
+      if (password.isEmpty) return null;
+      if (password.length < 8) {
+        return 'Password must be at least 8 characters';
+      }
+      return null;
+    });
+
+    isValid = computed(() {
+      final s = stateValue;
       return s.email.isNotEmpty &&
           s.password.isNotEmpty &&
           emailError.value == null &&
@@ -128,7 +197,7 @@ class LoginFormCubit extends CubitSignal<LoginFormState> {
         p([
           Component.text(
             'Notice that emailError, passwordError, and isValid are not stored fields in LoginFormState. '
-            'They are derived signals created via computed(). They track state.value automatically and only notify '
+            'They are derived signals created via computed(). They track stateValue automatically and only notify '
             'listeners when their evaluated validation result changes.',
           ),
         ]),
@@ -137,19 +206,240 @@ class LoginFormCubit extends CubitSignal<LoginFormState> {
       // 4. Flutter UI Integration
       section(id: 'ui-integration', classes: 'docs-section', [
         h2([Component.text('Flutter UI Integration')]),
+        p([
+          Component.text('In the UI layer, retrieve the cubit via '),
+          apiLink(
+            DocSymbol.contextRead,
+            label: 'context.read<LoginFormCubit>()',
+          ),
+          Component.text(
+            ' for calling methods in event handlers. To ensure the widget rebuilds reactively when input state updates, '
+            'wrap the form in ',
+          ),
+          apiLink(DocSymbol.blocSignalBuilder),
+          Component.text(':'),
+        ]),
+        DocsCallout(
+          type: CalloutType.warning,
+          title: 'context.watch vs. State-Driven Rebuilds',
+          children: [
+            p([
+              Component.text('Do not use '),
+              apiLink(
+                DocSymbol.contextWatch,
+                label: 'context.watch<LoginFormCubit>()',
+              ),
+              Component.text(
+                ' expecting widget rebuilds on state emissions. In BlocSignal, context.watch listens strictly to '
+                'provider instance replacement (for dynamic dependency injection swapping), avoiding coarse whole-tree '
+                'rebuild cascades. Use ',
+              ),
+              apiLink(DocSymbol.blocSignalBuilder),
+              Component.text(' or '),
+              apiLink(DocSymbol.contextSelect, label: 'context.select'),
+              Component.text(
+                ' to subscribe to state and computed signal changes.',
+              ),
+            ]),
+          ],
+        ),
         const DocsCodeBlock(
           title: 'lib/login_form_view.dart',
-          language: 'dart',
-          code: '''
+          dart313Code: '''
 import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
 import 'package:flutter/material.dart';
+import 'login_form_cubit.dart';
 
 class LoginFormView extends StatelessWidget {
   const LoginFormView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final cubit = context.watch<LoginFormCubit>();
+    final cubit = context.read<LoginFormCubit>();
+
+    return BlocSignalBuilder<LoginFormCubit, LoginFormState>(
+      builder: (context, state) {
+        return Column(
+          children: [
+            TextField(
+              onChanged: cubit.emailChanged,
+              decoration: InputDecoration(
+                labelText: 'Email',
+                errorText: cubit.emailError.value,
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              obscureText: true,
+              onChanged: cubit.passwordChanged,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                errorText: cubit.passwordError.value,
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: cubit.isValid.value ? () => _submit(context) : null,
+              child: const Text('Log In'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _submit(BuildContext context) {
+    // Handle form submission logic
+  }
+}''',
+          dart35Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'login_form_cubit.dart';
+
+class LoginFormView extends StatelessWidget {
+  const LoginFormView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<LoginFormCubit>();
+
+    return BlocSignalBuilder<LoginFormCubit, LoginFormState>(
+      builder: (context, state) {
+        return Column(
+          children: [
+            TextField(
+              onChanged: cubit.emailChanged,
+              decoration: InputDecoration(
+                labelText: 'Email',
+                errorText: cubit.emailError.value,
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              obscureText: true,
+              onChanged: cubit.passwordChanged,
+              decoration: InputDecoration(
+                labelText: 'Password',
+                errorText: cubit.passwordError.value,
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: cubit.isValid.value ? () => _submit(context) : null,
+              child: const Text('Log In'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _submit(BuildContext context) {
+    // Handle form submission logic
+  }
+}''',
+        ),
+      ]),
+
+      // 5. Scoped Provider Setup
+      section(id: 'provider-setup', classes: 'docs-section', [
+        h2([Component.text('Scoped Provider Setup')]),
+        p([
+          Component.text('Provide the '),
+          code([Component.text('LoginFormCubit')]),
+          Component.text(' to the widget subtree using '),
+          apiLink(DocSymbol.blocSignalProvider),
+          Component.text(' (or '),
+          apiLink(DocSymbol.multiBlocSignalProvider),
+          Component.text(' when combining multiple providers):'),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/login_form_page.dart',
+          dart313Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'login_form_cubit.dart';
+import 'login_form_view.dart';
+
+class LoginFormPage extends StatelessWidget {
+  const LoginFormPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: BlocSignalProvider<LoginFormCubit>(
+        create: (context) => LoginFormCubit(),
+        child: const Padding(
+          padding: EdgeInsets.all(24.0),
+          child: LoginFormView(),
+        ),
+      ),
+    );
+  }
+}''',
+          dart35Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'login_form_cubit.dart';
+import 'login_form_view.dart';
+
+class LoginFormPage extends StatelessWidget {
+  const LoginFormPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: BlocSignalProvider<LoginFormCubit>(
+        create: (context) => LoginFormCubit(),
+        child: const Padding(
+          padding: EdgeInsets.all(24.0),
+          child: LoginFormView(),
+        ),
+      ),
+    );
+  }
+}''',
+        ),
+      ]),
+
+      // 6. Fine-Grained Rebuilds with context.select
+      section(id: 'fine-grained-select', classes: 'docs-section', [
+        h2([Component.text('Fine-Grained Rebuilds with context.select')]),
+        p([
+          Component.text(
+            'For optimal performance in complex forms, you can also use ',
+          ),
+          apiLink(DocSymbol.contextSelect, label: 'context.select<B, R>()'),
+          Component.text(
+            ' to subscribe individual widgets exclusively to their specific computed validation signal. '
+            'With this approach, typing in the password field will not rebuild the email text field at all:',
+          ),
+        ]),
+        const DocsCodeBlock(
+          title: 'lib/fine_grained_login_view.dart',
+          dart313Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'login_form_cubit.dart';
+
+class FineGrainedLoginFormView extends StatelessWidget {
+  const FineGrainedLoginFormView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<LoginFormCubit>();
+    final emailError = context.select<LoginFormCubit, String?>(
+      (c) => c.emailError.value,
+    );
+    final passwordError = context.select<LoginFormCubit, String?>(
+      (c) => c.passwordError.value,
+    );
+    final isValid = context.select<LoginFormCubit, bool>(
+      (c) => c.isValid.value,
+    );
 
     return Column(
       children: [
@@ -157,7 +447,7 @@ class LoginFormView extends StatelessWidget {
           onChanged: cubit.emailChanged,
           decoration: InputDecoration(
             labelText: 'Email',
-            errorText: cubit.emailError.value,
+            errorText: emailError,
           ),
         ),
         const SizedBox(height: 16),
@@ -166,12 +456,64 @@ class LoginFormView extends StatelessWidget {
           onChanged: cubit.passwordChanged,
           decoration: InputDecoration(
             labelText: 'Password',
-            errorText: cubit.passwordError.value,
+            errorText: passwordError,
           ),
         ),
         const SizedBox(height: 24),
         ElevatedButton(
-          onPressed: cubit.isValid.value ? () => _submit(context) : null,
+          onPressed: isValid ? () => _submit(context) : null,
+          child: const Text('Log In'),
+        ),
+      ],
+    );
+  }
+
+  void _submit(BuildContext context) {
+    // Handle submission logic
+  }
+}''',
+          dart35Code: '''
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:flutter/material.dart';
+import 'login_form_cubit.dart';
+
+class FineGrainedLoginFormView extends StatelessWidget {
+  const FineGrainedLoginFormView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<LoginFormCubit>();
+    final emailError = context.select<LoginFormCubit, String?>(
+      (c) => c.emailError.value,
+    );
+    final passwordError = context.select<LoginFormCubit, String?>(
+      (c) => c.passwordError.value,
+    );
+    final isValid = context.select<LoginFormCubit, bool>(
+      (c) => c.isValid.value,
+    );
+
+    return Column(
+      children: [
+        TextField(
+          onChanged: cubit.emailChanged,
+          decoration: InputDecoration(
+            labelText: 'Email',
+            errorText: emailError,
+          ),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          obscureText: true,
+          onChanged: cubit.passwordChanged,
+          decoration: InputDecoration(
+            labelText: 'Password',
+            errorText: passwordError,
+          ),
+        ),
+        const SizedBox(height: 24),
+        ElevatedButton(
+          onPressed: isValid ? () => _submit(context) : null,
           child: const Text('Log In'),
         ),
       ],
@@ -185,7 +527,7 @@ class LoginFormView extends StatelessWidget {
         ),
       ]),
 
-      // 5. Performance & Debouncing
+      // 7. Performance & Debouncing
       section(id: 'performance-debouncing', classes: 'docs-section', [
         h2([Component.text('Performance & Debouncing')]),
         p([

--- a/website/test/docs_code_snippets_syntax_test.dart
+++ b/website/test/docs_code_snippets_syntax_test.dart
@@ -112,5 +112,61 @@ void main() {
             '${violations.join('\n')}',
       );
     });
+
+    test('no recipe or package documentation page incorrectly uses context.watch to read state/signals in UI views', () {
+      final blocks = <DocsCodeBlock>[];
+      for (final category in DocsRegistry.categories) {
+        for (final section in category.sections) {
+          final pageComponent = section.builder();
+          _collectCodeBlocks(pageComponent, blocks);
+        }
+      }
+
+      final invalidWatchUsageRegex = RegExp(
+        r'context\.watch<[A-Za-z0-9_]+>\(\)(?:\.stateValue|\.state|\.canUndo|\.canRedo|\.emailError|\.passwordError|\.isValid)?',
+      );
+
+      final violations = <String>[];
+
+      for (final block in blocks) {
+        final title = block.displayTitle ?? 'Untitled';
+        // Skip docs_flutter_context and docs_migration_bloc which explicitly document context.watch mechanics and comparison
+        if (title.contains('context_watch') ||
+            title.contains('context.watch') ||
+            title.contains('room_view') ||
+            title.contains('Migration')) {
+          continue;
+        }
+
+        for (final (label, snippet) in [
+          ('dart313Code', block.dart313Code),
+          ('dart35Code', block.dart35Code),
+          ('code', block.code),
+        ]) {
+          if (snippet == null) continue;
+          final lines = snippet.split('\n');
+          for (var i = 0; i < lines.length; i++) {
+            final line = lines[i];
+            if (invalidWatchUsageRegex.hasMatch(line) &&
+                (title.contains('Recipe') ||
+                    title.contains('form') ||
+                    title.contains('caching') ||
+                    title.contains('toolbar') ||
+                    title.contains('view') ||
+                    title.contains('Replay'))) {
+              violations.add('$title [$label line ${i + 1}]: $line');
+            }
+          }
+        }
+      }
+
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Found incorrect context.watch usage in documentation recipe/feature snippets:\n'
+            '${violations.join('\n')}',
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #194

### Summary of Changes
- Clarify why `context.watch<T>()` in `BlocSignal` is designed strictly for provider instance swapping rather than state-driven widget rebuilds.
- Update `LoginFormView` in the *"Form Validation with Reactive Signals"* recipe to use `context.read<LoginFormCubit>()` and `BlocSignalBuilder<LoginFormCubit, LoginFormState>`.
- Add a new section demonstrating fine-grained, per-field reactivity using `context.select<LoginFormCubit, R>`.
- Add the complete `BlocSignalProvider<LoginFormCubit>` setup in `LoginFormPage`.
- Add full dual Dart 3.13 / Dart 3.5 code examples across updated recipes.
- Fix `context.watch` usages in `CanvasToolbar` (`docs_pkg_replay.dart`) and `NewsFeedView` (`docs_recipe_caching.dart`).
- Add an automated syntax test in `website/test/docs_code_snippets_syntax_test.dart` to continuously prevent `context.watch` from being used for state reads in docs UI snippets.

---

### 🛡️ Pre-Commit Self-Critical Review (The 6 Pillars)

#### 1. Intent
- **Completeness**: Fully resolves #194 by addressing developer confusion about why `context.watch` did not trigger rebuilds on form input changes, showing the full provider setup, and adding both standard `BlocSignalBuilder` and fine-grained `context.select` recipes.
- **Scope Limit**: Confined to documentation pages and testing tools without touching member package runtime code.

#### 2. Verification
- **TDD Protocol**: Created automated AST/regex test in `website/test/docs_code_snippets_syntax_test.dart` that flagged all 3 incorrect `context.watch` instances on the unmodified codebase.
- **Green Verification**: All 22 tests in `website/` pass; monorepo test suite (`tool/run_workspace_tests.dart`) passed 100% green across all 10 packages; `dart analyze --fatal-infos` reported zero issues.

#### 3. Architecture
- Adheres to `BlocSignal` core reactivity principles: `context.read` for event dispatching, `BlocSignalBuilder` for state updates, and `context.select` for fine-grained computed reads.
- Adheres to dual Dart 3.13 (modern syntax) and Dart 3.5 (baseline syntax) presentation standards.

#### 4. Blast Radius
- Zero runtime impact on published packages. Purely enhances documentation accuracy and developer ergonomics on `blocsignal.dev`.

#### 5. Reviewer Defense
- **Why not make `context.watch` rebuild on state changes?** Because signals-based architecture deliberately separates O(1) container lookups from granular state reactions to prevent whole-tree inherited widget rebuild cascades.

#### 6. Immune Defenses & Crash Antibodies
- Added automated CI check in `docs_code_snippets_syntax_test.dart` ensuring no future docs sample uses `context.watch` for state consumption in UI components.
