### PR TITLE
fix(flutter, jaspr): rebind select subscription on provider swap (#204)

### DIFF
--- a/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
+++ b/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
@@ -179,8 +179,8 @@ extension BlocSignalProviderExtension on BuildContext {
   /// Unlike Riverpod's 3-parameter `context.select` or `package:flutter_bloc`,
   /// `BlocSignal`'s `context.select` takes **2** generic type parameters:
   /// 1. `T`: The [BlocSignalBase] container type
-  ///    (e.g., `CounterBloc` or `UserCubit`).
-  /// 2. `R`: The selected return value type (e.g., `int` or `String`).
+  ///    (for example `CounterBloc` or `UserCubit`).
+  /// 2. `R`: The selected return value type (for example `int` or `String`).
   ///
   /// The selector callback receives the **`bloc` instance** directly:
   /// `(bloc) => bloc.stateValue.property`.
@@ -195,7 +195,7 @@ extension BlocSignalProviderExtension on BuildContext {
     R Function(T bloc) selector,
   ) {
     final element = this as Element;
-    final bloc = BlocSignalProvider.of<T>(this);
+    final bloc = BlocSignalProvider.of<T>(this, listen: true);
 
     final selectorState = _elementSelectors[element] ??= _SelectorState();
     final currentIndex = selectorState.index;

--- a/bloc_signals_flutter/test/bloc_signals_flutter_test.dart
+++ b/bloc_signals_flutter/test/bloc_signals_flutter_test.dart
@@ -775,5 +775,48 @@ void main() {
         await bloc.close();
       },
     );
+
+    testWidgets(
+      'context.select transfers subscription when provider bloc instance '
+      'is swapped above const subtree',
+      (tester) async {
+        final bloc1 = CounterBloc();
+        final bloc2 = CounterBloc();
+
+        Widget buildTree(CounterBloc bloc) {
+          return MaterialApp(
+            home: BlocSignalProvider<CounterBloc>.value(
+              value: bloc,
+              child: const _ConstSelectorChild(),
+            ),
+          );
+        }
+
+        await tester.pumpWidget(buildTree(bloc1));
+        expect(find.text('Count: 0'), findsOneWidget);
+
+        // Swap provider value to bloc2
+        await tester.pumpWidget(buildTree(bloc2));
+        expect(find.text('Count: 0'), findsOneWidget);
+
+        // State changes on new bloc should trigger rebuild
+        bloc2.add(Increment());
+        await tester.pump();
+        expect(find.text('Count: 1'), findsOneWidget);
+
+        await bloc1.close();
+        await bloc2.close();
+      },
+    );
   });
+}
+
+class _ConstSelectorChild extends StatelessWidget {
+  const _ConstSelectorChild();
+
+  @override
+  Widget build(BuildContext context) {
+    final count = context.select<CounterBloc, int>((b) => b.stateValue);
+    return Text('Count: $count');
+  }
 }

--- a/bloc_signals_jaspr/lib/src/bloc_signal_provider.dart
+++ b/bloc_signals_jaspr/lib/src/bloc_signal_provider.dart
@@ -192,7 +192,7 @@ extension BlocSignalProviderExtension on BuildContext {
     R Function(T bloc) selector,
   ) {
     final element = this as Element;
-    final bloc = BlocSignalProvider.of<T>(this);
+    final bloc = BlocSignalProvider.of<T>(this, listen: true);
 
     final selectorState = _elementSelectors[element] ??= _SelectorState();
     final currentIndex = selectorState.index;

--- a/bloc_signals_jaspr/test/bloc_signals_jaspr_test.dart
+++ b/bloc_signals_jaspr/test/bloc_signals_jaspr_test.dart
@@ -279,5 +279,84 @@ void main() {
 
       expect(events, containsAll(['counter:1', 'theme:dark']));
     });
+
+    testComponents(
+      'context.select transfers subscription when provider bloc instance '
+      'is swapped above const subtree',
+      (tester) async {
+        final cubit1 = CounterCubit();
+        final cubit2 = CounterCubit();
+        late _JasprSwapProviderState swapState;
+
+        tester.pumpComponent(
+          _JasprSwapProvider(
+            initialCubit: cubit1,
+            onCreated: (state) => swapState = state,
+          ),
+        );
+        expect(find.text('Count: 0'), findsOneComponent);
+
+        // Swap provider to cubit2 via stateful component
+        swapState.setCubit(cubit2);
+        await tester.pump();
+        expect(find.text('Count: 0'), findsOneComponent);
+
+        // State changes on cubit2 should trigger rebuild
+        cubit2.increment();
+        await tester.pump();
+        expect(find.text('Count: 1'), findsOneComponent);
+
+        await cubit1.close();
+        await cubit2.close();
+      },
+    );
   });
