### PR TITLE
feat(example): use declarative Kaisel 1.1 guards with reevaluateOn (#222)

### DIFF
--- a/bloc_signals_flutter/example/README.md
+++ b/bloc_signals_flutter/example/README.md
@@ -14,8 +14,10 @@ This example demonstrates best practices for building reactive Flutter applicati
    - State emissions via `emit()` propagate synchronously to widget subtrees in the exact same frame.
    - Built-in state de-duplication using `==` equality prevents unnecessary UI rebuilds.
 
-3. **Type-Safe Routing with Kaisel**:
+3. **Type-Safe Declarative Routing with Kaisel 1.1**:
    - Sealed class route hierarchies (`AppRoute`) paired with `MaterialApp.router`.
+   - Declarative route guards (`KaiselGuard`) protecting authenticated destinations without UI-level redirection side-effects.
+   - Automatic guard re-evaluation driven directly by `reevaluateOn: loginBloc.toValueListenable()`.
 
 4. **Dependency Injection & UI Scoping**:
    - `BlocSignalProvider` for managing BLoC lifecycles and automatic disposal.

--- a/bloc_signals_flutter/example/lib/main.dart
+++ b/bloc_signals_flutter/example/lib/main.dart
@@ -257,12 +257,40 @@ class TimerBloc extends BlocSignal<TimerEvent, TimerState> {
 }
 
 // ==========================================
-// 3. Main App Entry
+// 3. Main App Entry & Declarative Routing
 // ==========================================
-void main() {
-  /// Initialize type-safe Kaisel router matching routes to screen widgets.
-  final config = KaiselRouterConfig<AppRoute>(
-    initial: const LoginRoute(),
+/// Guards application navigation based on [LoginBloc] authentication state.
+///
+/// Unauthenticated users are redirected to [LoginRoute]. Authenticated users
+/// attempting to navigate to [LoginRoute] are redirected to [HomeRoute].
+KaiselGuard<AppRoute> authGuard(LoginBloc loginBloc) => (current, proposed) {
+      final isLoggedIn = loginBloc.stateValue.isLoggedIn;
+
+      // When unauthenticated, only LoginRoute is permitted
+      if (!isLoggedIn) {
+        if (proposed.length == 1 && proposed.first is LoginRoute) {
+          return proposed;
+        }
+        return const [LoginRoute()];
+      }
+
+      // When authenticated, redirect away from LoginRoute to HomeRoute
+      if (proposed.any((r) => r is LoginRoute)) {
+        return [HomeRoute(loginBloc.stateValue.username)];
+      }
+
+      return proposed;
+    };
+
+/// Creates the [KaiselRouterConfig] wired with [authGuard] and [loginBloc]
+/// guard re-evaluation.
+KaiselRouterConfig<AppRoute> createRouterConfig(LoginBloc loginBloc) {
+  return KaiselRouterConfig<AppRoute>(
+    initial: loginBloc.stateValue.isLoggedIn
+        ? HomeRoute(loginBloc.stateValue.username)
+        : const LoginRoute(),
+    guards: [authGuard(loginBloc)],
+    reevaluateOn: loginBloc.toValueListenable(),
     builder: (context, route) => switch (route) {
       LoginRoute() => const LoginScreen(),
       HomeRoute(:final username) => HomeScreen(username: username),
@@ -272,12 +300,16 @@ void main() {
         ),
     },
   );
+}
+
+void main() {
+  final loginBloc = LoginBloc();
+  final config = createRouterConfig(loginBloc);
 
   runApp(
-    /// Inject [LoginBloc] globally using [BlocSignalProvider].
-    /// It automatically manages the BLoC's lifecycle and disposes it on removal.
-    BlocSignalProvider<LoginBloc>(
-      create: (_) => LoginBloc(),
+    /// Inject [LoginBloc] globally using [BlocSignalProvider.value].
+    BlocSignalProvider<LoginBloc>.value(
+      value: loginBloc,
       child: MyApp(routerConfig: config),
     ),
   );
@@ -340,13 +372,6 @@ class LoginScreen extends StatelessWidget {
                   padding: const EdgeInsets.all(32.0),
                   child: BlocSignalBuilder<LoginBloc, LoginState>(
                     builder: (context, state) {
-                      // Navigate to dashboard if logged in
-                      if (state.isLoggedIn) {
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          context.replaceTop(HomeRoute(state.username));
-                        });
-                      }
-
                       return Column(
                         mainAxisSize: MainAxisSize.min,
                         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -466,9 +491,9 @@ class HomeScreen extends StatelessWidget {
           IconButton(
             icon: const Icon(Icons.logout),
             onPressed: () {
-              // Dispatch logout event and navigate back
+              // Dispatch logout event; Kaisel authGuard automatically
+              // re-evaluates via reevaluateOn and redirects to LoginRoute.
               bloc.add(Logout());
-              context.replaceTop(const LoginRoute());
             },
           ),
         ],

--- a/bloc_signals_flutter/example/pubspec.yaml
+++ b/bloc_signals_flutter/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  kaisel: ^1.0.0
+  kaisel: ^1.1.0
   bloc_signals_flutter: ^1.0.0
 
 dev_dependencies:

--- a/bloc_signals_flutter/example/test/widget_test.dart
+++ b/bloc_signals_flutter/example/test/widget_test.dart
@@ -1,31 +1,138 @@
+import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
+import 'package:example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:example/main.dart';
-import 'package:kaisel/kaisel.dart';
-import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
 
 void main() {
-  testWidgets('App renders login screen initially', (
-    WidgetTester tester,
-  ) async {
-    final config = KaiselRouterConfig<AppRoute>(
-      initial: const LoginRoute(),
-      builder: (context, route) => switch (route) {
-        LoginRoute() => const LoginScreen(),
-        HomeRoute(:final username) => HomeScreen(username: username),
-        TimerRoute() => const SizedBox(),
-      },
-    );
+  group('authGuard unit tests', () {
+    test('redirects unauthenticated stack to LoginRoute', () {
+      final loginBloc = LoginBloc();
+      final guard = authGuard(loginBloc);
 
-    await tester.pumpWidget(
-      BlocSignalProvider<LoginBloc>(
-        create: (_) => LoginBloc(),
-        child: MyApp(routerConfig: config),
-      ),
-    );
+      // Attempting to go to HomeRoute while unauthenticated
+      final proposed = [const HomeRoute('alice')];
+      final result = guard(const [LoginRoute()], proposed);
 
-    // Verify that the login screen welcome text is present
-    expect(find.text('Welcome Back'), findsOneWidget);
-    expect(find.text('Sign In'), findsOneWidget);
+      expect(result, equals([const LoginRoute()]));
+    });
+
+    test('allows authenticated user to navigate to HomeRoute', () {
+      final loginBloc = LoginBloc();
+      loginBloc.emit(
+        const LoginState(username: 'alice', isLoggedIn: true),
+      );
+      final guard = authGuard(loginBloc);
+
+      final proposed = [const HomeRoute('alice')];
+      final result = guard(const [LoginRoute()], proposed);
+
+      expect(result, equals(proposed));
+    });
+
+    test('redirects authenticated user away from LoginRoute to HomeRoute', () {
+      final loginBloc = LoginBloc();
+      loginBloc.emit(
+        const LoginState(username: 'alice', isLoggedIn: true),
+      );
+      final guard = authGuard(loginBloc);
+
+      final proposed = [const LoginRoute()];
+      final result = guard(const [HomeRoute('alice')], proposed);
+
+      expect(result, equals([const HomeRoute('alice')]));
+    });
+  });
+
+  group('Kaisel declarative routing widget tests', () {
+    testWidgets('App renders login screen initially and gates protected route',
+        (
+      WidgetTester tester,
+    ) async {
+      final loginBloc = LoginBloc();
+      final config = createRouterConfig(loginBloc);
+
+      await tester.pumpWidget(
+        BlocSignalProvider<LoginBloc>.value(
+          value: loginBloc,
+          child: MyApp(routerConfig: config),
+        ),
+      );
+
+      // Verify that the login screen is rendered
+      expect(find.text('Welcome Back'), findsOneWidget);
+      expect(find.text('Sign In'), findsOneWidget);
+
+      // Attempt unauthenticated navigation to HomeRoute
+      config.router.push(const HomeRoute('intruder'));
+      await tester.pumpAndSettle();
+
+      // Should still be on LoginScreen because authGuard blocked it
+      expect(find.text('Welcome Back'), findsOneWidget);
+      expect(find.text('Hello, intruder!'), findsNothing);
+    });
+
+    testWidgets(
+        'Logging in triggers reevaluateOn and transitions to HomeScreen', (
+      WidgetTester tester,
+    ) async {
+      final loginBloc = LoginBloc();
+      final config = createRouterConfig(loginBloc);
+
+      await tester.pumpWidget(
+        BlocSignalProvider<LoginBloc>.value(
+          value: loginBloc,
+          child: MyApp(routerConfig: config),
+        ),
+      );
+
+      expect(find.text('Welcome Back'), findsOneWidget);
+
+      // Enter valid credentials
+      await tester.enterText(find.byType(TextField).at(0), 'Randal');
+      await tester.enterText(find.byType(TextField).at(1), 'password');
+      await tester.tap(find.text('Sign In'));
+
+      // Advance past simulated network delay in LoginBloc (800ms)
+      await tester.pump(const Duration(milliseconds: 900));
+      await tester.pumpAndSettle();
+
+      // Verify we arrived at HomeScreen without manual navigation in the widget
+      expect(find.text('Hello, Randal!'), findsOneWidget);
+      expect(find.text('Welcome Back'), findsNothing);
+    });
+
+    testWidgets(
+        'Logging out triggers reevaluateOn and transitions back to LoginScreen',
+        (
+      WidgetTester tester,
+    ) async {
+      final loginBloc = LoginBloc();
+      // Start already logged in
+      loginBloc.emit(
+        const LoginState(username: 'Randal', isLoggedIn: true),
+      );
+
+      final config = createRouterConfig(loginBloc);
+
+      await tester.pumpWidget(
+        BlocSignalProvider<LoginBloc>.value(
+          value: loginBloc,
+          child: MyApp(routerConfig: config),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Verify currently on HomeScreen
+      expect(find.text('Hello, Randal!'), findsOneWidget);
+
+      // Tap the logout icon
+      await tester.tap(find.byIcon(Icons.logout));
+      await tester.pumpAndSettle();
+
+      // Verify we automatically transitioned back to LoginScreen via guard re-evaluation
+      expect(find.text('Welcome Back'), findsOneWidget);
+      expect(find.text('Hello, Randal!'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## 🎯 Summary & Motivation

Resolves #222.

Refactors the `bloc_signals_flutter` example application (`bloc_signals_flutter/example`) to replace imperative UI routing side-effects with declarative route guards using **Kaisel 1.1.0**'s `reevaluateOn: Listenable?` parameter and **`bloc_signals_flutter`**'s `bloc.toValueListenable()` adapter.

### Key Changes
- **Wired `KaiselRouterConfig` with `authGuard`**: Declared a pure `KaiselGuard<AppRoute>` protecting authenticated routes (`HomeRoute`, `TimerRoute`).
- **Reactive Guard Re-evaluation**: Configured `reevaluateOn: loginBloc.toValueListenable()`. Authentication state changes immediately trigger the router's guard pipeline without UI intervention.
- **Eradicated UI Navigation Side Effects**: Removed `WidgetsBinding.instance.addPostFrameCallback` from `LoginScreen` and manual `context.replaceTop` from `HomeScreen` logout.
- **Enforced Lower Bound**: Bumped `kaisel` dependency in `bloc_signals_flutter/example/pubspec.yaml` to `^1.1.0`.
- **TDD Test Suite**: Added 3 unit tests and 3 comprehensive widget tests covering route gating, reactive sign-in redirection, and reactive logout redirection.

---

# Self-Critical Review: Issue #222 (Kaisel 1.1 Declarative Route Guards via `reevaluateOn`)

**Branch Audited:** `feat/222-kaisel-declarative-guards`  
**Base Comparison:** `origin/main...HEAD`  
**Target Scope:** `bloc_signals_flutter/example`

---

## 1. Intent & Scope Fidelity
- **Problem Addressed:** The example previously relied on an imperative anti-pattern (`WidgetsBinding.instance.addPostFrameCallback((_) => context.replaceTop(...))`) inside `LoginScreen`'s widget build tree, coupled `HomeScreen`'s logout button directly to imperative navigation, and lacked route gating on protected screens.
- **Evaluation:**
  - The changes completely and surgically implement the proposed solution from Issue #222.
  - Imperative `addPostFrameCallback` was completely deleted from `LoginScreen`.
  - Manual `context.replaceTop(const LoginRoute())` was removed from `HomeScreen`.
  - `authGuard` properly gates routes and works alongside `reevaluateOn: loginBloc.toValueListenable()`.
  - Zero unrelated changes or piggybacking detected (no scope creep into core library or other packages).

---

## 2. Verification & TDD Evidence
- **Methodology:** Verified via strict Test-Driven Development.
  - Initial tests in `test/widget_test.dart` asserting `authGuard` and `createRouterConfig` were written first and failed to compile against the unmodified codebase.
  - Unit tests in `test/widget_test.dart` (`authGuard unit tests` group) explicitly verify:
    1. Redirection of unauthenticated stack proposals to `LoginRoute`.
    2. Permission for authenticated users to navigate to `HomeRoute`.
    3. Redirection of authenticated users away from `LoginRoute` to `HomeRoute`.
  - Widget tests in `test/widget_test.dart` (`Kaisel declarative routing widget tests` group) verify:
    1. Gating of protected routes (`HomeRoute`) when unauthenticated via `router.push`.
    2. End-to-end login flow triggering `reevaluateOn` and transitioning to `HomeScreen` after simulated async latency.
    3. Logout button click dispatching `Logout()` and triggering reactive redirection back to `LoginScreen`.
  - Total test count: 19/19 tests passing in `bloc_signals_flutter/example`.
  - Monorepo test suite: All 14 packages passing via `tool/run_workspace_tests.dart`.

---

## 3. Architecture & Bespoke Pattern Adherence
- **Reactivity & Listenable Interop:** Properly leverages `loginBloc.toValueListenable()`, which comes from `BlocSignalValueListenableX` in `bloc_signals_flutter`. This cleanly bridges the reactive signal state machine with Flutter's `Listenable` requirement on `reevaluateOn`.
- **Elimination of Side Effects:** Purged `addPostFrameCallback` from the widget build tree, restoring UI purity: widgets now only display state and dispatch events.
- **Provider Semantics:** Uses `BlocSignalProvider<LoginBloc>.value(value: loginBloc, child: MyApp(routerConfig: config))` at the root. Because `loginBloc` is needed to wire `createRouterConfig` before `runApp()`, `.value` is the correct constructor to avoid re-instantiation and ensure proper scoping.

---

## 4. Blast Radius & Regressions
- **Blast Radius:** Minimal. Confined exclusively to `bloc_signals_flutter/example`.
- **Package Integrity:** No changes were made to `bloc_signals_flutter`'s published library code (`lib/`), meaning no breaking API changes, no semver impact on published artifacts, and zero risk to downstream consumers.
- **Dependency Impact:** `bloc_signals_flutter/example/pubspec.yaml` was bumped from `kaisel: ^1.0.0` to `kaisel: ^1.1.0`. Because `kaisel 1.1.0` is already resolved and locked in the monorepo, there are no dependency conflicts or resolution issues.

---

## 5. Reviewer Defense & Design Trade-offs
- **Question 1: Why extract `createRouterConfig(LoginBloc loginBloc)`?**
  - *Defense:* Enables deterministic unit and widget testing without duplicating route definitions or coupling test harnesses to top-level global variables.
- **Question 2: Why check `loginBloc.stateValue.isLoggedIn` for `initial:` in `createRouterConfig`?**
  - *Defense:* Kaisel does not re-run guards against the initial route during router construction; setting `initial` conditionally guarantees that if an app starts with pre-seeded or restored auth state, the initial route is correct from frame 1.
- **Question 3: Why `if (proposed.length == 1 && proposed.first is LoginRoute) return proposed;`?**
  - *Defense:* If an unauthenticated stack proposal is already `[LoginRoute]`, returning `proposed` signals "allow" to the guard pipeline without forcing an unnecessary stack rebuild or cycle.

---

## 6. Immune Defenses & Crash Antibodies
- **Pathogen 1: Infinite Guard Redirection Loop**
  - *Wound:* Failing to allow navigation to the login route inside an auth guard causes an infinite redirect loop when the guard tries to redirect to login.
  - *Antibody:* Explicitly guarded:
    ```dart
    if (!isLoggedIn) {
      if (proposed.length == 1 && proposed.first is LoginRoute) {
        return proposed;
      }
      return const [LoginRoute()];
    }
    ```
- **Pathogen 2: `avoid_emit_in_build` / UI Side-Effect Trap**
  - *Wound:* Direct mutations or router manipulations inside widget `build()` methods cause build-phase assertions or dropped frames.
  - *Antibody:* Both `LoginScreen` and `HomeScreen` are now 100% free of navigation side-effects. All navigation is handled outside the widget tree by Kaisel's guard pipeline.
- **Pathogen 3: Dependency Lower-Bound Analysis Failure**
  - *Wound:* Using a newer minor version API (`reevaluateOn:` in 1.1.0) while leaving `^1.0.0` in `pubspec.yaml` breaks `pub downgrade` analysis.
  - *Antibody:* Explicitly bumped `pubspec.yaml` constraint to `kaisel: ^1.1.0`.

---

## 7. Mandatory `origin/main...HEAD` Proactive Audit
- **Diff Audit:**
  - `bloc_signals_flutter/example/pubspec.yaml`: 1 line change (`kaisel: ^1.1.0`).
  - `bloc_signals_flutter/example/lib/main.dart`: Clean, surgical changes adding `authGuard`, `createRouterConfig`, and stripping imperative navigation.
  - `bloc_signals_flutter/example/test/widget_test.dart`: Complete coverage of all guard states and widget transitions with zero unused imports.
  - `bloc_signals_flutter/example/README.md`: Updated documentation accurately describing Kaisel 1.1 declarative routing.
- **Formatting & Diagnostics:** `dart format` is clean across all files; `flutter analyze` reports 0 warnings and 0 errors.
