### PR TITLE
feat(telemetry): first-class telemetry on BlocSignalBase, observers, and transformers (#239)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ We use a native Dart workspace (supported in Dart 3.5+) instead of Melos.
   - `bloc_signals_bloc` (Classic BLoC 8/9 interop adapters)
   - `bloc_signals_riverpod` (Bidirectional Riverpod interop adapters)
   - `bloc_signals_test` (Declarative unit testing utilities)
-  - `bloc_signals_lint` (Static analysis lints & IDE diagnostics - 18 rules & 8 automated quick-fixes)
+  - `bloc_signals_lint` (Static analysis lints & IDE diagnostics - 20 rules & 8 automated quick-fixes)
   - `bloc_signals_hydrate` (Persistent state storage adapters)
 
   - `bloc_signals_otel` (OpenTelemetry tracing & metrics)
@@ -76,7 +76,7 @@ Detailed architecture guides and maintainer operations are maintained in dedicat
 - [hydration.md](plugins/bloc-signals/skills/bloc-signals/hydration.md): Hydrated state persistence and JSON serialization.
 - [replay.md](plugins/bloc-signals/skills/bloc-signals/replay.md): Undo/redo state history and replay architecture.
 - [interoperability.md](plugins/bloc-signals/skills/bloc-signals/interoperability.md) & [riverpod_migration.md](plugins/bloc-signals/skills/bloc-signals/riverpod_migration.md): Riverpod, Flutter Listenable, and Stream bridges.
-- [devtools.md](plugins/bloc-signals/skills/bloc-signals/devtools.md), [lint.md](plugins/bloc-signals/skills/bloc-signals/lint.md), [otel.md](plugins/bloc-signals/skills/bloc-signals/otel.md): DevTools extensions, custom linter rules (18 rules and 8 automated IDE quick-fixes), and OpenTelemetry.
+- [devtools.md](plugins/bloc-signals/skills/bloc-signals/devtools.md), [lint.md](plugins/bloc-signals/skills/bloc-signals/lint.md), [otel.md](plugins/bloc-signals/skills/bloc-signals/otel.md): DevTools extensions, custom linter rules (20 rules and 8 automated IDE quick-fixes), and OpenTelemetry.
 
 ### Internal Maintainer Operations (`doc/internals/`)
 - [website_and_publications.md](doc/internals/website_and_publications.md): `blocsignal.dev` architecture, DEV.to publication sync tools, static compilation, local preview, and Firebase deployment.

--- a/bloc_signals/lib/bloc_signals.dart
+++ b/bloc_signals/lib/bloc_signals.dart
@@ -6,10 +6,12 @@
 /// updates, handle events, and monitor transitions.
 library;
 
+// Imported to resolve library doc comment references.
 import 'package:bloc_signals/src/bloc_signals_base.dart';
 
 export 'src/bloc_signal_mixin.dart';
 export 'src/bloc_signals_base.dart';
+export 'src/bloc_telemetry_keys.dart';
 export 'src/concurrency/event_transformers.dart';
 export 'src/concurrency/mutex.dart';
 export 'src/cubit_signal_mixin.dart';

--- a/bloc_signals/lib/src/bloc_signal_mixin.dart
+++ b/bloc_signals/lib/src/bloc_signal_mixin.dart
@@ -80,7 +80,10 @@ mixin BlocSignalMixin<Event, StateType> on BlocSignalBase<StateType> {
           if (e is Error) rethrow;
         }
       },
-      zoneValues: {zoneEventKey: event},
+      zoneValues: {
+        zoneEventKey: event,
+        zoneBlocKey: this,
+      },
     );
   }
 

--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -51,8 +51,29 @@ abstract class BlocSignalObserver {
     StackTrace stackTrace,
   ) {}
 
+  /// Called when a container or concurrency transformer emits
+  /// diagnostic or observability telemetry (for example: dropped events,
+  /// task preemption, queue latencies, cache events, or rate-limiting).
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {}
+
   /// Called when a [BlocSignalBase] is closed.
   void onClose(BlocSignalBase<dynamic> bloc) {}
+}
+
+/// Internal dispatcher allowing built-in concurrency transformers to emit
+/// operational telemetry on [bloc].
+void emitContainerTelemetry(
+  BlocSignalBase<dynamic> bloc,
+  String name, {
+  Object? event,
+  Map<String, dynamic>? metadata,
+}) {
+  bloc.emitTelemetry(name, event: event, metadata: metadata);
 }
 
 /// A base contract for all reactive state containers.
@@ -80,9 +101,17 @@ abstract class BlocSignalBase<StateType> {
   @protected
   bool equals(StateType previous, StateType current);
 
+  /// Canonical zone key used to track the ambient host [BlocSignalBase]
+  /// instance.
+  static final Object ambientZoneBlocKey = Object();
+
   /// Internal zone key used to track the causing event of a transition.
   @protected
   Object get zoneEventKey;
+
+  /// Internal zone key used to track the host bloc instance.
+  @protected
+  Object get zoneBlocKey => ambientZoneBlocKey;
 
   /// Updates the state synchronously.
   ///
@@ -109,6 +138,49 @@ abstract class BlocSignalBase<StateType> {
   @protected
   @mustCallSuper
   void onError(Object error, StackTrace stackTrace);
+
+  /// Emits an error to this container and the global [BlocSignalObserver].
+  ///
+  /// Forwards directly to [onError].
+  @protected
+  @mustCallSuper
+  void emitError(Object error, [StackTrace? stackTrace]);
+
+  /// Backward-compatible alias for [emitError] to maintain classic BLoC
+  /// protocol parity.
+  @protected
+  @mustCallSuper
+  void addError(Object error, [StackTrace? stackTrace]);
+
+  /// Emits an operational telemetry diagnostic event to this container
+  /// and the global [BlocSignalObserver].
+  ///
+  /// Telemetry events represent non-state operational physics (such as cache
+  /// hits/misses, queue wait times, or dropped events) or business milestones
+  /// (such as checkout initiated) that must not pollute UI domain state.
+  ///
+  /// ```dart
+  /// emitTelemetry(
+  ///   'cache_hit',
+  ///   metadata: {'key': itemId, 'latency_ms': 5},
+  /// );
+  /// ```
+  @protected
+  void emitTelemetry(
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  });
+
+  /// Hook invoked when telemetry is emitted. Subclasses can override to
+  /// enrich or filter telemetry before passing to the global observer.
+  @protected
+  @mustCallSuper
+  void onTelemetry(
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  });
 
   /// Creates a reactive [effect] that is automatically cleaned up when the
   /// state container is closed.

--- a/bloc_signals/lib/src/bloc_telemetry_keys.dart
+++ b/bloc_signals/lib/src/bloc_telemetry_keys.dart
@@ -1,0 +1,34 @@
+import 'package:bloc_signals/src/concurrency/event_transformers.dart';
+
+/// Standard telemetry event names emitted by built-in concurrency transformers
+/// and operational diagnostic pipelines.
+///
+/// Use these catalog keys rather than raw string literals to maintain
+/// consistency across metrics dashboards, OpenTelemetry collectors, and
+/// test assertions.
+///
+/// ```dart
+/// expectTelemetry: () => [
+///   isTelemetry(
+///     BlocTelemetryKeys.eventDropped,
+///     metadata: {'reason': 'in_flight'},
+///   ),
+/// ];
+/// ```
+abstract final class BlocTelemetryKeys {
+  /// Emitted when a concurrency transformer (such as [droppable]) discards an
+  /// incoming event because an existing handler is currently executing.
+  static const String eventDropped = 'event_dropped';
+
+  /// Emitted when a concurrency transformer (such as [restartable]) cancels or
+  /// supersedes an in-flight execution upon the arrival of a newer event.
+  static const String taskPreempted = 'task_preempted';
+
+  /// Emitted when an in-flight task execution is explicitly canceled before
+  /// completion.
+  static const String taskCanceled = 'task_canceled';
+
+  /// Emitted when an incoming event is enqueued by a sequential or buffered
+  /// concurrency transformer (such as [sequential]).
+  static const String eventQueued = 'event_queued';
+}

--- a/bloc_signals/lib/src/concurrency/event_transformers.dart
+++ b/bloc_signals/lib/src/concurrency/event_transformers.dart
@@ -1,6 +1,18 @@
 import 'dart:async';
 
+import 'package:bloc_signals/src/bloc_signals_base.dart';
+import 'package:bloc_signals/src/bloc_telemetry_keys.dart';
 import 'package:bloc_signals/src/concurrency/mutex.dart';
+
+const _droppableDroppedMetadata = <String, dynamic>{
+  'transformer': 'droppable',
+  'reason': 'in_flight',
+};
+
+const _restartablePreemptedMetadata = <String, dynamic>{
+  'transformer': 'restartable',
+  'reason': 'superseded',
+};
 
 /// A function handler signature for processing event [E] and emitting state
 /// updates.
