### PR TITLE
feat(flutter): add context.value and context.state extensions (#248)

### DIFF
--- a/bloc_signals_flutter/CHANGELOG.md
+++ b/bloc_signals_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0
+
+- Add `context.value<T, S>()` extension to subscribe to state emissions and return current state value in `build()` (#248).
+- Add `context.state<T, S>()` extension to look up the underlying `ReadonlySignal<S>` without registering an element rebuild dependency for `computed()` or `effect()` composition (#248).
+
 ## 1.2.2
 
 - Refactor example application to showcase declarative routing with Kaisel 1.1 `reevaluateOn` and `loginBloc.toValueListenable()` (#222, #223).

--- a/bloc_signals_flutter/README.md
+++ b/bloc_signals_flutter/README.md
@@ -154,6 +154,30 @@ final canSubmit = context.select<FormCubit, bool>(
 );
 ```
 
+### 5. Reactive State & Signal Access (`context.value` & `context.state`)
+
+To subscribe directly to state emissions inside widget `build()` methods:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  // Rebuilds this element whenever CounterCubit emits a new state value:
+  final count = context.value<CounterCubit, int>();
+
+  return Text('Count: $count');
+}
+```
+
+To look up the underlying `ReadonlySignal<S>` without registering an element rebuild dependency (for composing signals via `computed()` or `effect()`):
+
+```dart
+// Looks up the container signal without registering an element rebuild dependency:
+final counterSignal = context.state<CounterCubit, int>();
+
+// Composes reactively in signals:
+final isEven = computed(() => counterSignal.value.isEven);
+```
+
 > [!TIP]
 > **Generic Type Parameters for `context.select`**:
 > Unlike Riverpod's 3-parameter `context.select` or `package:flutter_bloc`, `BlocSignal`'s `context.select` takes **2** generic type parameters:
@@ -162,7 +186,7 @@ final canSubmit = context.select<FormCubit, bool>(
 >
 > The callback receives the **`bloc` instance** directly: `context.select<FormCubit, bool>((cubit) => cubit.stateValue.canSubmit)`.
 
-### 5. MultiBlocSignalProvider
+### 6. MultiBlocSignalProvider
 
 ```dart
 MultiBlocSignalProvider(
@@ -174,7 +198,7 @@ MultiBlocSignalProvider(
 )
 ```
 
-### 6. Flutter `Listenable` & `ChangeNotifier` Interop
+### 7. Flutter `Listenable` & `ChangeNotifier` Interop
 
 ```dart
 // Convert any ChangeNotifier into a CubitSignal

--- a/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
+++ b/bloc_signals_flutter/lib/src/bloc_signal_provider.dart
@@ -235,6 +235,46 @@ extension BlocSignalProviderExtension on BuildContext {
 
     return subscription.value;
   }
+
+  /// Watches the state of container [T] and registers a fine-grained rebuild
+  /// dependency on this [BuildContext], returning the current state value [S].
+  ///
+  /// This method is intended for use inside widget `build()` methods when
+  /// the widget element needs to rebuild whenever the container's state emits.
+  /// For composing reactive signals in `computed()` or `effect()`, use
+  /// [state] instead.
+  ///
+  /// Example:
+  /// ```dart
+  /// @override
+  /// Widget build(BuildContext context) {
+  ///   final count = context.value<CounterCubit, int>();
+  ///   return Text('Count: $count');
+  /// }
+  /// ```
+  S value<T extends BlocSignalBase<S>, S>() {
+    return select<T, S>((bloc) => bloc.stateValue);
+  }
+
+  /// Looks up the [T] container and returns its reactive state
+  /// [ReadonlySignal].
+  ///
+  /// Registers an inherited dependency on container instance swapping
+  /// (triggering a rebuild only if an ancestor replaces the container
+  /// instance), but does NOT rebuild when container state emits.
+  ///
+  /// This method is ideal for composing derived signals via `computed()` or
+  /// subscribing via `effect()` without triggering unnecessary element
+  /// rebuilds on state emissions.
+  ///
+  /// Example:
+  /// ```dart
+  /// final counterSignal = context.state<CounterCubit, int>();
+  /// final isEven = computed(() => counterSignal.value.isEven);
+  /// ```
+  ReadonlySignal<S> state<T extends BlocSignalBase<S>, S>() {
+    return BlocSignalProvider.of<T>(this, listen: true).state;
+  }
 }
 
 /// A widget that merges multiple [BlocSignalProvider]s into a single linear

--- a/bloc_signals_flutter/test/bloc_signals_flutter_test.dart
+++ b/bloc_signals_flutter/test/bloc_signals_flutter_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:bloc_signals_flutter/bloc_signals_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 
 sealed class CounterEvent {}
 
@@ -806,6 +807,171 @@ void main() {
 
         await bloc1.close();
         await bloc2.close();
+      },
+    );
+
+    testWidgets(
+      'context.value<T, S>() rebuilds reactively on state emission with '
+      'explicit state type',
+      (tester) async {
+        final cubit = CounterCubit();
+        var builds = 0;
+
+        final widget = MaterialApp(
+          home: BlocSignalProvider<CounterCubit>.value(
+            value: cubit,
+            child: Builder(
+              builder: (context) {
+                builds++;
+                final count = context.value<CounterCubit, int>();
+                // Assert type at compile-time by passing to typed helper
+                expect(count, isA<int>());
+                return Text('Count: $count');
+              },
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        expect(find.text('Count: 0'), findsOneWidget);
+        expect(builds, equals(1));
+
+        cubit.increment();
+        await tester.pump();
+        expect(find.text('Count: 1'), findsOneWidget);
+        expect(builds, equals(2));
+
+        await cubit.close();
+      },
+    );
+
+    testWidgets(
+      'context.value<T, S>() scopes rebuilds when wrapped inside Builder',
+      (tester) async {
+        final cubit = CounterCubit();
+        var parentBuilds = 0;
+        var scopedBuilds = 0;
+
+        final widget = MaterialApp(
+          home: BlocSignalProvider<CounterCubit>.value(
+            value: cubit,
+            child: Builder(
+              builder: (context) {
+                parentBuilds++;
+                return Column(
+                  children: [
+                    const Text('Parent'),
+                    Builder(
+                      builder: (innerContext) {
+                        scopedBuilds++;
+                        final count = innerContext.value<CounterCubit, int>();
+                        return Text('Scoped: $count');
+                      },
+                    ),
+                  ],
+                );
+              },
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        expect(parentBuilds, equals(1));
+        expect(scopedBuilds, equals(1));
+        expect(find.text('Scoped: 0'), findsOneWidget);
+
+        cubit.increment();
+        await tester.pump();
+        // Parent must not rebuild; only scoped inner builder rebuilds
+        expect(parentBuilds, equals(1));
+        expect(scopedBuilds, equals(2));
+        expect(find.text('Scoped: 1'), findsOneWidget);
+
+        await cubit.close();
+      },
+    );
+
+    testWidgets(
+      'context.state<T, S>() returns ReadonlySignal for computed signal '
+      'composition without rebuilding context',
+      (tester) async {
+        final cubit = CounterCubit();
+        var builds = 0;
+        late Computed<String> derivedSummary;
+
+        final widget = MaterialApp(
+          home: BlocSignalProvider<CounterCubit>.value(
+            value: cubit,
+            child: Builder(
+              builder: (context) {
+                builds++;
+                final stateSignal = context.state<CounterCubit, int>();
+                derivedSummary =
+                    computed(() => 'Computed: ${stateSignal.value}');
+                return const Text('Static UI');
+              },
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(widget);
+        expect(builds, equals(1));
+        expect(derivedSummary.value, equals('Computed: 0'));
+
+        cubit.increment();
+        await tester.pump();
+        // context.state must NOT trigger an element rebuild on context
+        expect(builds, equals(1));
+        // But the computed signal reacts synchronously to the underlying
+        // state signal
+        expect(derivedSummary.value, equals('Computed: 1'));
+
+        await cubit.close();
+      },
+    );
+
+    testWidgets(
+      'context.state<T, S>() rebinds when ancestor provider container is '
+      'swapped',
+      (tester) async {
+        final cubit1 = CounterCubit();
+        final cubit2 = CounterCubit();
+        var builds = 0;
+        ReadonlySignal<int>? currentSignal;
+
+        Widget buildTree(CounterCubit cubit) {
+          return MaterialApp(
+            home: BlocSignalProvider<CounterCubit>.value(
+              value: cubit,
+              child: Builder(
+                builder: (context) {
+                  builds++;
+                  currentSignal = context.state<CounterCubit, int>();
+                  return Text(
+                    'Signal Hash: ${identityHashCode(currentSignal)}',
+                  );
+                },
+              ),
+            ),
+          );
+        }
+
+        await tester.pumpWidget(buildTree(cubit1));
+        expect(builds, equals(1));
+        expect(currentSignal, equals(cubit1.state));
+
+        // State emissions do not trigger rebuilds
+        cubit1.increment();
+        await tester.pump();
+        expect(builds, equals(1));
+
+        // Swapping provider instance DOES trigger rebuild to update signal
+        await tester.pumpWidget(buildTree(cubit2));
+        expect(builds, equals(2));
+        expect(currentSignal, equals(cubit2.state));
+
+        await cubit1.close();
+        await cubit2.close();
       },
     );
   });

--- a/plugins/bloc-signals/skills/bloc-signals/flutter.md
+++ b/plugins/bloc-signals/skills/bloc-signals/flutter.md
@@ -101,6 +101,39 @@ lookup registers an inherited dependency (`listen: true`), so if an ancestor pro
 container instance, `context.select` automatically rebinds to the new container and continues
 observing state updates seamlessly.
 
+### `context.value<B, S>()` (Reactive State in `build()`)
+
+To subscribe directly to state emissions inside widget `build()` methods without writing an explicit selector callback, use `context.value<B, S>()`:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  // Subscribes this element to state changes on CounterCubit:
+  final count = context.value<CounterCubit, int>();
+
+  return Text('Count: $count');
+}
+```
+
+`context.value<B, S>()` delegates directly to `context.select<B, S>((bloc) => bloc.stateValue)`. It registers an element rebuild dependency so the calling widget rebuilds when state emits. When wrapped inside a `Builder(builder: (ctx) => ...)`, it scopes the rebuild exclusively to that inner builder subtree.
+
+### `context.state<B, S>()` (Signal Composition in `computed()`)
+
+To look up the underlying `ReadonlySignal<S>` without registering an element rebuild dependency on the context (`listen: false`), use `context.state<B, S>()`:
+
+```dart
+// Looks up the container signal without triggering element rebuilds on context:
+final counterSignal = context.state<CounterCubit, int>();
+
+// Composes reactively in signals:
+final isEven = computed(() => counterSignal.value.isEven);
+```
+
+> [!IMPORTANT]
+> **`context.value` vs `context.state` in Signal Graphs**:
+> - **In widget `build()` methods**: Use `context.value<B, S>()` when the widget itself must rebuild on state updates.
+> - **In `computed(() => ...)` or `effect(() => ...)`**: Always use `context.state<B, S>()`. Calling `context.value<B, S>()` inside a `computed` would inappropriately attach Flutter `Element` rebuild effects to pure reactive signal evaluations.
+
 ## Listeners, consumers, and selectors
 
 `BlocSignalListener<T, S>` captures the current state on subscription, suppresses the effect's

--- a/plugins/bloc-signals/skills/bloc-signals/flutter.md
+++ b/plugins/bloc-signals/skills/bloc-signals/flutter.md
@@ -119,10 +119,10 @@ Widget build(BuildContext context) {
 
 ### `context.state<B, S>()` (Signal Composition in `computed()`)
 
-To look up the underlying `ReadonlySignal<S>` without registering an element rebuild dependency on the context (`listen: false`), use `context.state<B, S>()`:
+To look up the underlying `ReadonlySignal<S>` without registering an element rebuild dependency on state emissions (while listening for ancestor provider swaps), use `context.state<B, S>()`:
 
 ```dart
-// Looks up the container signal without triggering element rebuilds on context:
+// In a stateful or long-lived owner (for example initState or service setup):
 final counterSignal = context.state<CounterCubit, int>();
 
 // Composes reactively in signals:

--- a/website/lib/src/components/docs/pages/docs_flutter_context.dart
+++ b/website/lib/src/components/docs/pages/docs_flutter_context.dart
@@ -324,15 +324,11 @@ class OrderSummaryBadge extends StatelessWidget {
     final cartSignal = context.state<CartCubit, CartState>();
     final promoSignal = context.state<PromoCubit, PromoState>();
 
-    // 2. Compose signals cleanly in a computed derivation:
-    final totalSignal = computed(() {
-      final subtotal = cartSignal.value.subtotal;
-      final discount = promoSignal.value.discountAmount;
-      return subtotal - discount;
+    // 2. Reactively evaluate inside Watch without allocating unmanaged computed signals:
+    return Watch((context) {
+      final total = cartSignal.value.subtotal - promoSignal.value.discountAmount;
+      return Text('Total: \$total');
     });
-
-    // 3. For UI rendering, bind the computed signal with Watch:
-    return Watch((context) => Text('Total: \${totalSignal.value}'));
   }
 }
 ''',
@@ -348,15 +344,12 @@ class OrderSummaryBadge extends StatelessWidget {
     final ReadonlySignal<PromoState> promoSignal =
         context.state<PromoCubit, PromoState>();
 
-    // 2. Compose signals cleanly in a computed derivation:
-    final Computed<double> totalSignal = computed(() {
-      final double subtotal = cartSignal.value.subtotal;
-      final double discount = promoSignal.value.discountAmount;
-      return subtotal - discount;
+    // 2. Reactively evaluate inside Watch without allocating unmanaged computed signals:
+    return Watch((context) {
+      final double total =
+          cartSignal.value.subtotal - promoSignal.value.discountAmount;
+      return Text('Total: \$total');
     });
-
-    // 3. For UI rendering, bind the computed signal with Watch:
-    return Watch((context) => Text('Total: \${totalSignal.value}'));
   }
 }
 ''',

--- a/website/lib/src/components/docs/pages/docs_flutter_context.dart
+++ b/website/lib/src/components/docs/pages/docs_flutter_context.dart
@@ -13,6 +13,8 @@ class const DocsFlutterContextPage({super.key}) extends StatelessComponent {
     TocHeading(title: '1. context.read<B>()', anchor: 'read'),
     TocHeading(title: '2. context.watch<B>()', anchor: 'watch'),
     TocHeading(title: '3. context.select<B, R>()', anchor: 'select'),
+    TocHeading(title: '4. context.value<B, S>()', anchor: 'value'),
+    TocHeading(title: '5. context.state<B, S>()', anchor: 'state'),
   ];
 
   @override
@@ -25,11 +27,11 @@ class const DocsFlutterContextPage({super.key}) extends StatelessComponent {
         h1([Component.text('BuildContext Extensions')]),
         p(classes: 'docs-lead', [
           Component.text(
-            'Master context.read, context.watch, and context.select on ',
+            'Master context.read, context.watch, context.select, context.value, and context.state on ',
           ),
           apiLink(DocSymbol.blocSignalProviderExtension, label: 'BuildContext'),
           Component.text(
-            ' for clean, expressive state access throughout your Flutter widget tree.',
+            ' for clean, expressive state access and reactive signal composition throughout your Flutter widget tree.',
           ),
         ]),
       ]),
@@ -220,6 +222,141 @@ class UsernameDisplay extends StatelessWidget {
     );
 
     return Text('Logged in as: \$username');
+  }
+}
+''',
+        ),
+      ]),
+
+      section(id: 'value', classes: 'docs-section', [
+        h2([Component.text('4. context.value<B, S>()')]),
+        p([
+          code([Component.text('context.value<B, S>()')]),
+          Component.text(
+            ' subscribes the current BuildContext Element to state emissions on ',
+          ),
+          code([Component.text('B')]),
+          Component.text(' and returns the current state value '),
+          code([Component.text('S')]),
+          Component.text('. It delegates directly to '),
+          code([Component.text('context.select<B, S>((b) => b.stateValue)')]),
+          Component.text(
+            ' while providing clean single-line state access without writing an explicit selector closure.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.tip,
+          title: 'Ideal for build() Methods & Scoped Builders',
+          children: [
+            p([
+              Component.text(
+                'Use context.value<B, S>() when the widget itself must rebuild on state updates. '
+                'When wrapped inside a Builder(builder: (ctx) => ...), calling ctx.value<B, S>() '
+                'scopes the rebuild exclusively to that inner subtree.',
+              ),
+            ]),
+          ],
+        ),
+        const DocsCodeBlock(
+          title: 'context.value in build() Methods',
+          dart313Code: '''
+class CounterDisplay extends StatelessWidget {
+  const CounterDisplay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuilds this element whenever CounterCubit emits a new state:
+    final count = context.value<CounterCubit, int>();
+
+    return Text('Count: \$count');
+  }
+}
+''',
+          dart35Code: '''
+class CounterDisplay extends StatelessWidget {
+  const CounterDisplay({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuilds this element whenever CounterCubit emits a new state:
+    final int count = context.value<CounterCubit, int>();
+
+    return Text('Count: \$count');
+  }
+}
+''',
+        ),
+      ]),
+
+      section(id: 'state', classes: 'docs-section', [
+        h2([Component.text('5. context.state<B, S>()')]),
+        p([
+          code([Component.text('context.state<B, S>()')]),
+          Component.text(' looks up the container and returns its underlying '),
+          code([Component.text('ReadonlySignal<S>')]),
+          Component.text(
+            ' without registering a rebuild dependency on the calling BuildContext. '
+            'It is designed specifically for reactive signal graph composition.',
+          ),
+        ]),
+        const DocsCallout(
+          type: CalloutType.important,
+          title: 'Signal Graph Composition (computed & effect)',
+          children: [
+            p([
+              Component.text(
+                'In computed(() => ...) or effect(() => ...), always use context.state<B, S>() '
+                'rather than context.value<B, S>(). Using context.value inside a computed signal would '
+                'inappropriately attach Flutter Element rebuild subscriptions to pure reactive signal evaluations.',
+              ),
+            ]),
+          ],
+        ),
+        const DocsCodeBlock(
+          title: 'context.state in computed Signals',
+          dart313Code: '''
+class OrderSummaryBadge extends StatelessWidget {
+  const OrderSummaryBadge({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // 1. Look up signals for composition without context rebuilds:
+    final cartSignal = context.state<CartCubit, CartState>();
+    final promoSignal = context.state<PromoCubit, PromoState>();
+
+    // 2. Compose signals cleanly in a computed derivation:
+    final totalSignal = computed(() {
+      final subtotal = cartSignal.value.subtotal;
+      final discount = promoSignal.value.discountAmount;
+      return subtotal - discount;
+    });
+
+    // 3. For UI rendering, bind the computed signal with Watch:
+    return Watch((context) => Text('Total: \${totalSignal.value}'));
+  }
+}
+''',
+          dart35Code: '''
+class OrderSummaryBadge extends StatelessWidget {
+  const OrderSummaryBadge({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // 1. Look up signals for composition without context rebuilds:
+    final ReadonlySignal<CartState> cartSignal =
+        context.state<CartCubit, CartState>();
+    final ReadonlySignal<PromoState> promoSignal =
+        context.state<PromoCubit, PromoState>();
+
+    // 2. Compose signals cleanly in a computed derivation:
+    final Computed<double> totalSignal = computed(() {
+      final double subtotal = cartSignal.value.subtotal;
+      final double discount = promoSignal.value.discountAmount;
+      return subtotal - discount;
+    });
+
+    // 3. For UI rendering, bind the computed signal with Watch:
+    return Watch((context) => Text('Total: \${totalSignal.value}'));
   }
 }
 ''',


### PR DESCRIPTION
Resolves #248

### Overview
This pull request adds `context.value<T, S>()` and `context.state<T, S>()` extensions on `BuildContext` to simplify state consumption and reactive signal graph composition in Flutter widgets.

- **`context.value<T, S>()`**: Subscribes the calling `BuildContext` to state emissions via `context.select<T, S>((bloc) => bloc.stateValue)` and returns the current state value `S`. When wrapped in a `Builder`, it scopes the rebuild exclusively to the inner subtree.
- **`context.state<T, S>()`**: Looks up the container's underlying `ReadonlySignal<S>` via `BlocSignalProvider.of<T>(this, listen: true).state` without registering an element rebuild dependency on state emissions. Designed for composing signals in `computed(() => ...)` and `effect(() => ...)`.

---

### Six Pillars Code Review

**VERDICT: APPROVED (0 BLOCKERS)**

#### 1. Intent
The implementation strictly fulfills the requirements of Issue #248 by introducing:
- `context.value<T, S>()`: Subscribes the calling `BuildContext` to state emissions via `context.select<T, S>((bloc) => bloc.stateValue)` and returns the current state value `S`.
- `context.state<T, S>()`: Retrieves the container's underlying `ReadonlySignal<S>` via `BlocSignalProvider.of<T>(this, listen: true).state` without registering an element rebuild dependency on state emissions, purpose-built for composing reactive signals in `computed(() => ...)` and `effect(() => ...)`.

Both features maintain Dart 3.5 backward compatibility while offering ergonomic state access in both widget trees and reactive signal graphs.

#### 2. Verification
- **100% Line Coverage**: All code branches in `bloc_signals_flutter` remain fully covered.
- **Dedicated Test Cases**:
  - `context.value<T, S>() rebuilds reactively on state emission with explicit state type`: Validates widget rebuilds on container emission.
  - `context.value<T, S>() scopes rebuilds when wrapped inside Builder`: Validates that wrapping with `Builder` prevents parent rebuilds while updating the child subtree.
  - `context.state<T, S>() returns ReadonlySignal for computed signal composition without rebuilding context`: Validates that `context.state` does not trigger element rebuilds while allowing computed derivations to react.
  - `context.state<T, S>() rebinds when ancestor provider container is swapped`: Verifies that ancestor container instance swaps automatically rebind the returned signal reference (immune against `SCAR-INV-01`).
- **Static Analysis**: 0 analyzer issues across `flutter analyze` and `dart analyze`.

#### 3. Architecture
- **API Diamond Invariant & DRY**: `context.value` delegates directly to `context.select<T, S>((bloc) => bloc.stateValue)`, reusing the robust indexed selector subscription, deduplication, and cleanup finalizers.
- **Signal Graph Segregation**: Clear distinction between `context.value` (for widget `build()` methods requiring UI rebuilds) and `context.state` (for `computed` / `effect` compositions).
- **Concentric Ring Documentation**: The feature is consistently documented across `CHANGELOG.md`, `README.md`, the `flutter.md` skill, and `docs_flutter_context.dart` on `blocsignal.dev` with accurate `Watch` bindings.

#### 4. Blast Radius
- **Strictly Additive**: Introduces two new extension methods on `BuildContext` within `BlocSignalProviderExtension`.
- **Zero Breaking Changes**: Existing APIs (`context.select`, `context.read`, `context.watch`, `BlocSignalBuilder`, `BlocSignalProvider`) remain completely unaffected.

#### 5. Reviewer Defense
- **Single vs Two Generics**: Addressed upfront in documentation and tests. Dart requires either both type parameters `<T, S>` or none when declaring `<T extends BlocSignalBase<S>, S>`, so `context.value<CounterCubit, int>()` is the standard canonical pattern (analogous to `BlocBuilder<CounterCubit, int>`).
- **Reactive UI Guidance**: Documentation explicitly demonstrates using `Watch((context) => Text(...))` for computed signals to prevent accidental static UI traps.

#### 6. Immune Defenses & Crash Antibodies
- **Zombie Subscription Immunity (`SCAR-INV-01` / `SCAR-PROC-28`)**: `context.state<T, S>()` uses `BlocSignalProvider.of<T>(this, listen: true).state`. Since `_BlocSignalProviderInherited.updateShouldNotify` only evaluates `bloc != oldWidget.bloc`, `listen: true` introduces zero overhead on state emissions while ensuring that swapping an ancestor provider immediately rebinds the widget to the new container's signal.
- **Disposal Safety**: Rebuild subscriptions in `context.value` rely on `_selectFinalizer` and post-frame callback cleanup, ensuring no retained subscriptions across element unmounts.