### PR TITLE
feat(core): add container.value as alias for container.stateValue (#249)

### DIFF
--- a/bloc_signals/CHANGELOG.md
+++ b/bloc_signals/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+- Add `container.value` getter as an alias for `container.stateValue` on `BlocSignalBase` and `CubitSignalMixin` to provide complete 1:1 symmetry with `container.state`, Flutter context extensions (`context.state` / `context.value`), and Flutter's `ValueListenable.value`.
+
 ## 1.3.0
 
 - Introduce `BlocEventTransformer<E, StateType>` signature passing host `bloc` as first parameter `(bloc, event, handler, emit)` for typed access to `stateValue`, telemetry, and container context.

--- a/bloc_signals/README.md
+++ b/bloc_signals/README.md
@@ -47,7 +47,7 @@ The `BlocSignal` monorepo consists of 11 modular packages:
 ### Key Architectural Differences & Design Choices:
 - ⚡ **Synchronous State Propagation**: State changes run synchronously when calling `emit(newState)` rather than asynchronously on microtask-queue Streams.
 - 🔑 **Named Constructor Initial State (`initialState:`)**: Constructors require the named parameter `initialState:` (for example, `: super(initialState: 0)`), unlike Felix BLoC's positional `: super(0)`.
-- 📊 **Explicit State Value Access (`stateValue`)**: Use `stateValue` (or `state.value`) to read raw `StateType` values in methods or event handlers (for example, `emit(stateValue + 1)`), while `state` exposes `ReadonlySignal<StateType>` for reactive signal bindings.
+- 📊 **Explicit State Value Access (`value` / `stateValue`)**: Access raw `StateType` values directly via `value` (the preferred modern getter) or `stateValue` (fully supported for backward compatibility), for example `emit(value + 1)`. `state` exposes `ReadonlySignal<StateType>` for reactive signal bindings.
 - 🔒 **Streamless Concurrency**: Support for `Mutex`, `droppable()`, `sequential()`, and `restartable()` event transformers using pure Dart higher-order functions with zero stream memory allocations.
 
 ---

--- a/bloc_signals/lib/src/bloc_signals_base.dart
+++ b/bloc_signals/lib/src/bloc_signals_base.dart
@@ -92,6 +92,23 @@ abstract class BlocSignalBase<StateType> {
   ReadonlySignal<StateType> get state;
 
   /// Retrieves the current raw state value.
+  ///
+  /// This is the preferred modern getter for reading raw container state,
+  /// establishing 1:1 symmetry with [state] (`bloc.state` / `bloc.value`),
+  /// Flutter context extensions (`context.state` / `context.value`), and
+  /// Flutter's `ValueListenable.value`.
+  ///
+  /// ```dart
+  /// final counterBloc = CounterBloc();
+  /// print(counterBloc.value); // 0
+  /// ```
+  StateType get value;
+
+  /// Retrieves the current raw state value.
+  ///
+  /// This getter remains fully supported for backward compatibility with
+  /// earlier releases, but [value] is preferred for concise and symmetrical
+  /// code.
   StateType get stateValue;
 
   /// Compares [previous] and [current] state to determine if state has changed.

--- a/bloc_signals/lib/src/cubit_signal_mixin.dart
+++ b/bloc_signals/lib/src/cubit_signal_mixin.dart
@@ -122,6 +122,16 @@ mixin CubitSignalMixin<StateType> implements BlocSignalBase<StateType> {
   }
 
   @override
+  StateType get value {
+    assert(
+      _isInitialized,
+      'initCubitSignal() must be called in the constructor of $runtimeType '
+      'before accessing value.',
+    );
+    return _state.value;
+  }
+
+  @override
   StateType get stateValue {
     assert(
       _isInitialized,

--- a/bloc_signals/pubspec.yaml
+++ b/bloc_signals/pubspec.yaml
@@ -1,7 +1,7 @@
 name: bloc_signals
 resolution: workspace
 description: Core pure Dart reactive state container bridging BLoC semantics with signals v7 primitives.
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/RandalSchwartz/BlocSignal
 issue_tracker: https://github.com/RandalSchwartz/BlocSignal/issues
 

--- a/bloc_signals/test/bloc_signals_test.dart
+++ b/bloc_signals/test/bloc_signals_test.dart
@@ -373,12 +373,15 @@ void main() {
 
     test('supports on<E> registration and handles events synchronously', () {
       final bloc = RegistryBloc();
+      expect(bloc.value, equals(0));
       expect(bloc.stateValue, equals(0));
 
       bloc.add(Increment());
+      expect(bloc.value, equals(1));
       expect(bloc.stateValue, equals(1));
 
       bloc.add(Decrement());
+      expect(bloc.value, equals(0));
       expect(bloc.stateValue, equals(0));
 
       unawaited(bloc.close());
@@ -417,6 +420,7 @@ void main() {
     group('CubitSignal Tests', () {
       test('initial state is correct', () {
         final cubit = CounterCubit();
+        expect(cubit.value, equals(0));
         expect(cubit.stateValue, equals(0));
         expect(cubit.state.value, equals(0));
         unawaited(cubit.close());
@@ -425,8 +429,10 @@ void main() {
       test('updates state synchronously when methods are called', () {
         final cubit = CounterCubit();
         cubit.increment();
+        expect(cubit.value, equals(1));
         expect(cubit.stateValue, equals(1));
         cubit.decrement();
+        expect(cubit.value, equals(0));
         expect(cubit.stateValue, equals(0));
         unawaited(cubit.close());
       });

--- a/bloc_signals/test/mixins_test.dart
+++ b/bloc_signals/test/mixins_test.dart
@@ -199,12 +199,14 @@ void main() {
       final controller = CounterServiceController();
       expect(controller.serviceName, 'CounterService');
       expect(controller.isInitialized, isTrue);
+      expect(controller.value, 0);
       expect(controller.stateValue, 0);
       expect(controller.state.value, 0);
       expect(controller, isA<BlocSignalBase<int>>());
       expect(observer.created, contains(controller));
 
       controller.increment();
+      expect(controller.value, 1);
       expect(controller.stateValue, 1);
       expect(controller.state.value, 1);
       expect(observer.changes.length, 1);
@@ -212,6 +214,7 @@ void main() {
       expect(observer.changes.first.nextState, 1);
 
       controller.decrement();
+      expect(controller.value, 0);
       expect(controller.stateValue, 0);
 
       await controller.close();
@@ -226,6 +229,7 @@ void main() {
       final uninit = UninitializedServiceController();
       expect(uninit.isInitialized, isFalse);
       expect(() => uninit.state, throwsA(isA<AssertionError>()));
+      expect(() => uninit.value, throwsA(isA<AssertionError>()));
       expect(() => uninit.stateValue, throwsA(isA<AssertionError>()));
       expect(() => uninit.publicEmit(1), throwsA(isA<AssertionError>()));
       await uninit.close();


### PR DESCRIPTION
## 🎯 Overview & Context
Closes #249.

Introduces `container.value` as the preferred modern getter alias for `container.stateValue` on `BlocSignalBase` and `CubitSignalMixin`.

This establishes complete 1:1 symmetry across the framework:
- `bloc.state` $\longleftrightarrow$ `context.state<T, S>()`
- `bloc.value` $\longleftrightarrow$ `context.value<T, S>()`
- Aligns with Flutter's `ValueListenable.value` and Signals' `Signal.value`.

`container.stateValue` is fully preserved as a non-deprecated permanent alias for backward compatibility. Downstream adapter and ecosystem integration updates are tracked in follow-up #251.

---

## 🛡️ Six Pillars Self-Critical Review

**VERDICT: APPROVED (0 BLOCKERS)**

### 1. Intent
- Completely addresses Issue #249: introduces `container.value` as an alias for `container.stateValue` on `BlocSignalBase` and `CubitSignalMixin`.
- Scope is strictly controlled: touches only the core `bloc_signals` package. All ecosystem adapters and Jaspr bindings have been isolated into follow-up GitHub Issue #251.

### 2. Verification
- **TDD Verification**: Reproduction test failure was verified (tests failed compilation on unmodified base class where `value` was undefined).
- **Behavioral Parity**: Tests in `bloc_signals_test.dart` and `mixins_test.dart` assert that `bloc.value == bloc.stateValue` before and after emissions, across synchronous updates and transitions.
- **Edge Cases**: Uninitialized mixin access was properly guarded with `assert(_isInitialized)` in `CubitSignalMixin.value`, and verified in `mixins_test.dart` via `expect(() => uninit.value, throwsA(isA<AssertionError>()))`.
- **Suite Verification**: All 11 workspace packages passed (`dart run tool/run_workspace_tests.dart`), `dart analyze .` passed with 0 issues, and formatting is 100% clean.

### 3. Architecture
- **BlocSignal Principles**: Establishes complete 1:1 symmetry across the framework (`bloc.value` $\longleftrightarrow$ `context.value<T, S>()` and `bloc.state` $\longleftrightarrow$ `context.state<T, S>()`) without introducing stream allocations or microtask delays.
- **SCAR-API-06 (Schwartz Expansion/Preservation Metric)**: Expands developer ergonomics while preserving `stateValue` as a non-deprecated permanent alias, preventing breaking changes or churn across user apps.
- **SDK Baseline**: Conforms strictly to `sdk: ^3.5.0` for published packages.

### 4. Blast Radius
- **Zero Breaking Changes**: `BlocSignalBase` subclasses compose `CubitSignalMixin` (which implements `value`), preventing compilation errors. Generic bounds `<B extends BlocSignalBase<T>>` in ecosystem packages are unaffected.
- **Zero Performance Overhead**: `value` directly returns `_state.value`, identical to `stateValue`.

### 5. Reviewer Defense
- **Trade-offs**: Retaining `stateValue` without deprecation prevents deprecation noise across existing codebases. Deferring ecosystem package updates to Issue #251 keeps this PR surgical and self-contained.

### 6. Immune Defenses & Crash Antibodies
- **Uninitialized Guards**: Present in `CubitSignalMixin.value` asserting `_isInitialized`.
- **Documentation**: Complete doc comments with runnable code examples on `value` and clear cross-references explaining that `value` is preferred while `stateValue` remains fully supported.
- **Phrasing Standards**: Complies with repo rules (using "for example" rather than "e.g.").