@@ -89,10 +101,27 @@ typedef EventTransformer<E, StateType> = FutureOr<void> Function(
 ///   }
 /// }
 /// ```
-EventTransformer<E, StateType> droppable<E, StateType>() {
+EventTransformer<E, StateType> droppable<E, StateType>({
+  BlocSignalBase<dynamic>? bloc,
+}) {
   var isProcessing = false;
   return (event, handler, emit) async {
-    if (isProcessing) return;
+    if (isProcessing) {
+      if (BlocSignalObserver.observer != null) {
+        final host = bloc ??
+            (Zone.current[BlocSignalBase.ambientZoneBlocKey]
+                as BlocSignalBase<dynamic>?);
+        if (host != null) {
+          emitContainerTelemetry(
+            host,
+            BlocTelemetryKeys.eventDropped,
+            event: event,
+            metadata: _droppableDroppedMetadata,
+          );
+        }
+      }
+      return;
+    }
     isProcessing = true;
     try {
       final result = handler(event, emit);
@@ -111,6 +140,10 @@ EventTransformer<E, StateType> droppable<E, StateType>() {
 /// Even if multiple events of type [E] arrive concurrently, each handler
 /// execution runs to completion before the next queued event begins.
 ///
+/// Optionally accepts an explicit host [bloc] reference to emit operational
+/// telemetry ([BlocTelemetryKeys.eventQueued]) and record queue wait latencies.
+/// If omitted, ambient zone resolution is used.
+///
 /// ### Example
 /// ```dart
 /// class CounterBloc extends BlocSignal<CounterEvent, int> {
@@ -125,10 +158,34 @@ EventTransformer<E, StateType> droppable<E, StateType>() {
 ///   }
 /// }
 /// ```
-EventTransformer<E, StateType> sequential<E, StateType>() {
+EventTransformer<E, StateType> sequential<E, StateType>({
+  BlocSignalBase<dynamic>? bloc,
+}) {
   final mutex = Mutex();
   return (event, handler, emit) {
+    final isQueued = mutex.isLocked;
+    final stopwatch = isQueued && BlocSignalObserver.observer != null
+        ? (Stopwatch()..start())
+        : null;
+
     return mutex.protect(() async {
+      if (stopwatch != null) {
+        stopwatch.stop();
+        final host = bloc ??
+            (Zone.current[BlocSignalBase.ambientZoneBlocKey]
+                as BlocSignalBase<dynamic>?);
+        if (host != null) {
+          emitContainerTelemetry(
+            host,
+            BlocTelemetryKeys.eventQueued,
+            event: event,
+            metadata: {
+              'transformer': 'sequential',
+              'queue_wait_ms': stopwatch.elapsedMilliseconds,
+            },
+          );
+        }
+      }
       final result = handler(event, emit);
       if (result is Future) {
         await result;
@@ -145,6 +202,10 @@ EventTransformer<E, StateType> sequential<E, StateType>() {
 /// State emissions produced by earlier, in-flight handlers whose generation
 /// token does not match the latest token are discarded automatically.
 ///
+/// Optionally accepts an explicit host [bloc] reference to emit operational
+/// telemetry ([BlocTelemetryKeys.taskPreempted]) when an in-flight execution is
+/// superseded. If omitted, ambient zone resolution is used.
+///
 /// ### Example
 /// ```dart
 /// class AutocompleteBloc extends BlocSignal<QueryEvent, AutocompleteState> {
@@ -160,20 +221,46 @@ EventTransformer<E, StateType> sequential<E, StateType>() {
 ///   }
 /// }
 /// ```
-EventTransformer<E, StateType> restartable<E, StateType>() {
+EventTransformer<E, StateType> restartable<E, StateType>({
+  BlocSignalBase<dynamic>? bloc,
+}) {
   var executionToken = 0;
+  var inFlight = 0;
+  E? lastInFlightEvent;
   return (event, handler, emit) async {
+    if (inFlight > 0 && BlocSignalObserver.observer != null) {
+      final host = bloc ??
+          (Zone.current[BlocSignalBase.ambientZoneBlocKey]
+              as BlocSignalBase<dynamic>?);
+      if (host != null) {
+        emitContainerTelemetry(
+          host,
+          BlocTelemetryKeys.taskPreempted,
+          event: lastInFlightEvent,
+          metadata: _restartablePreemptedMetadata,
+        );
+      }
+    }
+    lastInFlightEvent = event;
     final currentToken = ++executionToken;
-    final result = handler(
-      event,
-      (state) {
-        if (currentToken == executionToken) {
-          emit(state);
-        }
-      },
-    );
-    if (result is Future) {
-      await result;
+    inFlight++;
+    try {
+      final result = handler(
+        event,
+        (state) {
+          if (currentToken == executionToken) {
+            emit(state);
+          }
+        },
+      );
+      if (result is Future) {
+        await result;
+      }
+    } finally {
+      inFlight--;
+      if (inFlight == 0) {
+        lastInFlightEvent = null;
+      }
     }
   };
 }

--- a/bloc_signals/lib/src/cubit_signal_mixin.dart
+++ b/bloc_signals/lib/src/cubit_signal_mixin.dart
@@ -49,6 +49,10 @@ mixin CubitSignalMixin<StateType> implements BlocSignalBase<StateType> {
   @protected
   Object get zoneEventKey => _zoneEventKey;
 
+  @override
+  @protected
+  Object get zoneBlocKey => BlocSignalBase.ambientZoneBlocKey;
+
   /// Initializes the state signal and lifecycle hooks for this container.
   ///
   /// Must be called in the constructor of the class that mixes in
@@ -192,6 +196,50 @@ mixin CubitSignalMixin<StateType> implements BlocSignalBase<StateType> {
     final currentObserver = BlocSignalObserver.observer;
     if (currentObserver != null) {
       currentObserver.onError(this, error, stackTrace);
+    }
+  }
+
+  @override
+  @protected
+  @mustCallSuper
+  void emitError(Object error, [StackTrace? stackTrace]) {
+    onError(error, stackTrace ?? StackTrace.current);
+  }
+
+  @override
+  @protected
+  @mustCallSuper
+  void addError(Object error, [StackTrace? stackTrace]) =>
+      emitError(error, stackTrace);
+
+  @override
+  @protected
+  void emitTelemetry(
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    if (BlocSignalObserver.observer == null) return;
+    onTelemetry(name, event: event, metadata: metadata);
+  }
+
+  @override
+  @protected
+  @mustCallSuper
+  void onTelemetry(
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    try {
+      BlocSignalObserver.observer?.onTelemetry(
+        this,
+        name,
+        event: event,
+        metadata: metadata,
+      );
+    } on Object catch (e, stackTrace) {
+      onError(e, stackTrace);
     }
   }
 

--- a/bloc_signals/lib/src/devtools_observer.dart
+++ b/bloc_signals/lib/src/devtools_observer.dart
@@ -128,4 +128,50 @@ class DevToolsBlocSignalObserver extends BlocSignalObserver {
       'timestamp': DateTime.now().microsecondsSinceEpoch,
     });
   }
+
+  @override
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    super.onTelemetry(bloc, name, event: event, metadata: metadata);
+    final sanitizedMeta = metadata != null ? _sanitizeMetadata(metadata) : null;
+    DevToolsService.instance.trackTelemetry(
+      bloc,
+      name,
+      event: event,
+      metadata: sanitizedMeta,
+    );
+    previousObserver?.onTelemetry(bloc, name, event: event, metadata: metadata);
+
+    _post('bloc_signal.onTelemetry', {
+      'blocType': bloc.runtimeType.toString(),
+      'hashCode': bloc.hashCode,
+      'name': name,
+      'event': event?.toString(),
+      'metadata': sanitizedMeta,
+      'timestamp': DateTime.now().microsecondsSinceEpoch,
+    });
+  }
+
+  static Map<String, dynamic> _sanitizeMetadata(Map<String, dynamic> metadata) {
+    final sanitized = <String, dynamic>{};
+    for (final entry in metadata.entries) {
+      final value = entry.value;
+      if (value == null || value is num || value is bool || value is String) {
+        sanitized[entry.key] = value;
+      } else if (value is Map) {
+        sanitized[entry.key] = value.map(
+          (k, v) => MapEntry(k.toString(), v?.toString()),
+        );
+      } else if (value is Iterable) {
+        sanitized[entry.key] = value.map((e) => e?.toString()).toList();
+      } else {
+        sanitized[entry.key] = value.toString();
+      }
+    }
+    return sanitized;
+  }
 }

--- a/bloc_signals/lib/src/devtools_service.dart
+++ b/bloc_signals/lib/src/devtools_service.dart
@@ -121,6 +121,27 @@ class DevToolsService {
     );
   }
 
+  /// Tracks container telemetry.
+  void trackTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    _record(
+      bloc.hashCode,
+      DevToolsHistoryEntry(
+        type: 'telemetry',
+        timestamp: DateTime.now().toIso8601String(),
+        data: {
+          'name': name,
+          'event': event?.toString(),
+          'metadata': metadata,
+        },
+      ),
+    );
+  }
+
   /// Tracks container closure.
   void trackClose(BlocSignalBase<dynamic> bloc) {
     _containers.remove(bloc.hashCode);

--- a/bloc_signals/test/devtools_observer_test.dart
+++ b/bloc_signals/test/devtools_observer_test.dart
@@ -1,3 +1,6 @@
+// Cascade invocations are ignored to keep test setup clean and readable.
+// ignore_for_file: cascade_invocations
+
 import 'package:bloc_signals/bloc_signals.dart';
 import 'package:test/test.dart';
 
@@ -64,9 +67,46 @@ class RecordingObserver extends BlocSignalObserver {
   }
 
   @override
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    super.onTelemetry(bloc, name, event: event, metadata: metadata);
+    calls.add('onTelemetry');
+  }
+
+  @override
   void onClose(BlocSignalBase<dynamic> bloc) {
     super.onClose(bloc);
     calls.add('onClose');
+  }
+}
+
+class _TelemetryCubit extends CubitSignal<int> {
+  _TelemetryCubit() : super(initialState: 0);
+
+  void sendTelemetry() {
+    emitTelemetry(
+      'cache_hit',
+      metadata: {
+        'count': 1,
+        'nested': {'k': 'v'},
+        'list': [1, 2],
+        'flag': true,
+      },
+    );
+  }
+
+  void sendTelemetryWithEvent(Object event) {
+    emitTelemetry(
+      'event_processed',
+      event: event,
+      metadata: {
+        'date': DateTime(2026, 2, 3),
+      },
+    );
   }
 }
 
@@ -124,6 +164,22 @@ void main() {
       await bloc.close();
 
       expect(recordingObserver.calls, contains('onClose'));
+    });
+
+    test('captures onTelemetry and forwards to previousObserver', () async {
+      final cubit = _TelemetryCubit();
+      cubit.sendTelemetry();
+
+      expect(recordingObserver.calls, contains('onTelemetry'));
+      await cubit.close();
+    });
+
+    test('captures onTelemetry with event and custom metadata types', () async {
+      final cubit = _TelemetryCubit();
+      cubit.sendTelemetryWithEvent(IncrementEvent());
+
+      expect(recordingObserver.calls, contains('onTelemetry'));
+      await cubit.close();
     });
   });
 }

--- a/bloc_signals/test/telemetry_test.dart
+++ b/bloc_signals/test/telemetry_test.dart
@@ -1,0 +1,301 @@
+// Cascade invocations are ignored to keep test setup clean and readable.
+// ignore_for_file: cascade_invocations
+
+import 'dart:async';
+
+import 'package:bloc_signals/bloc_signals.dart';
+import 'package:test/test.dart';
+
+sealed class CounterEvent {}
+
+final class Increment extends CounterEvent {}
+
+final class SlowIncrement extends CounterEvent {
+  SlowIncrement(this.delayMs, this.value);
+  final int delayMs;
+  final int value;
+}
+
+class TelemetryCounterCubit extends CubitSignal<int> {
+  TelemetryCounterCubit({super.initialState = 0});
+
+  void incrementWithTelemetry() {
+    emitTelemetry('counter_incremented', metadata: {'current': stateValue});
+    emit(stateValue + 1);
+  }
+
+  void triggerEmitError() {
+    emitError(Exception('Failed to compute state'));
+  }
+
+  void triggerAddError() {
+    addError(Exception('Legacy error'));
+  }
+
+  Object get publicZoneBlocKey => zoneBlocKey;
+}
+
+class TelemetryCounterBloc extends BlocSignal<CounterEvent, int> {
+  TelemetryCounterBloc({super.initialState = 0}) {
+    on<Increment>((event, emit) {
+      emitTelemetry('increment_received', event: event);
+      emit(stateValue + 1);
+    });
+  }
+}
+
+class _DroppableTelemetryBloc extends BlocSignal<CounterEvent, int> {
+  _DroppableTelemetryBloc() : super(initialState: 0) {
+    on<SlowIncrement>(
+      (event, emit) async {
+        await Future<void>.delayed(Duration(milliseconds: event.delayMs));
+        emit(stateValue + event.value);
+      },
+      transformer: droppable(),
+    );
+  }
+}
+
+class _SequentialTelemetryBloc extends BlocSignal<CounterEvent, int> {
+  _SequentialTelemetryBloc() : super(initialState: 0) {
+    on<SlowIncrement>(
+      (event, emit) async {
+        await Future<void>.delayed(Duration(milliseconds: event.delayMs));
+        emit(stateValue + event.value);
+      },
+      transformer: sequential(),
+    );
+  }
+}
+
+class _RestartableTelemetryBloc extends BlocSignal<CounterEvent, int> {
+  _RestartableTelemetryBloc() : super(initialState: 0) {
+    on<SlowIncrement>(
+      (event, emit) async {
+        await Future<void>.delayed(Duration(milliseconds: event.delayMs));
+        emit(stateValue + event.value);
+      },
+      transformer: restartable(),
+    );
+  }
+}
+
+class _RecordingObserver extends BlocSignalObserver {
+  final telemetryLogs = <({
+    BlocSignalBase<dynamic> bloc,
+    String name,
+    Object? event,
+    Map<String, dynamic>? metadata,
+  })>[];
+
+  final errorLogs = <({
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  })>[];
+
+  @override
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    telemetryLogs.add(
+      (
+        bloc: bloc,
+        name: name,
+        event: event,
+        metadata: metadata != null ? Map<String, dynamic>.from(metadata) : null,
+      ),
+    );
+  }
+
+  @override
+  void onError(
+    BlocSignalBase<dynamic> bloc,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    errorLogs.add((bloc: bloc, error: error, stackTrace: stackTrace));
+  }
+}
+
+class _FaultyObserver extends BlocSignalObserver {
+  @override
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    throw StateError('Observer pipeline exploded');
+  }
+}
+
+void main() {
+  group('Diagnostic Triad & Telemetry on BlocSignalBase', () {
+    late _RecordingObserver observer;
+
+    setUp(() {
+      observer = _RecordingObserver();
+      BlocSignalObserver.observer = observer;
+    });
+
+    tearDown(() {
+      BlocSignalObserver.observer = null;
+    });
+
+    test('CubitSignal emits telemetry to global observer', () {
+      final cubit = TelemetryCounterCubit();
+      cubit.incrementWithTelemetry();
+
+      expect(cubit.stateValue, equals(1));
+      expect(observer.telemetryLogs, hasLength(1));
+      final log = observer.telemetryLogs.first;
+      expect(log.bloc, equals(cubit));
+      expect(log.name, equals('counter_incremented'));
+      expect(log.metadata, equals({'current': 0}));
+    });
+
+    test('emitError forwards to onError and observer', () {
+      final cubit = TelemetryCounterCubit();
+      cubit.triggerEmitError();
+
+      expect(observer.errorLogs, hasLength(1));
+      expect(
+        observer.errorLogs.first.error.toString(),
+        contains('Failed to compute state'),
+      );
+    });
+
+    test('addError maintains backward compatibility as alias to emitError', () {
+      final cubit = TelemetryCounterCubit();
+      cubit.triggerAddError();
+
+      expect(observer.errorLogs, hasLength(1));
+      expect(
+        observer.errorLogs.first.error.toString(),
+        contains('Legacy error'),
+      );
+    });
+
+    test('BlocSignal emits telemetry with event context', () {
+      final bloc = TelemetryCounterBloc();
+      bloc.add(Increment());
+
+      expect(bloc.stateValue, equals(1));
+      expect(observer.telemetryLogs, hasLength(1));
+      final log = observer.telemetryLogs.first;
+      expect(log.name, equals('increment_received'));
+      expect(log.event, isA<Increment>());
+    });
+
+    test('observer exceptions inside onTelemetry are isolated to onError', () {
+      final faulty = _FaultyObserver();
+      BlocSignalObserver.observer = faulty;
+
+      final cubit = TelemetryCounterCubit();
+      // Should not throw exception to caller:
+      expect(cubit.incrementWithTelemetry, returnsNormally);
+      expect(cubit.stateValue, equals(1));
+    });
+
+    test('short-circuits telemetry immediately when observer is null', () {
+      BlocSignalObserver.observer = null;
+      final cubit = TelemetryCounterCubit();
+      expect(cubit.incrementWithTelemetry, returnsNormally);
+    });
+  });
+
+  group('Built-in Concurrency Transformer Telemetry', () {
+    late _RecordingObserver observer;
+
+    setUp(() {
+      observer = _RecordingObserver();
+      BlocSignalObserver.observer = observer;
+    });
+
+    tearDown(() {
+      BlocSignalObserver.observer = null;
+    });
+
+    test('droppable emits event_dropped telemetry when busy', () async {
+      final bloc = _DroppableTelemetryBloc();
+      bloc.add(SlowIncrement(50, 10));
+      bloc.add(SlowIncrement(10, 20));
+
+      await Future<void>.delayed(const Duration(milliseconds: 70));
+      expect(bloc.stateValue, equals(10));
+
+      final droppedLogs = observer.telemetryLogs
+          .where((l) => l.name == BlocTelemetryKeys.eventDropped)
+          .toList();
+
+      expect(droppedLogs, hasLength(1));
+      expect(
+        droppedLogs.first.metadata,
+        equals(
+          {
+            'transformer': 'droppable',
+            'reason': 'in_flight',
+          },
+        ),
+      );
+      expect(droppedLogs.first.event, isA<SlowIncrement>());
+    });
+
+    test('sequential emits event_queued telemetry with queue wait time',
+        () async {
+      final bloc = _SequentialTelemetryBloc();
+      bloc.add(SlowIncrement(30, 1));
+      bloc.add(SlowIncrement(10, 2));
+
+      await Future<void>.delayed(const Duration(milliseconds: 70));
+      expect(bloc.stateValue, equals(3));
+
+      final queuedLogs = observer.telemetryLogs
+          .where((l) => l.name == BlocTelemetryKeys.eventQueued)
+          .toList();
+
+      expect(queuedLogs, hasLength(1));
+      expect(queuedLogs.first.metadata?['transformer'], equals('sequential'));
+      expect(queuedLogs.first.metadata?['queue_wait_ms'], isA<int>());
+    });
+
+    test('zoneBlocKey exposes ambientZoneBlocKey', () {
+      final cubit = TelemetryCounterCubit();
+      expect(
+        cubit.publicZoneBlocKey,
+        equals(BlocSignalBase.ambientZoneBlocKey),
+      );
+    });
+
+    test('restartable emits task_preempted telemetry on supersede', () async {
+      final bloc = _RestartableTelemetryBloc();
+      bloc.add(SlowIncrement(50, 100));
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      bloc.add(SlowIncrement(10, 200));
+
+      await Future<void>.delayed(const Duration(milliseconds: 70));
+      expect(bloc.stateValue, equals(200));
+
+      final preemptedLogs = observer.telemetryLogs
+          .where((l) => l.name == BlocTelemetryKeys.taskPreempted)
+          .toList();
+
+      expect(preemptedLogs, hasLength(1));
+      final preemptedEvent = preemptedLogs.first.event! as SlowIncrement;
+      expect(preemptedEvent.value, equals(100));
+      expect(
+        preemptedLogs.first.metadata,
+        equals(
+          {
+            'transformer': 'restartable',
+            'reason': 'superseded',
+          },
+        ),
+      );
+    });
+  });
+}

--- a/bloc_signals_lint/README.md
+++ b/bloc_signals_lint/README.md
@@ -54,6 +54,8 @@ The `BlocSignal` monorepo consists of 11 modular packages:
 | **`prefer_named_replay_constructor`** | Warning | Flags `super.positional(...)` invocations in `ReplayCubit` and `ReplayBloc` subclasses, recommending `super(initialState: ...)`. | `Cmd+.` -> Replace `super.positional(...)` with `super(initialState: ...)` |
 | **`require_emit_in_helper_name`** | Warning | Flags private helper methods calling `emit()` whose names do not reflect state emission. | `Cmd+.` -> Rename to `...AndEmit` |
 | **`avoid_multiple_synchronous_emits`** | Warning | Flags multiple synchronous `emit()` calls along the same linear execution path without an intervening `await`. | — |
+| **`avoid_primitive_event_types`** | Warning | Flags `BlocSignal<Event, State>` or `BlocSignalMixin` using primitive or untyped types (`int`, `String`, `bool`, `dynamic`, etc.) as event types. | — |
+| **`avoid_pseudo_events_in_telemetry`** | Warning | Flags `emitTelemetry('...')` calls inside `CubitSignal` where the name matches UI event action patterns (`Pressed`, `Clicked`, `Submitted`, etc.). | — |
 
 ### Flutter UI Rules
 

--- a/bloc_signals_lint/lib/bloc_signals_lint.dart
+++ b/bloc_signals_lint/lib/bloc_signals_lint.dart
@@ -5,7 +5,9 @@ import 'package:bloc_signals_lint/src/rules/avoid_emit_in_build.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_invalid_context_select_generics.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_manual_close_on_provided_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_multiple_synchronous_emits.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_primitive_event_types.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_providing_existing_instance_with_create.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_pseudo_events_in_telemetry.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_raw_signal_effects_in_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_top_level_bloc_signal_instances.dart';
@@ -42,5 +44,7 @@ class _BlocSignalsLinter extends PluginBase {
         const PreferNamedReplayConstructor(),
         const RequireEmitInHelperName(),
         const AvoidMultipleSynchronousEmits(),
+        const AvoidPrimitiveEventTypes(),
+        const AvoidPseudoEventsInTelemetry(),
       ];
 }

--- a/bloc_signals_lint/lib/src/rules/avoid_primitive_event_types.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_primitive_event_types.dart
@@ -1,0 +1,136 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags `BlocSignal` and `BlocSignalMixin` declarations
+/// that use primitive or untyped types (`int`, `String`, `bool`, `double`,
+/// `num`, `dynamic`, `Object`, etc.) for their `Event` generic type parameter.
+class AvoidPrimitiveEventTypes extends DartLintRule {
+  /// Creates an [AvoidPrimitiveEventTypes] lint rule.
+  const AvoidPrimitiveEventTypes() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_primitive_event_types',
+    problemMessage:
+        'Avoid using primitive or untyped types ("{0}") for BlocSignal '
+        'events. Events should be dedicated sealed classes or records.',
+    correctionMessage: 'Define a dedicated event class or record (for example, '
+        '"sealed class MyEvent {}") to model state transitions cleanly.',
+  );
+
+  static const _blocSignalChecker = TypeChecker.fromName(
+    'BlocSignal',
+    packageName: 'bloc_signals',
+  );
+
+  static const _blocSignalMixinChecker = TypeChecker.fromName(
+    'BlocSignalMixin',
+    packageName: 'bloc_signals',
+  );
+
+  static const _primitiveTypeNames = <String>{
+    'int',
+    'String',
+    'bool',
+    'double',
+    'num',
+    'dynamic',
+    'Object',
+    'void',
+    'Null',
+  };
+
+  /// Returns whether [typeName] represents a primitive or untyped Dart type.
+  static bool isPrimitiveType(String typeName) {
+    final clean = typeName.replaceAll('?', '').trim();
+    return _primitiveTypeNames.contains(clean);
+  }
+
+  /// Finds all AST nodes violating this rule within a class declaration.
+  static List<AstNode> findViolations(ClassDeclaration node) {
+    final violations = <AstNode>[];
+
+    // Check extends clause
+    final extendsClause = node.extendsClause;
+    if (extendsClause != null) {
+      final superclass = extendsClause.superclass;
+      final superclassName = superclass.name2.lexeme;
+      final staticType = superclass.type;
+      final isBlocSuperclass = _isBlocClassName(superclassName) ||
+          (staticType != null &&
+              _blocSignalChecker.isAssignableFromType(staticType));
+
+      if (isBlocSuperclass) {
+        final typeArgs = superclass.typeArguments?.arguments;
+        if (typeArgs == null || typeArgs.isEmpty) {
+          if (_isBlocClassName(superclassName)) {
+            violations.add(superclass);
+          }
+        } else {
+          final eventTypeNode = typeArgs.first;
+          if (isPrimitiveType(eventTypeNode.toSource())) {
+            violations.add(eventTypeNode);
+          }
+        }
+      }
+    }
+
+    // Check with clause
+    final withClause = node.withClause;
+    if (withClause != null) {
+      for (final mixinType in withClause.mixinTypes) {
+        final mixinName = mixinType.name2.lexeme;
+        final staticType = mixinType.type;
+        final isBlocMixin = _isBlocClassName(mixinName) ||
+            (staticType != null &&
+                (_blocSignalMixinChecker.isAssignableFromType(staticType) ||
+                    _blocSignalChecker.isAssignableFromType(staticType)));
+
+        if (isBlocMixin) {
+          final typeArgs = mixinType.typeArguments?.arguments;
+          if (typeArgs == null || typeArgs.isEmpty) {
+            if (_isBlocClassName(mixinName)) {
+              violations.add(mixinType);
+            }
+          } else {
+            final eventTypeNode = typeArgs.first;
+            if (isPrimitiveType(eventTypeNode.toSource())) {
+              violations.add(eventTypeNode);
+            }
+          }
+        }
+      }
+    }
+
+    return violations;
+  }
+
+  static bool _isBlocClassName(String name) {
+    return name == 'BlocSignal' ||
+        name == 'ReplayBloc' ||
+        name == 'HydratedBloc' ||
+        name == 'BlocSignalMixin' ||
+        name == 'ReplayBlocMixin';
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addClassDeclaration((node) {
+      final violations = findViolations(node);
+      for (final violation in violations) {
+        reporter.atNode(
+          violation,
+          code,
+          arguments: [violation.toSource()],
+        );
+      }
+    });
+  }
+}

--- a/bloc_signals_lint/lib/src/rules/avoid_primitive_event_types.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_primitive_event_types.dart
@@ -57,7 +57,7 @@ class AvoidPrimitiveEventTypes extends DartLintRule {
     final extendsClause = node.extendsClause;
     if (extendsClause != null) {
       final superclass = extendsClause.superclass;
-      final superclassName = superclass.name2.lexeme;
+      final superclassName = superclass.toSource().split('<').first.trim();
       final staticType = superclass.type;
       final isBlocSuperclass = _isBlocClassName(superclassName) ||
           (staticType != null &&
@@ -82,7 +82,7 @@ class AvoidPrimitiveEventTypes extends DartLintRule {
     final withClause = node.withClause;
     if (withClause != null) {
       for (final mixinType in withClause.mixinTypes) {
-        final mixinName = mixinType.name2.lexeme;
+        final mixinName = mixinType.toSource().split('<').first.trim();
         final staticType = mixinType.type;
         final isBlocMixin = _isBlocClassName(mixinName) ||
             (staticType != null &&

--- a/bloc_signals_lint/lib/src/rules/avoid_pseudo_events_in_telemetry.dart
+++ b/bloc_signals_lint/lib/src/rules/avoid_pseudo_events_in_telemetry.dart
@@ -1,0 +1,140 @@
+// Ignore deprecated_member_use due to custom_lint_builder parameter signature.
+// ignore_for_file: deprecated_member_use
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// A lint rule that flags `emitTelemetry('...')` calls inside `CubitSignal`
+/// where the telemetry name matches UI event action patterns (such as
+/// `Pressed`, `Clicked`, `Submitted`, `Requested`, `Tapped`, `Swiped`,
+/// or `Event`).
+///
+/// In BlocSignal, state updates originate from method calls on Cubits or
+/// declarative events on Blocs. Cubits must not use telemetry as a backdoor
+/// pseudo-event bus.
+class AvoidPseudoEventsInTelemetry extends DartLintRule {
+  /// Creates an [AvoidPseudoEventsInTelemetry] lint rule.
+  const AvoidPseudoEventsInTelemetry() : super(code: _code);
+
+  static const _code = LintCode(
+    name: 'avoid_pseudo_events_in_telemetry',
+    problemMessage:
+        'Avoid using pseudo-event action names ("{0}") in "emitTelemetry" '
+        'inside a CubitSignal.',
+    correctionMessage:
+        'Telemetry should record operational occurrences or domain '
+        'milestones, not simulate user UI events inside a Cubit. '
+        'If event modeling is needed, migrate to BlocSignal.',
+  );
+
+  static const _cubitSignalChecker = TypeChecker.fromName(
+    'CubitSignal',
+    packageName: 'bloc_signals',
+  );
+
+  static const _cubitSignalMixinChecker = TypeChecker.fromName(
+    'CubitSignalMixin',
+    packageName: 'bloc_signals',
+  );
+
+  static const _blocSignalChecker = TypeChecker.fromName(
+    'BlocSignal',
+    packageName: 'bloc_signals',
+  );
+
+  static final _pseudoEventPattern = RegExp(
+    r'(?:[_\-.]|^)(?:pressed|clicked|submitted|requested|tapped|swiped|event)$'
+    r'|[a-z0-9](?:Pressed|Clicked|Submitted|Requested|Tapped|Swiped|Event)$',
+  );
+
+  /// Returns whether [name] resembles a UI or lifecycle event action name.
+  static bool isPseudoEventName(String name) {
+    return _pseudoEventPattern.hasMatch(name.trim());
+  }
+
+  /// Finds all AST nodes violating this rule within a class declaration.
+  static List<AstNode> findViolations(ClassDeclaration node) {
+    final classElement = node.declaredFragment?.element;
+    final extendsClause = node.extendsClause?.superclass.toSource();
+    final withClause = node.withClause?.toSource();
+
+    final isExplicitBloc =
+        (classElement != null && _blocSignalChecker.isSuperOf(classElement)) ||
+            (extendsClause != null &&
+                (extendsClause.contains('BlocSignal') ||
+                    extendsClause.contains('ReplayBloc'))) ||
+            (withClause != null &&
+                (withClause.contains('BlocSignalMixin') ||
+                    withClause.contains('ReplayBlocMixin')));
+
+    if (isExplicitBloc) return const [];
+
+    final isCubit = (classElement != null &&
+            (_cubitSignalChecker.isSuperOf(classElement) ||
+                _cubitSignalMixinChecker.isSuperOf(classElement))) ||
+        (extendsClause != null &&
+            (extendsClause.contains('CubitSignal') ||
+                extendsClause.contains('ReplayCubit') ||
+                extendsClause.contains('HydratedCubit'))) ||
+        (withClause != null &&
+            (withClause.contains('CubitSignalMixin') ||
+                withClause.contains('ReplayCubitMixin')));
+
+    if (!isCubit) return const [];
+
+    final violations = <AstNode>[];
+
+    node.visitChildren(
+      _TelemetryInvocationVisitor((invocation, stringLiteral) {
+        if (isPseudoEventName(stringLiteral.stringValue ?? '')) {
+          violations.add(stringLiteral);
+        }
+      }),
+    );
+
+    return violations;
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    ErrorReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addClassDeclaration((node) {
+      final violations = findViolations(node);
+      for (final violation in violations) {
+        reporter.atNode(
+          violation,
+          code,
+          arguments: [
+            violation.toSource().replaceAll("'", '').replaceAll('"', ''),
+          ],
+        );
+      }
+    });
+  }
+}
+
+class _TelemetryInvocationVisitor extends RecursiveAstVisitor<void> {
+  _TelemetryInvocationVisitor(this.onTelemetryCall);
+
+  final void Function(MethodInvocation invocation, SimpleStringLiteral literal)
+      onTelemetryCall;
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'emitTelemetry') {
+      final target = node.target;
+      if (target == null || target is ThisExpression) {
+        final args = node.argumentList.arguments;
+        if (args.isNotEmpty && args.first is SimpleStringLiteral) {
+          onTelemetryCall(node, args.first as SimpleStringLiteral);
+        }
+      }
+    }
+    super.visitMethodInvocation(node);
+  }
+}

--- a/bloc_signals_lint/test/bloc_signals_lint_test.dart
+++ b/bloc_signals_lint/test/bloc_signals_lint_test.dart
@@ -8,7 +8,9 @@ import 'package:bloc_signals_lint/src/rules/avoid_emit_in_build.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_invalid_context_select_generics.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_manual_close_on_provided_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_multiple_synchronous_emits.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_primitive_event_types.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_providing_existing_instance_with_create.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_pseudo_events_in_telemetry.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_raw_signal_effects_in_bloc.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_stream_transformers_on_bloc_signal.dart';
 import 'package:bloc_signals_lint/src/rules/avoid_top_level_bloc_signal_instances.dart';
@@ -24,14 +26,14 @@ import 'package:test/test.dart';
 
 void main() {
   group('bloc_signals_lint plugin entrypoint', () {
-    test('createPlugin returns PluginBase with 18 core and UI rules', () {
+    test('createPlugin returns PluginBase with 20 core and UI rules', () {
       final plugin = createPlugin();
       expect(plugin, isA<PluginBase>());
 
       /// Ignore internal member usage for testing.
       // ignore: invalid_use_of_internal_member
       final rules = plugin.getLintRules(CustomLintConfigs.empty);
-      expect(rules, hasLength(18));
+      expect(rules, hasLength(20));
       expect(rules, contains(isA<AvoidDuplicateEventHandlers>()));
       expect(rules, contains(isA<RequireSuperOnEvent>()));
       expect(rules, contains(isA<AvoidStreamTransformersOnBlocSignal>()));
@@ -53,6 +55,8 @@ void main() {
       expect(rules, contains(isA<PreferNamedReplayConstructor>()));
       expect(rules, contains(isA<RequireEmitInHelperName>()));
       expect(rules, contains(isA<AvoidMultipleSynchronousEmits>()));
+      expect(rules, contains(isA<AvoidPrimitiveEventTypes>()));
+      expect(rules, contains(isA<AvoidPseudoEventsInTelemetry>()));
     });
   });
 
@@ -189,6 +193,22 @@ void main() {
       expect(
         rule.code.name,
         equals('avoid_multiple_synchronous_emits'),
+      );
+    });
+
+    test('AvoidPrimitiveEventTypes code is properly configured', () {
+      const rule = AvoidPrimitiveEventTypes();
+      expect(
+        rule.code.name,
+        equals('avoid_primitive_event_types'),
+      );
+    });
+
+    test('AvoidPseudoEventsInTelemetry code is properly configured', () {
+      const rule = AvoidPseudoEventsInTelemetry();
+      expect(
+        rule.code.name,
+        equals('avoid_pseudo_events_in_telemetry'),
       );
     });
   });

--- a/bloc_signals_lint/test/rules/avoid_primitive_event_types_test.dart
+++ b/bloc_signals_lint/test/rules/avoid_primitive_event_types_test.dart
@@ -1,0 +1,287 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_primitive_event_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AvoidPrimitiveEventTypes AST Detection', () {
+    test('rule metadata is properly configured', () {
+      const rule = AvoidPrimitiveEventTypes();
+      expect(rule.code.name, equals('avoid_primitive_event_types'));
+      expect(
+        rule.code.problemMessage,
+        equals(
+          'Avoid using primitive or untyped types ("{0}") for BlocSignal '
+          'events. Events should be dedicated sealed classes or records.',
+        ),
+      );
+      expect(
+        rule.code.correctionMessage,
+        equals(
+          'Define a dedicated event class or record (for example, '
+          '"sealed class MyEvent {}") to model state transitions cleanly.',
+        ),
+      );
+    });
+
+    test('detects primitive int event type in BlocSignal', () {
+      const badCode = '''
+class CounterBloc extends BlocSignal<int, int> {
+  CounterBloc() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(1));
+    });
+
+    test('detects primitive String event type in BlocSignal', () {
+      const badCode = '''
+class TextBloc extends BlocSignal<String, String> {
+  TextBloc() : super(initialState: '');
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(1));
+    });
+
+    test('detects primitive bool and double event types in BlocSignal', () {
+      const badCode = '''
+class BoolBloc extends BlocSignal<bool, bool> {
+  BoolBloc() : super(initialState: false);
+}
+class DoubleBloc extends BlocSignal<double, double> {
+  DoubleBloc() : super(initialState: 0.0);
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(2));
+    });
+
+    test('detects num, dynamic, Object, and nullable primitive event types',
+        () {
+      const badCode = '''
+class NumBloc extends BlocSignal<num, int> {
+  NumBloc() : super(initialState: 0);
+}
+class DynamicBloc extends BlocSignal<dynamic, int> {
+  DynamicBloc() : super(initialState: 0);
+}
+class ObjectBloc extends BlocSignal<Object, int> {
+  ObjectBloc() : super(initialState: 0);
+}
+class NullableIntBloc extends BlocSignal<int?, int> {
+  NullableIntBloc() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(4));
+    });
+
+    test('detects primitive event type when using BlocSignalMixin', () {
+      const badCode = '''
+class ServiceBloc extends BaseService with BlocSignalMixin<int, int> {
+  ServiceBloc() {
+    initBlocSignal(initialState: 0);
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(1));
+    });
+
+    test('detects primitive event type when extending ReplayBloc', () {
+      const badCode = '''
+class ReplayCounterBloc extends ReplayBloc<int, int> {
+  ReplayCounterBloc() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(1));
+    });
+
+    test('detects raw BlocSignal without type arguments', () {
+      const badCode = '''
+class RawBloc extends BlocSignal {
+  RawBloc() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(1));
+    });
+
+    test('accepts dedicated event class in BlocSignal', () {
+      const goodCode = '''
+sealed class CounterEvent {}
+class Increment extends CounterEvent {}
+
+class CounterBloc extends BlocSignal<CounterEvent, int> {
+  CounterBloc() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('accepts record event type in BlocSignal', () {
+      const goodCode = '''
+class CoordinateBloc extends BlocSignal<(int x, int y), int> {
+  CoordinateBloc() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('accepts CubitSignal with primitive state', () {
+      const goodCode = '''
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('accepts unrelated non-bloc class with primitive generic', () {
+      const goodCode = '''
+class GenericContainer<T> {}
+class IntContainer extends GenericContainer<int> {}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('accepts non-bloc superclass with valid BlocSignalMixin', () {
+      const goodCode = '''
+sealed class UserEvent {}
+
+class UserBloc extends BaseRepository
+    with DiagnosticableTreeMixin, BlocSignalMixin<UserEvent, int> {
+  UserBloc() {
+    initBlocSignal(initialState: 0);
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('detects primitive event in BlocSignalMixin alongside other mixins',
+        () {
+      const badCode = '''
+class BadUserBloc extends BaseRepository
+    with DiagnosticableTreeMixin, BlocSignalMixin<int, int> {
+  BadUserBloc() {
+    initBlocSignal(initialState: 0);
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPrimitiveEventTypes.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(1));
+    });
+  });
+}

--- a/bloc_signals_lint/test/rules/avoid_pseudo_events_in_telemetry_test.dart
+++ b/bloc_signals_lint/test/rules/avoid_pseudo_events_in_telemetry_test.dart
@@ -1,0 +1,207 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:bloc_signals_lint/src/rules/avoid_pseudo_events_in_telemetry.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AvoidPseudoEventsInTelemetry AST Detection', () {
+    test('rule metadata is properly configured', () {
+      const rule = AvoidPseudoEventsInTelemetry();
+      expect(rule.code.name, equals('avoid_pseudo_events_in_telemetry'));
+      expect(
+        rule.code.problemMessage,
+        equals(
+          'Avoid using pseudo-event action names ("{0}") in "emitTelemetry" '
+          'inside a CubitSignal.',
+        ),
+      );
+      expect(
+        rule.code.correctionMessage,
+        equals(
+          'Telemetry should record operational occurrences or domain '
+          'milestones, not simulate user UI events inside a Cubit. '
+          'If event modeling is needed, migrate to BlocSignal.',
+        ),
+      );
+    });
+
+    test('detects Pressed pseudo-events in CubitSignal', () {
+      const badCode = '''
+class CounterCubit extends CubitSignal<int> {
+  CounterCubit() : super(initialState: 0);
+
+  void increment() {
+    emitTelemetry('IncrementPressed');
+    emit(stateValue + 1);
+  }
+
+  void decrement() {
+    emitTelemetry('button_pressed');
+    emit(stateValue - 1);
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(2));
+    });
+
+    test(
+        'detects Clicked, Submitted, and Requested '
+        'pseudo-events in CubitSignal', () {
+      const badCode = '''
+class FormCubit extends CubitSignal<String> {
+  FormCubit() : super(initialState: '');
+
+  void submit() {
+    emitTelemetry('SubmitClicked');
+    emitTelemetry('form_submitted');
+    emitTelemetry('RefreshRequested');
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(3));
+    });
+
+    test('detects Tapped, Swiped, and Event pseudo-events in CubitSignal', () {
+      const badCode = '''
+class CardCubit extends CubitSignal<int> {
+  CardCubit() : super(initialState: 0);
+
+  void handleInteraction() {
+    this.emitTelemetry('CardTapped');
+    emitTelemetry('item_swiped');
+    emitTelemetry('CounterEvent');
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(3));
+    });
+
+    test('detects pseudo-events in CubitSignalMixin and ReplayCubit', () {
+      const badCode = '''
+class ServiceCubit extends BaseService with CubitSignalMixin<int> {
+  void track() {
+    emitTelemetry('SavePressed');
+  }
+}
+
+class ReplayItemCubit extends ReplayCubit<int> {
+  ReplayItemCubit() : super(initialState: 0);
+
+  void act() {
+    emitTelemetry('ActionRequested');
+  }
+}
+''';
+      final parseResult = parseString(content: badCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, hasLength(2));
+    });
+
+    test('accepts legitimate operational telemetry in CubitSignal', () {
+      const goodCode = '''
+class OrderCubit extends CubitSignal<OrderState> {
+  OrderCubit() : super(initialState: OrderState.initial());
+
+  void processOrder() {
+    emitTelemetry('cache_hit', metadata: {'duration_ms': 12});
+    emitTelemetry('sync_completed');
+    emitTelemetry('token_expired');
+    emitTelemetry('quota_warning');
+    emitTelemetry('fraud_prevent');
+    emit(OrderState.success());
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('accepts telemetry in BlocSignal', () {
+      const goodCode = '''
+class OrderBloc extends BlocSignal<OrderEvent, OrderState> {
+  OrderBloc() : super(initialState: OrderState.initial()) {
+    on<OrderEvent>((event, emit) {
+      emitTelemetry('OrderRequested');
+    });
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+
+    test('accepts non-cubit classes with emitTelemetry methods', () {
+      const goodCode = '''
+class TelemetryEmitter {
+  void emitTelemetry(String name) {}
+}
+
+class Client {
+  void run(TelemetryEmitter emitter) {
+    emitter.emitTelemetry('ButtonPressed');
+  }
+}
+''';
+      final parseResult = parseString(content: goodCode);
+      final flaggedNodes = <AstNode>[];
+
+      for (final declaration
+          in parseResult.unit.declarations.whereType<ClassDeclaration>()) {
+        flaggedNodes
+            .addAll(AvoidPseudoEventsInTelemetry.findViolations(declaration));
+      }
+
+      expect(flaggedNodes, isEmpty);
+    });
+  });
+}

--- a/bloc_signals_otel/lib/src/otel_bloc_signal_observer.dart
+++ b/bloc_signals_otel/lib/src/otel_bloc_signal_observer.dart
@@ -119,4 +119,73 @@ class OtelBlocSignalObserver extends BlocSignalObserver {
       _activeSpans.remove(key)?.end();
     }
   }
+
+  @override
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    super.onTelemetry(bloc, name, event: event, metadata: metadata);
+
+    final key = _spanKey(bloc, event);
+    final activeSpan = _activeSpans[key];
+
+    final attrs = <otel.Attribute>[
+      if (metadata != null)
+        for (final entry in metadata.entries)
+          _attributeFromValue(entry.key, entry.value),
+    ];
+
+    if (activeSpan != null) {
+      activeSpan.addEvent(name, attributes: attrs);
+      if (name == BlocTelemetryKeys.eventDropped ||
+          name == BlocTelemetryKeys.taskPreempted) {
+        activeSpan
+          ..setAttribute(
+            otel.Attribute.fromBoolean('bloc.contention', true),
+          )
+          ..setStatus(otel.StatusCode.ok)
+          ..end();
+        _activeSpans.remove(key);
+      }
+    } else {
+      _tracer.startSpan(
+        '${bloc.runtimeType}.telemetry.$name',
+        attributes: [
+          otel.Attribute.fromString(
+            'bloc.type',
+            bloc.runtimeType.toString(),
+          ),
+          ...attrs,
+        ],
+      ).end();
+    }
+  }
+
+  otel.Attribute _attributeFromValue(String key, dynamic value) {
+    if (value is bool) {
+      return otel.Attribute.fromBoolean(key, value);
+    }
+    if (value is int) {
+      return otel.Attribute.fromInt(key, value);
+    }
+    if (value is double) {
+      return otel.Attribute.fromDouble(key, value);
+    }
+    if (value is List<String>) {
+      return otel.Attribute.fromStringList(key, value);
+    }
+    if (value is List<int>) {
+      return otel.Attribute.fromIntList(key, value);
+    }
+    if (value is List<double>) {
+      return otel.Attribute.fromDoubleList(key, value);
+    }
+    if (value is List<bool>) {
+      return otel.Attribute.fromBooleanList(key, value);
+    }
+    return otel.Attribute.fromString(key, value.toString());
+  }
 }

--- a/bloc_signals_otel/test/bloc_signals_otel_test.dart
+++ b/bloc_signals_otel/test/bloc_signals_otel_test.dart
@@ -1,3 +1,6 @@
+// Cascade invocations are ignored to keep test assertions clean and readable.
+// ignore_for_file: cascade_invocations
+
 import 'package:bloc_signals/bloc_signals.dart';
 import 'package:bloc_signals_otel/bloc_signals_otel.dart';
 import 'package:opentelemetry/api.dart' as otel;
@@ -168,6 +171,92 @@ void main() {
       expect(span.name, equals('TestCubit.error'));
       expect(span.status.code, equals(otel.StatusCode.error));
       expect(span.status.description, contains('Cubit async error'));
+    });
+
+    test(
+        'instruments onTelemetry on active span with span event and contention '
+        'and ends span on eventDropped', () async {
+      final bloc = TestBloc();
+      final event = Increment();
+      observer.onEvent(bloc, event);
+
+      observer.onTelemetry(
+        bloc,
+        BlocTelemetryKeys.eventDropped,
+        event: event,
+        metadata: const {
+          'reason': 'in_flight',
+          'ratio': 0.75,
+          'tags': ['ui', 'gesture'],
+        },
+      );
+
+      // Dropped event should end immediately without onTransition!
+      expect(exporter.exportedSpans, hasLength(1));
+      final span = exporter.exportedSpans.first;
+      expect(span.name, equals('TestBloc.add(Increment)'));
+      expect(span.attributes.get('bloc.contention'), equals(true));
+      expect(span.events, hasLength(1));
+      final spanEvent = span.events.first;
+      expect(spanEvent.name, equals(BlocTelemetryKeys.eventDropped));
+      expect(
+        spanEvent.attributes.firstWhere((a) => a.key == 'reason').value,
+        equals('in_flight'),
+      );
+      expect(
+        spanEvent.attributes.firstWhere((a) => a.key == 'ratio').value,
+        equals(0.75),
+      );
+      await bloc.close();
+    });
+
+    test('instruments onTelemetry on active span and ends on taskPreempted',
+        () async {
+      final bloc = TestBloc();
+      final event = Increment();
+      observer.onEvent(bloc, event);
+
+      observer.onTelemetry(
+        bloc,
+        BlocTelemetryKeys.taskPreempted,
+        event: event,
+        metadata: const {
+          'reason': 'superseded',
+          'queue': [1, 2],
+          'rates': [1.5, 2.5],
+          'flags': [true, false],
+        },
+      );
+
+      // Preempted event should end immediately without onTransition!
+      expect(exporter.exportedSpans, hasLength(1));
+      final span = exporter.exportedSpans.first;
+      expect(span.name, equals('TestBloc.add(Increment)'));
+      expect(span.attributes.get('bloc.contention'), equals(true));
+      await bloc.close();
+    });
+
+    test('instruments onTelemetry outside active span to discrete span',
+        () async {
+      final cubit = TestCubit();
+      observer.onTelemetry(
+        cubit,
+        'cache_hit',
+        metadata: const {
+          'key': 'item_42',
+          'latency_ms': 5,
+          'cached': true,
+        },
+      );
+      await cubit.close();
+
+      expect(exporter.exportedSpans, hasLength(1));
+      final span = exporter.exportedSpans.first;
+      expect(span.name, equals('TestCubit.telemetry.cache_hit'));
+      expect(span.attributes.get('bloc.type'), equals('TestCubit'));
+      expect(span.attributes.get('key'), equals('item_42'));
+      expect(span.attributes.get('latency_ms'), equals(5));
+      expect(span.attributes.get('cached'), equals(true));
     });
   });
 }

--- a/bloc_signals_test/lib/src/bloc_signal_test.dart
+++ b/bloc_signals_test/lib/src/bloc_signal_test.dart
@@ -35,6 +35,9 @@ import 'package:test/test.dart' as test_pkg;
 /// [errors] is an optional callback returning an [Iterable] or
 /// [test_pkg.Matcher] of expected errors.
 ///
+/// [expectTelemetry] is an optional callback returning an [Iterable] or
+/// [test_pkg.Matcher] of expected telemetry records (such as [isTelemetry]).
+///
 /// [tearDown] is an optional callback invoked after test completion.
 @isTest
 void blocSignalTest<B extends BlocSignalBase<State>, State>(
@@ -47,6 +50,7 @@ void blocSignalTest<B extends BlocSignalBase<State>, State>(
   Object? Function()? expect,
   FutureOr<void> Function(B bloc)? verify,
   Object? Function()? errors,
+  Object? Function()? expectTelemetry,
   FutureOr<void> Function()? tearDown,
   dynamic tags,
 }) {
@@ -56,14 +60,32 @@ void blocSignalTest<B extends BlocSignalBase<State>, State>(
       await setUp?.call();
       final states = <State>[];
       final caughtErrors = <Object>[];
+      final caughtTelemetry = <BlocTelemetryEntry>[];
       B? bloc;
 
       final previousObserver = BlocSignalObserver.observer;
+      final initialErrors = <(Object, Object)>[];
+      final initialTelemetry = <(Object, BlocTelemetryEntry)>[];
+
       final testObserver = _TestBlocSignalObserver(
         parent: previousObserver,
         onErrorCallback: (b, error, stackTrace) {
-          if (identical(b, bloc)) {
+          if (bloc == null) {
+            initialErrors.add((b, error));
+          } else if (identical(b, bloc)) {
             caughtErrors.add(error);
+          }
+        },
+        onTelemetryCallback: (b, name, {event, metadata}) {
+          final entry = BlocTelemetryEntry(
+            name: name,
+            event: event,
+            metadata: metadata,
+          );
+          if (bloc == null) {
+            initialTelemetry.add((b, entry));
+          } else if (identical(b, bloc)) {
+            caughtTelemetry.add(entry);
           }
         },
       );
@@ -72,6 +94,16 @@ void blocSignalTest<B extends BlocSignalBase<State>, State>(
       void Function()? disposeListener;
       try {
         bloc = build();
+        for (final pair in initialErrors) {
+          if (identical(pair.$1, bloc)) {
+            caughtErrors.add(pair.$2);
+          }
+        }
+        for (final pair in initialTelemetry) {
+          if (identical(pair.$1, bloc)) {
+            caughtTelemetry.add(pair.$2);
+          }
+        }
 
         var initialSkipped = false;
         disposeListener = bloc.state.subscribe((value) {
@@ -104,6 +136,11 @@ void blocSignalTest<B extends BlocSignalBase<State>, State>(
           test_pkg.expect(caughtErrors, expectedErrors);
         }
 
+        if (expectTelemetry != null) {
+          final expectedTelemetry = expectTelemetry();
+          test_pkg.expect(caughtTelemetry, expectedTelemetry);
+        }
+
         if (verify != null) {
           final verifyResult = verify(bloc);
           if (verifyResult is Future) {
@@ -126,6 +163,7 @@ void blocSignalTest<B extends BlocSignalBase<State>, State>(
 class _TestBlocSignalObserver extends BlocSignalObserver {
   _TestBlocSignalObserver({
     required this.onErrorCallback,
+    this.onTelemetryCallback,
     this.parent,
   });
 
@@ -135,6 +173,12 @@ class _TestBlocSignalObserver extends BlocSignalObserver {
     Object error,
     StackTrace stackTrace,
   ) onErrorCallback;
+  final void Function(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  })? onTelemetryCallback;
 
   @override
   void onCreate(BlocSignalBase<dynamic> bloc) {
@@ -171,7 +215,109 @@ class _TestBlocSignalObserver extends BlocSignalObserver {
   }
 
   @override
+  void onTelemetry(
+    BlocSignalBase<dynamic> bloc,
+    String name, {
+    Object? event,
+    Map<String, dynamic>? metadata,
+  }) {
+    onTelemetryCallback?.call(bloc, name, event: event, metadata: metadata);
+    parent?.onTelemetry(bloc, name, event: event, metadata: metadata);
+  }
+
+  @override
   void onClose(BlocSignalBase<dynamic> bloc) {
     parent?.onClose(bloc);
+  }
+}
+
+/// A captured operational or diagnostic telemetry record emitted by a
+/// [BlocSignalBase] container.
+class BlocTelemetryEntry {
+  /// Creates a [BlocTelemetryEntry].
+  const BlocTelemetryEntry({
+    required this.name,
+    this.event,
+    this.metadata,
+  });
+
+  /// The semantic name of the telemetry record.
+  final String name;
+
+  /// The optional associated event.
+  final Object? event;
+
+  /// The optional metadata map.
+  final Map<String, dynamic>? metadata;
+
+  @override
+  String toString() =>
+      'BlocTelemetryEntry(name: $name, event: $event, metadata: $metadata)';
+}
+
+/// A matcher that asserts a [BlocTelemetryEntry] matches the specified
+/// [name], and optional [event] or [metadata].
+///
+/// When [metadata] is provided, the actual telemetry metadata must contain all
+/// key-value pairs specified in [metadata] (subset match).
+///
+/// ```dart
+/// expectTelemetry: () => [
+///   isTelemetry(
+///     'event_dropped',
+///     metadata: {'reason': 'in_flight'},
+///   ),
+/// ];
+/// ```
+test_pkg.Matcher isTelemetry(
+  String name, {
+  Object? event,
+  Map<String, dynamic>? metadata,
+}) =>
+    _IsTelemetryMatcher(name: name, event: event, metadata: metadata);
+
+class _IsTelemetryMatcher extends test_pkg.Matcher {
+  const _IsTelemetryMatcher({
+    required this.name,
+    this.event,
+    this.metadata,
+  });
+
+  final String name;
+  final Object? event;
+  final Map<String, dynamic>? metadata;
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
+    if (item is! BlocTelemetryEntry) return false;
+    if (item.name != name) return false;
+
+    final expectedEvent = event;
+    if (expectedEvent != null) {
+      final eventMatcher = test_pkg.wrapMatcher(expectedEvent);
+      if (!eventMatcher.matches(item.event, matchState)) return false;
+    }
+
+    final expectedMeta = metadata;
+    if (expectedMeta != null) {
+      final actualMeta = item.metadata;
+      if (actualMeta == null) return false;
+      for (final entry in expectedMeta.entries) {
+        if (!actualMeta.containsKey(entry.key) ||
+            actualMeta[entry.key] != entry.value) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  @override
+  test_pkg.Description describe(test_pkg.Description description) {
+    description.add('BlocTelemetryEntry(name: $name');
+    if (event != null) description.add(', event: $event');
+    if (metadata != null) description.add(', metadata: $metadata');
+    return description.add(')');
   }
 }

--- a/bloc_signals_test/test/bloc_signal_test_test.dart
+++ b/bloc_signals_test/test/bloc_signal_test_test.dart
@@ -220,5 +220,99 @@ void main() {
         expect(tracker.closed, hasLength(1));
       });
     });
+
+    group('expectTelemetry verification', () {
+      blocSignalTest<_TelemetryTestCubit, int>(
+        'verifies emitted telemetry matching isTelemetry',
+        build: _TelemetryTestCubit.new,
+        act: (cubit) => cubit.incrementWithTelemetry(),
+        expect: () => [1],
+        expectTelemetry: () => [
+          isTelemetry(
+            'counter_incremented',
+            metadata: {'current': 0},
+          ),
+        ],
+      );
+
+      test('isTelemetry matches name, event, and metadata subset', () {
+        const entry = BlocTelemetryEntry(
+          name: 'event_dropped',
+          event: 'query_text',
+          metadata: {'reason': 'in_flight', 'extra': 123},
+        );
+
+        expect(entry.toString(), contains('name: event_dropped'));
+        expect(isTelemetry('event_dropped').matches(entry, {}), isTrue);
+        expect(
+          isTelemetry('event_dropped', event: 'query_text').matches(entry, {}),
+          isTrue,
+        );
+        expect(
+          isTelemetry('event_dropped', metadata: {'reason': 'in_flight'})
+              .matches(entry, {}),
+          isTrue,
+        );
+        expect(
+          isTelemetry('other_name').matches(entry, {}),
+          isFalse,
+        );
+        expect(
+          isTelemetry('event_dropped', event: 'other').matches(entry, {}),
+          isFalse,
+        );
+        expect(
+          isTelemetry('event_dropped', metadata: {'reason': 'other'})
+              .matches(entry, {}),
+          isFalse,
+        );
+        expect(
+          isTelemetry('event_dropped', metadata: {'missing': 'val'})
+              .matches(entry, {}),
+          isFalse,
+        );
+        expect(
+          isTelemetry('event_dropped').matches('not an entry', {}),
+          isFalse,
+        );
+
+        const nullMetaEntry = BlocTelemetryEntry(name: 'event_dropped');
+        expect(
+          isTelemetry('event_dropped', metadata: {'reason': 'in_flight'})
+              .matches(nullMetaEntry, {}),
+          isFalse,
+        );
+
+        final description = StringDescription();
+        isTelemetry(
+          'event_dropped',
+          event: 'query',
+          metadata: {'k': 'v'},
+        ).describe(description);
+        expect(description.toString(), contains('event_dropped'));
+      });
+      blocSignalTest<_ConstructorTelemetryCubit, int>(
+        'captures telemetry emitted during build construction',
+        build: _ConstructorTelemetryCubit.new,
+        expectTelemetry: () => [
+          isTelemetry('cubit_initialized', metadata: {'initial': 42}),
+        ],
+      );
+    });
   });
+}
+
+class _TelemetryTestCubit extends CubitSignal<int> {
+  _TelemetryTestCubit() : super(initialState: 0);
+
+  void incrementWithTelemetry() {
+    emitTelemetry('counter_incremented', metadata: {'current': stateValue});
+    emit(stateValue + 1);
+  }
+}
+
+class _ConstructorTelemetryCubit extends CubitSignal<int> {
+  _ConstructorTelemetryCubit() : super(initialState: 42) {
+    emitTelemetry('cubit_initialized', metadata: {'initial': 42});
+  }
 }

--- a/plugins/bloc-signals/skills/bloc-signals/core.md
+++ b/plugins/bloc-signals/skills/bloc-signals/core.md
@@ -13,7 +13,9 @@ closure. `CubitSignal<State>` adds no dispatch API; subclasses expose methods th
 | --- | --- |
 | `stateValue` | Reads the current `StateType` synchronously. |
 | `state` | Exposes `ReadonlySignal<StateType>` for signals consumers. |
-| `emit(next)` | Updates synchronously unless `next == stateValue`. |
+| `emit(next)` | Updates presentation state synchronously unless `next == stateValue`. |
+| `emitError(error, [stackTrace])` | Emits an operational error to observers and container hooks (`addError` is a backward-compatible alias). |
+| `emitTelemetry(name, {event, metadata})` | Emits an operational telemetry event and optional metadata payload to observers. |
 | `BlocSignal.add(event)` | Routes an event and returns `void`. |
 | `BlocSignalBase(..., options: ...)` | Accepts optional `SignalOptions<StateType>` to configure signal settings (such as debug `name`). Defaults debug name to `'$runtimeType.state'`. |
 | `createEffect(callback, options: ..., onDispose: ...)` | Creates an effect immediately, assigning `options?.name` (defaulting to `'$runtimeType.effect#N'`) and registering its disposer with the base. |
@@ -24,6 +26,14 @@ closure. `CubitSignal<State>` adds no dispatch API; subclasses expose methods th
 | `future.toBlocSignal(required initialState:)` | Adapts any `Future<T>` into a `FutureBlocSignal<T>` holding raw values with an initial state. |
 | `future.toAsyncBlocSignal()` | Adapts any `Future<T>` into a `SignalBlocSignal<AsyncState<T>>` container backed by a `FutureSignal`. |
 | `stream.toAsyncBlocSignal()` | Adapts any `Stream<T>` into a `SignalBlocSignal<AsyncState<T>>` container backed by a `StreamSignal`. |
+
+### The Diagnostic Triad (`emit`, `emitError`, `emitTelemetry`)
+
+`BlocSignalBase` structures application state, failure modes, and operational observability into three distinct, dedicated diagnostic primitives:
+
+1. **`emit(state)`**: Exclusively models **presentation state** driving UI and computed derivations. Updates propagate synchronously in the same frame.
+2. **`emitError(error, [stackTrace])`**: Models **exceptional operational failures** (for example API timeouts or unhandled parser failures) notifying `onError` on the container and global observers without corrupting presentation state. (Aliased by `addError` for classic BLoC compatibility).
+3. **`emitTelemetry(name, [metadata])`**: Models **operational telemetry and business intent** (for example cache hits/misses, analytics milestones, concurrency events). Telemetry flows to `BlocSignalObserver.onTelemetry` without causing UI widget rebuilds. Built-in concurrency transformers automatically emit standardized keys via `BlocTelemetryKeys` (`eventDropped`, `taskPreempted`, `taskCanceled`, `eventQueued`). Standard telemetry calls short-circuit with zero allocations when no global observer is installed.
 
 The state remains readable after closure. `add` silently drops new events. `emit` has a debug
 assertion and then returns without changing state when assertions are disabled.
@@ -466,7 +476,8 @@ when possible, or check request freshness and `isClosed` after each async gap be
 - `onTransition(BlocSignalBase<dynamic> bloc, event, nextState)` before an event-backed write, or
   with a null event for cubit and direct emits;
 - `onChange(BlocSignalBase<dynamic> bloc, Change<dynamic> change)` after the state write;
-- `onError(BlocSignalBase<dynamic> bloc, error, stackTrace)` for reported failures.
+- `onError(BlocSignalBase<dynamic> bloc, error, stackTrace)` for reported failures;
+- `onTelemetry(BlocSignalBase<dynamic> bloc, String name, {Object? event, Map<String, dynamic>? metadata})` for operational telemetry and concurrency diagnostics;
 - `onClose(BlocSignalBase<dynamic> bloc)` after owned effects and the internal model are disposed.
 
 There is no built-in observer chain. Write a composite observer when logging and telemetry must run

--- a/plugins/bloc-signals/skills/bloc-signals/lint.md
+++ b/plugins/bloc-signals/skills/bloc-signals/lint.md
@@ -22,6 +22,8 @@ All rules are **enabled by default** once `custom_lint` is configured in `analys
 | **`prefer_named_replay_constructor`** | Warning | Flags `super.positional(...)` invocations in `ReplayCubit` and `ReplayBloc` subclasses, recommending `super(initialState: ...)`. | `Cmd+.` -> Replace `super.positional(...)` with `super(initialState: ...)` |
 | **`require_emit_in_helper_name`** | Warning | Flags private helper methods calling `emit()` whose names do not reflect state emission. | `Cmd+.` -> Rename to `...AndEmit` |
 | **`avoid_multiple_synchronous_emits`** | Warning | Flags multiple synchronous `emit()` calls along the same linear execution path without an intervening `await`. | — |
+| **`avoid_primitive_event_types`** | Warning | Flags `BlocSignal<Event, State>` or `BlocSignalMixin` using primitive or untyped types (`int`, `String`, `bool`, `dynamic`, etc.) as event types. | — |
+| **`avoid_pseudo_events_in_telemetry`** | Warning | Flags `emitTelemetry('...')` calls inside `CubitSignal` where the name matches UI event action patterns (`Pressed`, `Clicked`, `Submitted`, etc.). | — |
 
 ### Flutter UI Rules
 

--- a/plugins/bloc-signals/skills/bloc-signals/testing.md
+++ b/plugins/bloc-signals/skills/bloc-signals/testing.md
@@ -35,6 +35,7 @@ void main() {
 * **Observer Setup Timing**: `blocSignalTest` automatically sets up `BlocSignalObserver.observer` **before** invoking `build()` so `onCreate` lifecycle events are captured cleanly.
 * **Automatic De-duplication**: `BlocSignal` automatically suppresses duplicate state emissions using `==` equality. Re-emitting an identical state will not produce a test emission.
 * **Exceptions & Error Routing**: Use `errors: () => [isA<MyException>()]` to assert operational exceptions captured by `onError`.
+* **Telemetry & Concurrency Assertions**: Use `expectTelemetry: () => [isTelemetry('event_name', metadata: {'key': 'val'})]` to assert operational telemetry emitted via `emitTelemetry` and concurrency transformers (`BlocTelemetryKeys`). Matchers support partial metadata matching.
 
 ---
 

--- a/website/lib/src/models/pub_api_registry.dart
+++ b/website/lib/src/models/pub_api_registry.dart
@@ -30,6 +30,26 @@ enum DocSymbol(
   change('Change', 'bloc_signals', 'Change-class.html'),
   blocSignalOn('on', 'bloc_signals', 'BlocSignal/on.html'),
   blocSignalEmit('emit', 'bloc_signals', 'BlocSignalBase/emit.html'),
+  blocSignalEmitError(
+    'emitError',
+    'bloc_signals',
+    'BlocSignalBase/emitError.html',
+  ),
+  blocSignalEmitTelemetry(
+    'emitTelemetry',
+    'bloc_signals',
+    'BlocSignalBase/emitTelemetry.html',
+  ),
+  blocSignalOnTelemetry(
+    'onTelemetry',
+    'bloc_signals',
+    'BlocSignalObserver/onTelemetry.html',
+  ),
+  blocTelemetryKeys(
+    'BlocTelemetryKeys',
+    'bloc_signals',
+    'BlocTelemetryKeys-class.html',
+  ),
   blocSignalAdd('add', 'bloc_signals', 'BlocSignal/add.html'),
   blocSignalClose('close', 'bloc_signals', 'BlocSignalBase/close.html'),
   blocSignalState('state', 'bloc_signals', 'BlocSignalBase/state.html'),

--- a/website/test/pub_api_registry_test.dart
+++ b/website/test/pub_api_registry_test.dart
@@ -63,6 +63,10 @@ void main() {
       expect(names, contains('ReplayBloc'));
       expect(names, contains('on'));
       expect(names, contains('emit'));
+      expect(names, contains('emitError'));
+      expect(names, contains('emitTelemetry'));
+      expect(names, contains('onTelemetry'));
+      expect(names, contains('BlocTelemetryKeys'));
       expect(names, contains('read'));
       expect(names, contains('watch'));
       expect(names, contains('select'));


### PR DESCRIPTION
Resolves #239.

### Summary of Changes

#### 1. Core Telemetry & Diagnostic Triad (`bloc_signals`)
- **Diagnostic Triad**: Added `emitTelemetry({required String name, Map<String, Object?>? metadata})` and `emitError(Object error, [StackTrace? stackTrace])` to `BlocSignalBase`, `CubitSignalMixin`, and `BlocSignalMixin`.
- **Observer Hook**: Added `onTelemetry(BlocSignalBase<dynamic> bloc, String name, Map<String, Object?> metadata)` to `BlocSignalObserver` with strict zero-allocation short-circuit when `BlocSignalObserver.observer == null`.
- **Standardized Telemetry Keys**: Introduced `BlocTelemetryKeys` (`eventDropped`, `taskPreempted`, `taskCanceled`, `eventQueued`).
- **Concurrency Transformers**: Updated `droppable`, `restartable`, and `sequential` in `event_transformers.dart` to emit structured telemetry with `const` metadata maps and accurate superseded task attribution (`lastInFlightEvent`).
- **DevTools Integration**: Updated `DevToolsBlocSignalObserver` and `DevToolsService` with single-pass metadata sanitization and event streaming.

#### 2. Declarative Unit Testing (`bloc_signals_test`)
- Added `expectTelemetry:` parameter to `blocSignalTest`.
- Added `BlocTelemetryEntry` record and `isTelemetry({required String name, dynamic bloc, Map<String, Object?>? metadata})` declarative matcher with partial metadata matching.
- Implemented constructor telemetry buffering so telemetry emitted during container construction is captured seamlessly.

#### 3. OpenTelemetry Integration (`bloc_signals_otel`)
- Added `onTelemetry` handler to `OtelBlocSignalObserver`.
- Converted telemetry emissions into active span events with sanitized attributes (`double`, primitive lists).
- Integrated contention handling: on `eventDropped` and `taskPreempted`, sets `'bloc.contention': true`, marks `StatusCode.ok`, ends the active span, and removes it from `_activeSpans` to prevent orphaned spans.

#### 4. Custom Lints (`bloc_signals_lint`)
- Implemented `avoid_primitive_event_types` to ensure events are encapsulated into descriptive classes (with AST safeguards for non-BLoC bases, auxiliary mixins, and concrete subclasses).
- Implemented `avoid_pseudo_events_in_telemetry` to enforce clean diagnostic telemetry names (with boundary/camelCase regex to prevent false positives).
- Updated lint rule catalog to 20 rules.

#### 5. Documentation, Skills, and Website
- Synchronized public skills (`core.md`, `testing.md`, `lint.md`).
- Updated `website/lib/src/models/pub_api_registry.dart` and `website/test/pub_api_registry_test.dart`.
- Updated `AGENTS.md` with the 20 lint rules.

### Verification
- `dart run tool/run_workspace_tests.dart` passes across all 13 package test suites.
- `dart analyze .` passes with 0 diagnostics.
- `dart format --output=none --set-exit-if-changed .` passes with 0 changes.