+}
+
+class _JasprSwapProvider extends StatefulComponent {
+  const _JasprSwapProvider({
+    required this.initialCubit,
+    required this.onCreated,
+  });
+
+  final CounterCubit initialCubit;
+  final void Function(_JasprSwapProviderState state) onCreated;
+
+  @override
+  State<_JasprSwapProvider> createState() => _JasprSwapProviderState();
+}
+
+class _JasprSwapProviderState extends State<_JasprSwapProvider> {
+  late CounterCubit _cubit;
+
+  @override
+  void initState() {
+    super.initState();
+    _cubit = component.initialCubit;
+    component.onCreated(this);
+  }
+
+  void setCubit(CounterCubit newCubit) {
+    setState(() {
+      _cubit = newCubit;
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return BlocSignalProvider<CounterCubit>.value(
+      value: _cubit,
+      child: const _ConstSelectComponent(),
+    );
+  }
+}
+
+class _ConstSelectComponent extends StatelessComponent {
+  const _ConstSelectComponent();
+
+  @override
+  Component build(BuildContext context) {
+    final count = context.select<CounterCubit, int>((c) => c.stateValue);
+    return div([Component.text('Count: $count')]);
+  }
 }

--- a/plugins/bloc-signals/skills/bloc-signals/flutter.md
+++ b/plugins/bloc-signals/skills/bloc-signals/flutter.md
@@ -73,9 +73,10 @@ final isSubmitEnabled = context.select<FormCubit, bool>(
 > Unlike `flutter_riverpod` (which uses 3 generic parameters in some forms) or classic `flutter_bloc` context selection, `bloc_signals_flutter` passes the **`bloc` container instance** to the selector callback (`(bloc) => bloc.stateValue.canSubmit`), allowing direct property access via `bloc.stateValue`.
 
 It rebuilds the element when the selected value changes by `!=`. Keep each element's select calls
-unconditional and in a stable order because 0.2.0 caches subscriptions by call index. The lookup
-does not register an inherited-provider dependency, so a provider instance swap is not observed
-until another rebuild updates the subscription.
+unconditional and in a stable order because 0.2.0 caches subscriptions by call index. The provider
+lookup registers an inherited dependency (`listen: true`), so if an ancestor provider swaps its
+container instance, `context.select` automatically rebinds to the new container and continues
+observing state updates seamlessly.
 
 ## Listeners, consumers, and selectors
 


### PR DESCRIPTION
## Description

Resolves #204.

When an ancestor `BlocSignalProvider` (or `.value()` provider) replaces its bloc/cubit container instance above a subtree that does not otherwise rebuild (for example a `const` child subtree), `context.select<B, R>()` in `bloc_signals_flutter` and `bloc_signals_jaspr` previously retained a "zombie" signal subscription listening to the discarded old container.

### Root Cause
`context.select` executed `BlocSignalProvider.of<T>(this)` without registering an inherited dependency (which defaulted to `listen: false`). Consequently, when `_BlocSignalProviderInherited` notified about an instance change (`bloc != oldWidget.bloc`), the element using `context.select` was not notified to rebuild and rebind its internal `_SelectSubscription`.

### Solution
- Updated `context.select` in both `bloc_signals_flutter` and `bloc_signals_jaspr` to pass `listen: true` to `BlocSignalProvider.of<T>(this, listen: true)`.
- Because `_BlocSignalProviderInherited.updateShouldNotify` returns `bloc != oldWidget.bloc` (evaluating to `false` during regular state emissions), this introduces **zero runtime overhead** during normal state changes. Rebuild notifications occur if and only if the provider instance itself changes.
- Added reproduction widget and component test cases in both packages verifying subscription transfer over `const` subtrees.
- Updated documentation and skill guides.

---

## Self-Critical Review (The 6 Pillars)

### 1. Intent
- **Completeness**: Fully resolves #204 by guaranteeing that `context.select` rebinds its signal subscription when ancestor provider container instances change.
- **Scope**: Surgical update to `BlocSignalProvider.of<T>(this, listen: true)` in Flutter and Jaspr bindings.

### 2. Verification
- **TDD Tests**:
  - `bloc_signals_flutter/test/bloc_signals_flutter_test.dart`: `context.select transfers subscription when provider bloc instance is swapped above const subtree`
  - `bloc_signals_jaspr/test/bloc_signals_jaspr_test.dart`: `context.select transfers subscription when provider bloc instance is swapped above const subtree`
- **Suite Status**: All package tests pass (100% green); 0 analyzer issues.

### 3. Architecture
- **Framework Native**: Leverages Flutter's `InheritedWidget` and Jaspr's `InheritedComponent` dependency mechanisms.
- **Zero Overhead Invariant**: Normal state mutations propagate via signal effects, not inherited widgets (`updateShouldNotify` returns `false`).

### 4. Blast Radius
- Zero regression risk. Rebuild behavior for regular state updates is unchanged.
- Zero public API breaks.

### 5. Reviewer Defense
- **Q**: Does `listen: true` cause unnecessary rebuilds on state emissions?
- **A**: No. `updateShouldNotify` is strictly `bloc != oldWidget.bloc`. State mutations do not change the bloc reference.

### 6. Immune Defenses & Crash Antibodies
- Subscriptions are indexed per element and updated on rebuild via `_SelectSubscription.update(bloc, selector)`. `_SelectFinalizer` handles unmounting cleanup cleanly.

---

## Checklist
- [x] Failing reproduction tests written first (TDD)
- [x] Surgical fix applied across Flutter and Jaspr packages
- [x] 100% test pass rate across workspace
- [x] Formatted with `dart format .` and analyzed with `dart analyze .`
