### PR TITLE
ci: add skill auto-discovery to GCR and document in AGENTS.md

### DIFF
--- a/.github/workflows/gemini-code-review.yml
+++ b/.github/workflows/gemini-code-review.yml
@@ -86,8 +86,22 @@ jobs:
               // Always load core and testing skills if present
               const skillFilesToLoad = new Set(['core.md', 'testing.md']);
 
-              // Topic-specific skill routing based on diff contents
               const lowerDiff = diff.toLowerCase();
+
+              // Auto-discover skills: any *.md whose basename appears in the diff is automatically included
+              try {
+                const availableFiles = fs.readdirSync(pluginSkillsDir).filter(f => f.endsWith('.md'));
+                for (const file of availableFiles) {
+                  const baseName = path.basename(file, '.md').toLowerCase();
+                  if (lowerDiff.includes(baseName)) {
+                    skillFilesToLoad.add(file);
+                  }
+                }
+              } catch (e) {
+                console.log('Notice: Failed scanning plugin skills directory:', e.message);
+              }
+
+              // Component keyword aliases (mapping package/domain names to skill files)
               if (lowerDiff.includes('bloc_signals_flutter') || lowerDiff.includes('flutter') || lowerDiff.includes('widget')) {
                 skillFilesToLoad.add('flutter.md');
               }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Detailed architecture guides and maintainer operations are maintained in dedicat
 - [publishing_and_scoring.md](doc/internals/publishing_and_scoring.md): 160/160 pub.dev points checklist, explicit constructors for dartdoc, package examples, and README catalog tables.
 - [benchmarks_and_workflow.md](doc/internals/benchmarks_and_workflow.md): Benchmark microtask draining, batch UI updates, GitHub Actions script safety, and maintainer delivery protocols.
 - **Article Archive Maintenance (`doc/articles/`)**: Always maintain the local markdown archive in `doc/articles/` with every newly published DEV.to article by running `dart run tool/sync_all_articles.dart` to provide rich contextual knowledge for developers and AI agents.
+- **Automated Gemini Code Review & Skill Ingestion (`.github/workflows/gemini-code-review.yml`)**: Automated PR code reviews dynamically ingest `AGENTS.md` and scan `plugins/bloc-signals/skills/bloc-signals/` and `.agents/skills/` for relevant topic guidance. When introducing new member packages or architectural skills with non-obvious keywords, ensure corresponding aliases are registered in `gemini-code-review.yml` so automated PR reviews evaluate incoming changes against domain guidelines.
 
 ---
 
@@ -160,4 +161,9 @@ Detailed architecture guides and maintainer operations are maintained in dedicat
 - **The Pathogen / Wound**: Accessing `type.name.lexeme` on `NamedType` in AST lint rules causes `dart pub downgrade` analysis on pub.dev to fail with `UNDEFINED_GETTER: The getter 'name' isn't defined for the type 'NamedType'`, losing 20 pub points. In analyzer 6.x/7.x, `NamedType` exposed `name2`, whereas analyzer 8+ re-introduced `name` and removed `name2`.
 - **The Antigen / Vulnerability Vector**: Assuming property names on analyzer AST nodes are uniform across a wide dependency constraint range (for example `analyzer: ">=6.8.0 <15.0.0"`).
 - **The Antibody / Permanent Reflex**: When inspecting type names on `NamedType` across wide analyzer version ranges, query `type.toSource()` (inherited from `AstNode`) or check assignability using `TypeChecker` instead of accessing `.name` or `.name2` tokens. Guarded by `dart pub downgrade && dart analyze` validation.
+
+### 🩹 Scar: Automated PR Review Skill Routing & Knowledge Ingestion
+- **The Pathogen / Wound**: Creating new member packages or authoring new framework architectural skill guides in `plugins/bloc-signals/skills/bloc-signals/` without mapping them in `.github/workflows/gemini-code-review.yml` left the automated Gemini Code Review bot blinded to domain rules for those components on incoming pull requests.
+- **The Antigen / Vulnerability Vector**: Assuming external review bots automatically discover bespoke file naming schemes without explicit keyword mapping or dynamic directory scanning.
+- **The Antibody / Permanent Reflex**: The CI workflow dynamically scans `plugins/bloc-signals/skills/bloc-signals/` and matches all `*.md` file basenames against the pull request diff, supplemented by explicit package keyword aliases (for example `bloc_signals_flutter` ↔ `flutter.md`). When creating new member packages or architectural skills with non-obvious keywords, ensure corresponding topic aliases are registered in `gemini-code-review.yml` so the bot evaluates pull requests against the latest domain standards.
 


### PR DESCRIPTION
## Summary
- **Self-Healing Skill Auto-Discovery**: Enhances `.github/workflows/gemini-code-review.yml` to automatically scan `plugins/bloc-signals/skills/bloc-signals/` for any `*.md` files whose basename appears in the pull request diff, reducing manual workflow maintenance when authoring new framework skill guides.
- **Maintainer Operations Documentation**: Adds explicit entry under Internal Maintainer Operations in `AGENTS.md` outlining the automated Gemini Code Review bot and skill routing rules.
- **Repository Scar Registered**: Documents the *"Automated PR Review Skill Routing & Knowledge Ingestion"* scar in `AGENTS.md` to prevent future knowledge blinding when creating new member packages or architectural skills.